### PR TITLE
feat(notice): added support for custom CTA button

### DIFF
--- a/.changeset/some-games-smile.md
+++ b/.changeset/some-games-smile.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ebayui-core": minor
+---
+
+feat(notice): added support for custom CTA button

--- a/packages/ebayui-core/src/components/components/ebay-notice-base/component.ts
+++ b/packages/ebayui-core/src/components/components/ebay-notice-base/component.ts
@@ -25,11 +25,13 @@ interface NoticeBaseInput
     cta?: Marko.AttrTag<
         Marko.HTML.A & {
             renderBody?: Marko.Renderable;
+            as?: Marko.Renderable;
         }
     >;
     "education-icon"?: Marko.AttrTag<Marko.Renderable> | Marko.Renderable;
     prominent?: boolean;
     "on-dismiss"?: () => void;
+    "on-cta-click"?: () => void;
 }
 
 export interface Input extends WithNormalizedProps<NoticeBaseInput> {}

--- a/packages/ebayui-core/src/components/components/ebay-notice-base/index.marko
+++ b/packages/ebayui-core/src/components/components/ebay-notice-base/index.marko
@@ -93,7 +93,11 @@ $ const isEducation = prefixClass === 'education-notice';
         <${input.renderBody}/>
     </>
     <if(cta)>
-        <p class=`${prefixClass}__cta`><a ...cta><${cta}/></a></p>
+        <p class=`${prefixClass}__cta`>
+            <${cta.as || "a"} on-click("emit", "cta-click") ...processHtmlAttributes(cta, ["as"])>
+                <${cta}/>
+            </>
+        </p>
     </if>
 
     <if(footer && (isEducation || !a11yDismissText))>

--- a/packages/ebayui-core/src/components/ebay-page-notice/component.ts
+++ b/packages/ebayui-core/src/components/ebay-page-notice/component.ts
@@ -5,6 +5,7 @@ interface PageNoticeInput
     extends Omit<NoticeBaseInput, "role" | "prefixClass" | `on${string}`> {
     dismissed?: boolean;
     "on-dismiss"?: () => void;
+    "on-cta-click"?: () => void;
 }
 
 export interface Input extends WithNormalizedProps<PageNoticeInput> {}

--- a/packages/ebayui-core/src/components/ebay-page-notice/examples/with-custom-cta-dismiss.marko
+++ b/packages/ebayui-core/src/components/ebay-page-notice/examples/with-custom-cta-dismiss.marko
@@ -1,0 +1,18 @@
+class {}
+import fakeLink from "<ebay-fake-link>";
+
+<ebay-page-notice ...input on-dismiss('emit', 'dismiss') on-cta-click('emit', 'cta-click')>
+    <@title>
+        <div>Notice title</div>
+    </@title>
+    <@cta as=fakeLink>Link here</@cta>
+    <p>
+        <strong>Error:</strong> Please take another look at the following:
+    </p>
+    <p>
+        <a href="#">Card number</a>,
+        <a href="#">Expiration date</a>
+        &amp;
+        <a href="#">Security code</a>
+    </p>
+</ebay-page-notice>

--- a/packages/ebayui-core/src/components/ebay-page-notice/index.marko
+++ b/packages/ebayui-core/src/components/ebay-page-notice/index.marko
@@ -11,5 +11,6 @@ $ const {
         role="region"
         prefixClass="page-notice"
         on-dismiss('onDismiss')
+        on-cta-click('emit', 'cta-click')
     />
 </if>

--- a/packages/ebayui-core/src/components/ebay-page-notice/page-notice.stories.ts
+++ b/packages/ebayui-core/src/components/ebay-page-notice/page-notice.stories.ts
@@ -6,6 +6,9 @@ import withAction from "./examples/with-action.marko";
 import withActionCode from "./examples/with-action.marko?raw";
 import withDismiss from "./examples/with-dismiss.marko";
 import withDismissCode from "./examples/with-dismiss.marko?raw";
+import withCustomCTADismiss from "./examples/with-custom-cta-dismiss.marko";
+import withCustomCTADismissCode from "./examples/with-custom-cta-dismiss.marko?raw";
+
 import { Story } from "@storybook/marko";
 import type { Input } from "./component";
 
@@ -91,6 +94,16 @@ export default {
                 },
             },
         },
+        "on-cta-click": {
+            action: "on-cta-click",
+            description: "Triggered when CTA is clicked",
+            table: {
+                category: "Events",
+                defaultValue: {
+                    summary: "",
+                },
+            },
+        },
     },
 };
 
@@ -160,6 +173,27 @@ WithDismiss.parameters = {
     docs: {
         source: {
             code: withDismissCode,
+        },
+    },
+};
+
+export const WithCustomCTADismiss: Story<Input> = (args) => ({
+    input: args,
+    component: withCustomCTADismiss,
+});
+
+WithCustomCTADismiss.args = {
+    a11yText: "information",
+    a11yIconText: "",
+    a11yDismissText: "Dismiss Notice",
+    status: "information",
+    icon: null,
+} as any;
+
+WithCustomCTADismiss.parameters = {
+    docs: {
+        source: {
+            code: withCustomCTADismissCode,
         },
     },
 };

--- a/packages/ebayui-core/src/components/ebay-page-notice/test/__snapshots__/test.server.js.snap
+++ b/packages/ebayui-core/src/components/ebay-page-notice/test/__snapshots__/test.server.js.snap
@@ -90,6 +90,176 @@ exports[`page-notice > passes through additional html attributes 2`] = `
 </section>
 `;
 
+exports[`page-notice > renders basic 1`] = `
+"[36m<DocumentFragment>[39m
+  [36m<section[39m
+    [33maria-labelledby[39m=[32m"s0-0-status"[39m
+    [33mclass[39m=[32m"page-notice page-notice--null"[39m
+    [33mrole[39m=[32m"region"[39m
+  [36m>[39m
+    [36m<div[39m
+      [33mclass[39m=[32m"page-notice__header"[39m
+      [33mid[39m=[32m"s0-0-status"[39m
+    [36m/>[39m
+    [36m<div[39m
+      [33mclass[39m=[32m"page-notice__main"[39m
+    [36m>[39m
+      [36m<h2[39m
+        [33mclass[39m=[32m"page-notice__title"[39m
+      [36m>[39m
+        [0mAn error has occurred[0m
+      [36m</h2>[39m
+      [36m<p>[39m
+        [36m<strong>[39m
+          [0mError:[0m
+        [36m</strong>[39m
+        [0m Please take another look at the following:[0m
+      [36m</p>[39m
+      [0m
+    [0m
+      [36m<p>[39m
+        [0m
+        [0m
+        [36m<a[39m
+          [33mhref[39m=[32m"#"[39m
+        [36m>[39m
+          [0mCard number[0m
+        [36m</a>[39m
+        [0m
+        ,
+        [0m
+        [36m<a[39m
+          [33mhref[39m=[32m"#"[39m
+        [36m>[39m
+          [0mExpiration date[0m
+        [36m</a>[39m
+        [0m
+        &
+        [0m
+        [36m<a[39m
+          [33mhref[39m=[32m"#"[39m
+        [36m>[39m
+          [0mSecurity code[0m
+        [36m</a>[39m
+        [0m
+    [0m
+      [36m</p>[39m
+    [36m</div>[39m
+  [36m</section>[39m
+[36m</DocumentFragment>[39m"
+`;
+
+exports[`page-notice > renders with custom CTA 1`] = `
+"[36m<DocumentFragment>[39m
+  [36m<section[39m
+    [33maria-labelledby[39m=[32m"s0-0-0-status"[39m
+    [33mclass[39m=[32m"page-notice page-notice--information"[39m
+    [33mrole[39m=[32m"region"[39m
+  [36m>[39m
+    [36m<div[39m
+      [33mclass[39m=[32m"page-notice__header"[39m
+      [33mid[39m=[32m"s0-0-0-status"[39m
+    [36m>[39m
+      [36m<svg[39m
+        [33maria-label[39m=[32m"information"[39m
+        [33mclass[39m=[32m"icon--information-filled icon icon--16 icon--information-filled"[39m
+        [33mfocusable[39m=[32m"false"[39m
+        [33mrole[39m=[32m"img"[39m
+      [36m>[39m
+        [36m<defs>[39m
+          [36m<symbol[39m
+            [33mid[39m=[32m"icon-information-filled-16"[39m
+            [33mviewBox[39m=[32m"0 0 16 16"[39m
+          [36m>[39m
+            [36m<path[39m
+              [33md[39m=[32m"M8 0a8 8 0 1 0 0 16A8 8 0 0 0 8 0Zm1 11a1 1 0 1 1-2 0V8a1 1 0 0 1 2 0v3ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"[39m
+            [36m/>[39m
+          [36m</symbol>[39m
+        [36m</defs>[39m
+        [36m<use[39m
+          [33mhref[39m=[32m"#icon-information-filled-16"[39m
+        [36m/>[39m
+      [36m</svg>[39m
+    [36m</div>[39m
+    [36m<div[39m
+      [33mclass[39m=[32m"page-notice__main"[39m
+    [36m>[39m
+      [36m<h2[39m
+        [33mclass[39m=[32m"page-notice__title"[39m
+      [36m>[39m
+        [36m<div>[39m
+          [0mNotice title[0m
+        [36m</div>[39m
+      [36m</h2>[39m
+      [36m<p>[39m
+        [36m<strong>[39m
+          [0mError:[0m
+        [36m</strong>[39m
+        [0m Please take another look at the following:[0m
+      [36m</p>[39m
+      [36m<p>[39m
+        [36m<a[39m
+          [33mhref[39m=[32m"#"[39m
+        [36m>[39m
+          [0mCard number[0m
+        [36m</a>[39m
+        [0m, [0m
+        [36m<a[39m
+          [33mhref[39m=[32m"#"[39m
+        [36m>[39m
+          [0mExpiration date[0m
+        [36m</a>[39m
+        [0m & [0m
+        [36m<a[39m
+          [33mhref[39m=[32m"#"[39m
+        [36m>[39m
+          [0mSecurity code[0m
+        [36m</a>[39m
+      [36m</p>[39m
+    [36m</div>[39m
+    [36m<p[39m
+      [33mclass[39m=[32m"page-notice__cta"[39m
+    [36m>[39m
+      [36m<button[39m
+        [33mclass[39m=[32m"fake-link"[39m
+        [33mdata-ebayui[39m=[32m""[39m
+        [33mtype[39m=[32m"button"[39m
+      [36m>[39m
+        [0mLink here[0m
+      [36m</button>[39m
+    [36m</p>[39m
+    [36m<div[39m
+      [33mclass[39m=[32m"page-notice__footer"[39m
+    [36m>[39m
+      [36m<button[39m
+        [33maria-label[39m=[32m"Dismiss Notice"[39m
+        [33mclass[39m=[32m"fake-link page-notice__dismiss"[39m
+      [36m>[39m
+        [36m<svg[39m
+          [33maria-hidden[39m=[32m"true"[39m
+          [33mclass[39m=[32m"icon icon--close-16 icon icon--16"[39m
+          [33mfocusable[39m=[32m"false"[39m
+        [36m>[39m
+          [36m<defs>[39m
+            [36m<symbol[39m
+              [33mid[39m=[32m"icon-close-16"[39m
+              [33mviewBox[39m=[32m"0 0 16 16"[39m
+            [36m>[39m
+              [36m<path[39m
+                [33md[39m=[32m"M2.293 2.293a1 1 0 0 1 1.414 0L8 6.586l4.293-4.293a1 1 0 1 1 1.414 1.414L9.414 8l4.293 4.293a1 1 0 0 1-1.414 1.414L8 9.414l-4.293 4.293a1 1 0 0 1-1.414-1.414L6.586 8 2.293 3.707a1 1 0 0 1 0-1.414Z"[39m
+              [36m/>[39m
+            [36m</symbol>[39m
+          [36m</defs>[39m
+          [36m<use[39m
+            [33mhref[39m=[32m"#icon-close-16"[39m
+          [36m/>[39m
+        [36m</svg>[39m
+      [36m</button>[39m
+    [36m</div>[39m
+  [36m</section>[39m
+[36m</DocumentFragment>[39m"
+`;
+
 exports[`page-notice > renders with custom heading tag 1`] = `
 <h3
   as="h3"

--- a/packages/ebayui-core/src/components/ebay-page-notice/test/test.server.js
+++ b/packages/ebayui-core/src/components/ebay-page-notice/test/test.server.js
@@ -4,6 +4,11 @@ import { render } from "@marko/testing-library";
 import { testPassThroughAttributes } from "../../../common/test-utils/server";
 import template from "../index.marko";
 import * as mock from "./mock";
+import { composeStories } from "@storybook/marko";
+import { snapshotHTML } from "../../../common/test-utils/snapshots";
+import * as stories from "../page-notice.stories"; // import all stories from the stories file
+const { Basic, WithCustomCTADismiss } = composeStories(stories);
+const htmlSnap = snapshotHTML(__dirname);
 
 describe("page-notice", () => {
     it("renders with defaults", async () => {
@@ -54,6 +59,13 @@ describe("page-notice", () => {
         expect(content).toMatchSnapshot();
         expect(content.parentElement).toMatchSnapshot();
         expect(footer).toMatchSnapshot();
+    });
+
+    it("renders basic", async () => {
+        await htmlSnap(Basic);
+    });
+    it("renders with custom CTA", async () => {
+        await htmlSnap(WithCustomCTADismiss);
     });
 
     testPassThroughAttributes(template, {

--- a/packages/ebayui-core/src/components/ebay-section-notice/component.ts
+++ b/packages/ebayui-core/src/components/ebay-section-notice/component.ts
@@ -8,6 +8,7 @@ interface SectionNoticeInput
     > {
     dismissed?: boolean;
     "on-dismiss"?: () => void;
+    "on-cta-click"?: () => void;
 }
 
 export interface Input extends WithNormalizedProps<SectionNoticeInput> {}

--- a/packages/ebayui-core/src/components/ebay-section-notice/examples/with-custom-cta-dismiss.marko
+++ b/packages/ebayui-core/src/components/ebay-section-notice/examples/with-custom-cta-dismiss.marko
@@ -1,0 +1,18 @@
+class {}
+import fakeLink from "<ebay-fake-link>";
+
+<ebay-section-notice ...input on-dismiss('emit', 'dismiss') on-cta-click('emit', 'cta-click')>
+    <@title>
+        <div>Notice title</div>
+    </@title>
+    <@cta as=fakeLink>Link here</@cta>
+    <p>
+        <strong>Error:</strong> Please take another look at the following:
+    </p>
+    <p>
+        <a href="#">Card number</a>,
+        <a href="#">Expiration date</a>
+        &amp;
+        <a href="#">Security code</a>
+    </p>
+</ebay-section-notice>

--- a/packages/ebayui-core/src/components/ebay-section-notice/index.marko
+++ b/packages/ebayui-core/src/components/ebay-section-notice/index.marko
@@ -16,5 +16,6 @@ $ const {
         a11yRoleDescription=a11yRoleDescription
         class=[status === 'education' && 'section-notice--large-icon', inputClass]
         on-dismiss('onDismiss')
+        on-cta-click('emit', 'cta-click')
     />
 </if>

--- a/packages/ebayui-core/src/components/ebay-section-notice/section-notice.stories.ts
+++ b/packages/ebayui-core/src/components/ebay-section-notice/section-notice.stories.ts
@@ -9,6 +9,8 @@ import withAction from "./examples/with-action.marko";
 import withActionCode from "./examples/with-action.marko?raw";
 import withDismiss from "./examples/with-dismiss.marko";
 import withDismissCode from "./examples/with-dismiss.marko?raw";
+import withCustomCTADismiss from "./examples/with-custom-cta-dismiss.marko";
+import withCustomCTADismissCode from "./examples/with-custom-cta-dismiss.marko?raw";
 import { Story } from "@storybook/marko";
 import type { Input } from "./component";
 
@@ -98,6 +100,16 @@ export default {
                 },
             },
         },
+        "on-cta-click": {
+            action: "on-cta-click",
+            description: "Triggered when CTA is clicked",
+            table: {
+                category: "Events",
+                defaultValue: {
+                    summary: "",
+                },
+            },
+        }
     },
 };
 
@@ -151,3 +163,25 @@ export const WithDismiss = buildExtensionTemplate(
         icon: null,
     },
 );
+
+export const WithCustomCTADismiss: Story<Input> = (args) => ({
+    input: args,
+    component: withCustomCTADismiss,
+});
+
+WithCustomCTADismiss.args = {
+    a11yText: "information",
+    a11yIconText: "",
+    a11yDismissText: "Dismiss Notice",
+    status: "information",
+    icon: null,
+} as any;
+
+WithCustomCTADismiss.parameters = {
+    docs: {
+        source: {
+            code: withCustomCTADismissCode,
+        },
+    },
+};
+

--- a/packages/ebayui-core/src/components/ebay-section-notice/test/__snapshots__/test.server.js.snap
+++ b/packages/ebayui-core/src/components/ebay-section-notice/test/__snapshots__/test.server.js.snap
@@ -1,5 +1,161 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`section-notice > renders basic 1`] = `
+"[36m<DocumentFragment>[39m
+  [36m<section[39m
+    [33maria-labelledby[39m=[32m"s0-0-status"[39m
+    [33maria-roledescription[39m=[32m"Notice"[39m
+    [33mclass[39m=[32m"section-notice"[39m
+    [33mrole[39m=[32m"region"[39m
+  [36m>[39m
+    [36m<div[39m
+      [33mclass[39m=[32m"section-notice__header"[39m
+      [33mid[39m=[32m"s0-0-status"[39m
+    [36m>[39m
+      [36m<svg[39m
+        [33maria-label[39m=[32m"attention"[39m
+        [33mclass[39m=[32m"icon--attention-filled icon icon--16 icon--attention-filled"[39m
+        [33mfocusable[39m=[32m"false"[39m
+        [33mrole[39m=[32m"img"[39m
+      [36m>[39m
+        [36m<defs>[39m
+          [36m<symbol[39m
+            [33mid[39m=[32m"icon-attention-filled-16"[39m
+            [33mviewBox[39m=[32m"0 0 16 16"[39m
+          [36m>[39m
+            [36m<path[39m
+              [33md[39m=[32m"M8 0a8 8 0 1 0 0 16A8 8 0 0 0 8 0Zm0 12a1 1 0 1 1 0-2 1 1 0 0 1 0 2Zm1-4a1 1 0 1 1-2 0V5a1 1 0 0 1 2 0v3Z"[39m
+            [36m/>[39m
+          [36m</symbol>[39m
+        [36m</defs>[39m
+        [36m<use[39m
+          [33mhref[39m=[32m"#icon-attention-filled-16"[39m
+        [36m/>[39m
+      [36m</svg>[39m
+    [36m</div>[39m
+    [36m<span[39m
+      [33mclass[39m=[32m"section-notice__main"[39m
+    [36m>[39m
+      [36m<p>[39m
+        [0mSection notice info. Things you need to know.[0m
+      [36m</p>[39m
+    [36m</span>[39m
+  [36m</section>[39m
+[36m</DocumentFragment>[39m"
+`;
+
+exports[`section-notice > renders with custom CTA 1`] = `
+"[36m<DocumentFragment>[39m
+  [36m<section[39m
+    [33maria-labelledby[39m=[32m"s0-0-0-status"[39m
+    [33maria-roledescription[39m=[32m"Notice"[39m
+    [33mclass[39m=[32m"section-notice"[39m
+    [33mrole[39m=[32m"region"[39m
+  [36m>[39m
+    [36m<div[39m
+      [33mclass[39m=[32m"section-notice__header"[39m
+      [33mid[39m=[32m"s0-0-0-status"[39m
+    [36m>[39m
+      [36m<svg[39m
+        [33maria-label[39m=[32m"information"[39m
+        [33mclass[39m=[32m"icon--information-filled icon icon--16 icon--information-filled"[39m
+        [33mfocusable[39m=[32m"false"[39m
+        [33mrole[39m=[32m"img"[39m
+      [36m>[39m
+        [36m<defs>[39m
+          [36m<symbol[39m
+            [33mid[39m=[32m"icon-information-filled-16"[39m
+            [33mviewBox[39m=[32m"0 0 16 16"[39m
+          [36m>[39m
+            [36m<path[39m
+              [33md[39m=[32m"M8 0a8 8 0 1 0 0 16A8 8 0 0 0 8 0Zm1 11a1 1 0 1 1-2 0V8a1 1 0 0 1 2 0v3ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"[39m
+            [36m/>[39m
+          [36m</symbol>[39m
+        [36m</defs>[39m
+        [36m<use[39m
+          [33mhref[39m=[32m"#icon-information-filled-16"[39m
+        [36m/>[39m
+      [36m</svg>[39m
+    [36m</div>[39m
+    [36m<span[39m
+      [33mclass[39m=[32m"section-notice__main"[39m
+    [36m>[39m
+      [36m<h2[39m
+        [33mclass[39m=[32m"section-notice__title"[39m
+      [36m>[39m
+        [36m<div>[39m
+          [0mNotice title[0m
+        [36m</div>[39m
+      [36m</h2>[39m
+      [36m<p>[39m
+        [36m<strong>[39m
+          [0mError:[0m
+        [36m</strong>[39m
+        [0m Please take another look at the following:[0m
+      [36m</p>[39m
+      [36m<p>[39m
+        [36m<a[39m
+          [33mhref[39m=[32m"#"[39m
+        [36m>[39m
+          [0mCard number[0m
+        [36m</a>[39m
+        [0m, [0m
+        [36m<a[39m
+          [33mhref[39m=[32m"#"[39m
+        [36m>[39m
+          [0mExpiration date[0m
+        [36m</a>[39m
+        [0m & [0m
+        [36m<a[39m
+          [33mhref[39m=[32m"#"[39m
+        [36m>[39m
+          [0mSecurity code[0m
+        [36m</a>[39m
+      [36m</p>[39m
+    [36m</span>[39m
+    [36m<p[39m
+      [33mclass[39m=[32m"section-notice__cta"[39m
+    [36m>[39m
+      [36m<button[39m
+        [33mclass[39m=[32m"fake-link"[39m
+        [33mdata-ebayui[39m=[32m""[39m
+        [33mtype[39m=[32m"button"[39m
+      [36m>[39m
+        [0mLink here[0m
+      [36m</button>[39m
+    [36m</p>[39m
+    [36m<div[39m
+      [33mclass[39m=[32m"section-notice__footer"[39m
+    [36m>[39m
+      [36m<button[39m
+        [33maria-label[39m=[32m"Dismiss Notice"[39m
+        [33mclass[39m=[32m"fake-link section-notice__dismiss"[39m
+      [36m>[39m
+        [36m<svg[39m
+          [33maria-hidden[39m=[32m"true"[39m
+          [33mclass[39m=[32m"icon icon--close-16 icon icon--16"[39m
+          [33mfocusable[39m=[32m"false"[39m
+        [36m>[39m
+          [36m<defs>[39m
+            [36m<symbol[39m
+              [33mid[39m=[32m"icon-close-16"[39m
+              [33mviewBox[39m=[32m"0 0 16 16"[39m
+            [36m>[39m
+              [36m<path[39m
+                [33md[39m=[32m"M2.293 2.293a1 1 0 0 1 1.414 0L8 6.586l4.293-4.293a1 1 0 1 1 1.414 1.414L9.414 8l4.293 4.293a1 1 0 0 1-1.414 1.414L8 9.414l-4.293 4.293a1 1 0 0 1-1.414-1.414L6.586 8 2.293 3.707a1 1 0 0 1 0-1.414Z"[39m
+              [36m/>[39m
+            [36m</symbol>[39m
+          [36m</defs>[39m
+          [36m<use[39m
+            [33mhref[39m=[32m"#icon-close-16"[39m
+          [36m/>[39m
+        [36m</svg>[39m
+      [36m</button>[39m
+    [36m</div>[39m
+  [36m</section>[39m
+[36m</DocumentFragment>[39m"
+`;
+
 exports[`section-notice > renders with light 1`] = `
 <section
   aria-labelledby="s0-0-status"

--- a/packages/ebayui-core/src/components/ebay-section-notice/test/test.server.js
+++ b/packages/ebayui-core/src/components/ebay-section-notice/test/test.server.js
@@ -3,6 +3,11 @@ import { describe, it, expect } from "vitest";
 import { render } from "@marko/testing-library";
 import template from "../index.marko";
 import * as mock from "./mock";
+import { composeStories } from "@storybook/marko";
+import { snapshotHTML } from "../../../common/test-utils/snapshots";
+import * as stories from "../section-notice.stories"; // import all stories from the stories file
+const { Basic, WithCustomCTADismiss } = composeStories(stories);
+const htmlSnap = snapshotHTML(__dirname);
 
 describe("section-notice", () => {
     it("renders with status", async () => {
@@ -31,5 +36,12 @@ describe("section-notice", () => {
 
         const footer = getByText(input.footer.renderBody.text);
         expect(footer).toMatchSnapshot();
+    });
+
+    it("renders basic", async () => {
+        await htmlSnap(Basic);
+    });
+    it("renders with custom CTA", async () => {
+        await htmlSnap(WithCustomCTADismiss);
     });
 });


### PR DESCRIPTION

Fixes #9

- [ ] This PR contains CSS changes
- [X] This PR does not contain CSS changes

## Description
* Added support for custom CTA type (using `as`) in notice base
* Added event to emit (`cta-click`)
* Added support/tests/storybook changes in page notice and section notice

## Checklist
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue
