### PR TITLE
fix(filter-menu-button): removed focus from collapse and moved it to escape

### DIFF
--- a/.changeset/cold-baths-learn.md
+++ b/.changeset/cold-baths-learn.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ebayui-core": patch
+---
+
+fix(filter-menu-button): removed focus from collapse and moved it to escape keydown

--- a/packages/ebayui-core/src/components/ebay-filter-menu-button/component.ts
+++ b/packages/ebayui-core/src/components/ebay-filter-menu-button/component.ts
@@ -59,7 +59,10 @@ export default class extends MenuUtils<Input, MenuState> {
     handleMenuKeydown({ originalEvent }: FilterMenuEvent) {
         eventUtils.handleEscapeKeydown(
             originalEvent as KeyboardEvent,
-            () => (this._expander.expanded = false),
+            () => {
+                this._expander.expanded = false;
+                (this.getEl("button") as HTMLElement).focus();
+            },
         );
     }
 
@@ -96,7 +99,6 @@ export default class extends MenuUtils<Input, MenuState> {
 
     handleCollapse({ originalEvent }: FilterMenuEvent) {
         this.dropdownUtil.hide();
-        (this.getEl("button") as HTMLElement).focus();
         this._emitComponentEvent("collapse", originalEvent);
     }
 


### PR DESCRIPTION
Fixes #6


- [ ] This PR contains CSS changes
- [X] This PR does not contain CSS changes

## Description
* Moved focus to when escape is pressed not when menu is closed

## Checklist
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue
