### PR TITLE
fix(notice): resolve CTA alignment issue for none icon case

### DIFF
--- a/packages/skin/dist/section-notice/section-notice.css
+++ b/packages/skin/dist/section-notice/section-notice.css
@@ -81,7 +81,8 @@ span[role="region"].section-notice {
     margin-inline-end: var(--spacing-200);
 }
 
-.section-notice__header + .section-notice__main {
+.section-notice__header + .section-notice__main,
+.section-notice__header ~ .section-notice__cta {
     grid-column: 2;
 }
 
@@ -98,7 +99,7 @@ span[role="region"].section-notice {
 }
 
 p.section-notice__cta {
-    grid-column: 2;
+    grid-column: 1 / 3;
     grid-row: 2;
     justify-self: flex-start;
     margin-right: var(--spacing-200);
@@ -119,6 +120,9 @@ p.section-notice__cta {
         margin-bottom: 0;
         margin-top: 0;
         padding-right: var(--spacing-200);
+    }
+    .section-notice__header ~ .section-notice__cta {
+        grid-column: 4;
     }
     .section-notice__footer {
         padding-left: var(--spacing-200);

--- a/packages/skin/src/sass/section-notice/section-notice.scss
+++ b/packages/skin/src/sass/section-notice/section-notice.scss
@@ -103,7 +103,8 @@ span[role="region"].section-notice {
     margin-inline-end: var(--spacing-200);
 }
 
-.section-notice__header + .section-notice__main {
+.section-notice__header + .section-notice__main,
+.section-notice__header ~ .section-notice__cta {
     grid-column: 2;
 }
 
@@ -120,7 +121,7 @@ span[role="region"].section-notice {
 }
 
 p.section-notice__cta {
-    grid-column: 2;
+    grid-column: 1/3;
     grid-row: 2;
     justify-self: flex-start;
     margin-right: var(--spacing-200);
@@ -147,6 +148,10 @@ p.section-notice__cta {
         margin-bottom: 0;
         margin-top: 0;
         padding-right: var(--spacing-200);
+    }
+
+    .section-notice__header ~ .section-notice__cta {
+        grid-column: 4;
     }
 
     .section-notice__footer {


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #

<!-- Select which type of PR this is -->
- [x] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
<!-- Briefly describe the proposed changes -->
- Fixed the alignment issue of CTA when the `icon` is set to `none` for small screens.



## Notes
<!-- Be sure to mention anything unusual, out-of-scope or new technical debt, etc -->

## Screenshots
<!-- Upload screenshots of UI before & after these changes -->

**Before**

<img width="498" alt="Cursor_and_Skin___Section_Notice___Iconless_-_Dismiss_And_Fake_Link_CTA_⋅_Storybook_and_section-notice_scss_—_ebay-fork" src="https://github.com/user-attachments/assets/62a86edc-c433-4964-960c-f1671d0cb369" />



**After**

<img width="595" alt="Cursor_and_Skin___Section_Notice___Iconless_-_Dismiss_And_Fake_Link_CTA_⋅_Storybook" src="https://github.com/user-attachments/assets/129038f3-d532-4b58-8b57-7561f21dfa05" />

## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [ ] I verify the build is in a non-broken state
- [ ] I verify all changes are within scope of the linked issue

<!-- For Markup Changes -->
- [ ] I verify the markup will not be a breaking change (if not a major release)
- [ ] I verify the MIND pattern for the component has been created/revised

<!-- For CSS changes -->
- [x] I regenerated all CSS files under dist folder
- [x] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [ ] I tested the UI in dark mode and RTL mode
- [ ] I added/updated/removed Storybook coverage as appropriate
