### PR TITLE
fix(accordion): added direct child selector to li

### DIFF
--- a/.changeset/itchy-kids-visit.md
+++ b/.changeset/itchy-kids-visit.md
@@ -1,0 +1,5 @@
+---
+"@ebay/skin": patch
+---
+
+fix(accordion): added direct child selector to li

--- a/packages/skin/dist/accordion/accordion.css
+++ b/packages/skin/dist/accordion/accordion.css
@@ -7,7 +7,7 @@ ul.accordion ::marker {
     font-size: 0;
 }
 
-ul.accordion li:not(:last-child) {
+ul.accordion > li:not(:last-child) {
     border-bottom: 1px solid var(--color-stroke-subtle);
 }
 

--- a/packages/skin/src/sass/accordion/accordion.scss
+++ b/packages/skin/src/sass/accordion/accordion.scss
@@ -14,7 +14,7 @@ ul.accordion ::marker {
     font-size: 0;
 }
 
-ul.accordion li:not(:last-child) {
+ul.accordion > li:not(:last-child) {
     border-bottom: 1px solid var(--color-stroke-subtle);
 }
 


### PR DESCRIPTION
Fixes #5

- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
* Added direct child selector to accordion

## Checklist

- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue
- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [ ] I tested the UI in dark mode and RTL mode
- [ ] I added/updated/removed Storybook coverage as appropriate
