### PR TITLE
fix(snackbar): open is honored from input and accesskey is spread correctly

### DIFF
--- a/.changeset/mean-rabbits-yawn.md
+++ b/.changeset/mean-rabbits-yawn.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ebayui-core": patch
+---
+
+fix(snackbar-dialog): added action spread into snackbar dialog

--- a/.changeset/public-hands-relate.md
+++ b/.changeset/public-hands-relate.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ebayui-core": patch
+---
+
+fix: honor snackbar dialog input.open if type boolean

--- a/packages/ebayui-core/src/components/ebay-snackbar-dialog/component.ts
+++ b/packages/ebayui-core/src/components/ebay-snackbar-dialog/component.ts
@@ -35,7 +35,12 @@ class SnackbarDialog extends Marko.Component<Input, State> {
     }
 
     onInput(input: Input) {
-        this.state = { open: input.open || this.state.open || false };
+        this.state = {
+            open:
+                typeof input.open === "boolean"
+                    ? input.open
+                    : this.state.open || false,
+        };
     }
 
     onMount() {

--- a/packages/ebayui-core/src/components/ebay-snackbar-dialog/component.ts
+++ b/packages/ebayui-core/src/components/ebay-snackbar-dialog/component.ts
@@ -5,6 +5,8 @@ import type { Input as BaseInput } from "../components/ebay-dialog-base/componen
 interface SnackbarDialogInput extends Omit<BaseInput, `on${string}`> {
     layout?: "row" | "column";
     action?: BaseInput["action"] & {
+        accesskey?: string;
+         /** @deprecated use `accesskey` instead */
         accessKey?: string;
     };
     "on-action"?: () => void;
@@ -35,12 +37,7 @@ class SnackbarDialog extends Marko.Component<Input, State> {
     }
 
     onInput(input: Input) {
-        this.state = {
-            open:
-                typeof input.open === "boolean"
-                    ? input.open
-                    : this.state.open || false,
-        };
+        this.state = { open: input.open ?? (this.state.open || false) };
     }
 
     onMount() {

--- a/packages/ebayui-core/src/components/ebay-snackbar-dialog/examples/action.marko
+++ b/packages/ebayui-core/src/components/ebay-snackbar-dialog/examples/action.marko
@@ -26,7 +26,7 @@ class {
     on-action("emit", "action")
     ...input
 >
-    <@action accessKey="U">
+    <@action accesskey="U">
         Undo
     </@action>
     This 'snackbar' text should be 1-2 lines.

--- a/packages/ebayui-core/src/components/ebay-snackbar-dialog/examples/stacked.marko
+++ b/packages/ebayui-core/src/components/ebay-snackbar-dialog/examples/stacked.marko
@@ -25,7 +25,7 @@ class {
     Open Stacked Snackbar
 </ebay-button>
 <ebay-snackbar-dialog open=state.open layout="column" on-close("handleClose") on-action("handleAction")>
-    <@action accessKey="U">
+    <@action accesskey="U">
         Undo
     </@action>
     Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.

--- a/packages/ebayui-core/src/components/ebay-snackbar-dialog/index.marko
+++ b/packages/ebayui-core/src/components/ebay-snackbar-dialog/index.marko
@@ -23,11 +23,13 @@ $ const {
     <if(action)>
         <@action>
             <ebay-fake-link
+                ...action
+                accesskey=action.accesskey || action.accessKey
                 on-click("handleAction")
                 on-focus("handleFocus")
                 on-blur("handleBlur")>
                 <${action.renderBody}/>
-                <span class="clipped">- Access Key: ${action.accessKey}</span>
+                <span class="clipped">- Access Key: ${action.accesskey || action.accessKey}</span>
             </ebay-fake-link>
         </@action>
     </if>

--- a/packages/ebayui-core/src/components/ebay-snackbar-dialog/test/__snapshots__/test.server.js.snap
+++ b/packages/ebayui-core/src/components/ebay-snackbar-dialog/test/__snapshots__/test.server.js.snap
@@ -162,6 +162,7 @@ exports[`snackbar-dialog > renders with action version 1`] = `
         [33mclass[39m=[32m"snackbar-dialog__actions"[39m
       [36m>[39m
         [36m<button[39m
+          [33maccesskey[39m=[32m"U"[39m
           [33mclass[39m=[32m"fake-link"[39m
           [33mdata-ebayui[39m=[32m""[39m
           [33mtype[39m=[32m"button"[39m


### PR DESCRIPTION
Fixes #3 #7

- [ ] This PR contains CSS changes
- [X] This PR does not contain CSS changes

## Description
* Added a fix to allow open to swap based on input
* Added a fix to pass in actions to fake-button


## Checklist
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue
