### PR TITLE
fix: on close bug

### DIFF
--- a/packages/ebayui-core-react/src/ebay-dialog-base/components/dialogBase.tsx
+++ b/packages/ebayui-core-react/src/ebay-dialog-base/components/dialogBase.tsx
@@ -98,7 +98,7 @@ export const DialogBase: FC<DialogBaseProps<HTMLElement>> = ({
     useEffect(() => {
         let timeout: number
         const handleBackgroundClick = (e: DocumentEventMap['click']) => {
-            if (drawerBaseEl.current && !drawerBaseEl.current.contains(e.target)) {
+            if (drawerBaseEl.current && !drawerBaseEl.current.contains(e.target) && document.contains(e.target as Node)) {
                 onBackgroundClick(e as unknown as DialogCloseEvent)
             }
         }

--- a/packages/ebayui-core-react/src/ebay-lightbox-dialog/__tests__/index.stories.tsx
+++ b/packages/ebayui-core-react/src/ebay-lightbox-dialog/__tests__/index.stories.tsx
@@ -1,19 +1,14 @@
-import React, { useState } from 'react'
-import { Meta, StoryFn } from '@storybook/react'
-import { action } from '@storybook/addon-actions'
-import {
-    EbayDialogFooter,
-    EbayDialogHeader,
-    EbayDialogPreviousButton
-} from '../../ebay-dialog-base'
-import { EbayButton } from '../../ebay-button'
-import { EbayCheckbox } from '../../ebay-checkbox'
-import { EbayLabel } from '../../ebay-field'
-import { EbayLightboxDialog } from '../index'
-
+import React, { useState } from "react";
+import { Meta, StoryFn } from "@storybook/react";
+import { action } from "@storybook/addon-actions";
+import { EbayDialogFooter, EbayDialogHeader, EbayDialogPreviousButton } from "../../ebay-dialog-base";
+import { EbayButton } from "../../ebay-button";
+import { EbayCheckbox } from "../../ebay-checkbox";
+import { EbayLabel } from "../../ebay-field";
+import { EbayLightboxDialog } from "../index";
 
 const story: Meta<typeof EbayLightboxDialog> = {
-    title: 'dialogs/ebay-lightbox-dialog',
+    title: "dialogs/ebay-lightbox-dialog",
     component: EbayLightboxDialog,
 
     argTypes: {
@@ -75,17 +70,17 @@ const story: Meta<typeof EbayLightboxDialog> = {
 
 const textParagraph = (
     <p>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
-        labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
-        laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
-        voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat
-        non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+        magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+        consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+        pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est
+        laborum.
     </p>
-)
+);
 
 export const Default: StoryFn<typeof EbayLightboxDialog> = (args) => {
-    const [open, setOpen] = useState(false)
-    const close = () => setOpen(false)
+    const [open, setOpen] = useState(false);
+    const close = () => setOpen(false);
     return (
         <div>
             <button className="btn btn--secondary" onClick={() => setOpen(!open)}>
@@ -95,10 +90,10 @@ export const Default: StoryFn<typeof EbayLightboxDialog> = (args) => {
             <EbayLightboxDialog
                 {...args}
                 open={open}
-                onOpen={() => action('onOpen')()}
+                onOpen={() => action("onOpen")()}
                 onClose={() => {
-                    action('onClose')()
-                    close()
+                    action("onClose")();
+                    close();
                 }}
                 a11yCloseText="Close"
             >
@@ -115,8 +110,8 @@ export const Default: StoryFn<typeof EbayLightboxDialog> = (args) => {
                 </EbayDialogFooter>
             </EbayLightboxDialog>
         </div>
-    )
-}
+    );
+};
 
 export const AlwaysOpened: StoryFn<typeof EbayLightboxDialog> = (args) => (
     <div>
@@ -129,7 +124,7 @@ export const AlwaysOpened: StoryFn<typeof EbayLightboxDialog> = (args) => (
             </p>
         </EbayLightboxDialog>
     </div>
-)
+);
 
 export const ScrollingContent: StoryFn<typeof EbayLightboxDialog> = (args) => (
     <div>
@@ -151,7 +146,7 @@ export const ScrollingContent: StoryFn<typeof EbayLightboxDialog> = (args) => (
             </p>
         </EbayLightboxDialog>
     </div>
-)
+);
 
 export const MiniDialog: StoryFn<typeof EbayLightboxDialog> = (args) => (
     <div>
@@ -159,21 +154,21 @@ export const MiniDialog: StoryFn<typeof EbayLightboxDialog> = (args) => (
         <EbayLightboxDialog {...args} mode="mini" open a11yCloseText="Close">
             <EbayDialogHeader />
             <p>
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
-                labore et dolore magna aliqua.
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et
+                dolore magna aliqua.
             </p>
         </EbayLightboxDialog>
     </div>
-)
+);
 
 export const DisableDialogClose: StoryFn<typeof EbayLightboxDialog> = (args) => {
-    const [showDialog, setShowDialog] = useState(false)
-    const [dialogCloseable, setDialogCloseable] = useState(true)
+    const [showDialog, setShowDialog] = useState(false);
+    const [dialogCloseable, setDialogCloseable] = useState(true);
     const closeDialog = () => {
         if (dialogCloseable) {
-            setShowDialog(false)
+            setShowDialog(false);
         }
-    }
+    };
 
     return (
         <div>
@@ -206,12 +201,12 @@ export const DisableDialogClose: StoryFn<typeof EbayLightboxDialog> = (args) => 
                 </EbayDialogFooter>
             </EbayLightboxDialog>
         </div>
-    )
-}
+    );
+};
 
 export const WithAnimation: StoryFn<typeof EbayLightboxDialog> = (args) => {
-    const [open, setOpen] = useState(false)
-    const close = () => setOpen(false)
+    const [open, setOpen] = useState(false);
+    const close = () => setOpen(false);
     return (
         <div>
             <button className="btn btn--secondary" onClick={() => setOpen(!open)}>
@@ -232,11 +227,11 @@ export const WithAnimation: StoryFn<typeof EbayLightboxDialog> = (args) => {
                 </EbayDialogFooter>
             </EbayLightboxDialog>
         </div>
-    )
-}
+    );
+};
 export const WithNoBackgroundClick: StoryFn<typeof EbayLightboxDialog> = (args) => {
-    const [open, setOpen] = useState(false)
-    const close = () => setOpen(false)
+    const [open, setOpen] = useState(false);
+    const close = () => setOpen(false);
     return (
         <div>
             <button className="btn btn--secondary" onClick={() => setOpen(!open)}>
@@ -257,14 +252,14 @@ export const WithNoBackgroundClick: StoryFn<typeof EbayLightboxDialog> = (args) 
                 </EbayDialogFooter>
             </EbayLightboxDialog>
         </div>
-    )
-}
+    );
+};
 
 export const WithPreviousButton: StoryFn<typeof EbayLightboxDialog> = (args) => (
     <div>
         <p>Some outside content...</p>
         <EbayLightboxDialog {...args} open a11yCloseText="Close dialog">
-            <EbayDialogPreviousButton aria-label="Previous" onClick={action('previous button click')} />
+            <EbayDialogPreviousButton aria-label="Previous" onClick={action("previous button click")} />
             <EbayDialogHeader>Heading</EbayDialogHeader>
             {textParagraph}
             <p>
@@ -272,13 +267,13 @@ export const WithPreviousButton: StoryFn<typeof EbayLightboxDialog> = (args) => 
             </p>
         </EbayLightboxDialog>
     </div>
-)
+);
 
 export const WithWideSize: StoryFn<typeof EbayLightboxDialog> = (args) => (
     <div>
         <p>Some outside content...</p>
         <EbayLightboxDialog {...args} open a11yCloseText="Close dialog" size="wide">
-            <EbayDialogPreviousButton aria-label="Previous" onClick={action('previous button click')} />
+            <EbayDialogPreviousButton aria-label="Previous" onClick={action("previous button click")} />
             <EbayDialogHeader>Heading</EbayDialogHeader>
             {textParagraph}
             <p>
@@ -286,13 +281,13 @@ export const WithWideSize: StoryFn<typeof EbayLightboxDialog> = (args) => (
             </p>
         </EbayLightboxDialog>
     </div>
-)
+);
 
 export const WithNarrowSize: StoryFn<typeof EbayLightboxDialog> = (args) => (
     <div>
         <p>Some outside content...</p>
         <EbayLightboxDialog {...args} open a11yCloseText="Close dialog" size="narrow">
-            <EbayDialogPreviousButton aria-label="Previous" onClick={action('previous button click')} />
+            <EbayDialogPreviousButton aria-label="Previous" onClick={action("previous button click")} />
             <EbayDialogHeader>Heading</EbayDialogHeader>
             {textParagraph}
             <p>
@@ -300,13 +295,13 @@ export const WithNarrowSize: StoryFn<typeof EbayLightboxDialog> = (args) => (
             </p>
         </EbayLightboxDialog>
     </div>
-)
+);
 
 export const WithFullscreenSize: StoryFn<typeof EbayLightboxDialog> = (args) => (
     <div>
         <p>Some outside content...</p>
         <EbayLightboxDialog {...args} open a11yCloseText="Close dialog" size="fullscreen">
-            <EbayDialogPreviousButton aria-label="Previous" onClick={action('previous button click')} />
+            <EbayDialogPreviousButton aria-label="Previous" onClick={action("previous button click")} />
             <EbayDialogHeader>Heading</EbayDialogHeader>
             {textParagraph}
             <p>
@@ -314,13 +309,13 @@ export const WithFullscreenSize: StoryFn<typeof EbayLightboxDialog> = (args) => 
             </p>
         </EbayLightboxDialog>
     </div>
-)
+);
 
 export const WithLargeSize: StoryFn<typeof EbayLightboxDialog> = (args) => (
     <div>
         <p>Some outside content...</p>
         <EbayLightboxDialog {...args} open a11yCloseText="Close dialog" size="large">
-            <EbayDialogPreviousButton aria-label="Previous" onClick={action('previous button click')} />
+            <EbayDialogPreviousButton aria-label="Previous" onClick={action("previous button click")} />
             <EbayDialogHeader>Heading</EbayDialogHeader>
             {textParagraph}
             <p>
@@ -328,10 +323,10 @@ export const WithLargeSize: StoryFn<typeof EbayLightboxDialog> = (args) => (
             </p>
         </EbayLightboxDialog>
     </div>
-)
+);
 
 export const Expressive: StoryFn<typeof EbayLightboxDialog> = (args) => {
-    const [open, setOpen] = useState(false)
+    const [open, setOpen] = useState(false);
 
     return (
         <div>
@@ -343,10 +338,10 @@ export const Expressive: StoryFn<typeof EbayLightboxDialog> = (args) => {
                 bannerImgSrc="http://ir.ebaystatic.com/cr/v/c1/skin/image-treatment/mountain.jpeg"
                 bannerImgPosition="top"
                 open={open}
-                onOpen={() => action('onOpen')()}
+                onOpen={() => action("onOpen")()}
                 onClose={() => {
-                    action('onClose')()
-                    setOpen(false)
+                    action("onClose")();
+                    setOpen(false);
                 }}
                 a11yCloseText="Close"
             >
@@ -357,7 +352,36 @@ export const Expressive: StoryFn<typeof EbayLightboxDialog> = (args) => {
                 </p>
             </EbayLightboxDialog>
         </div>
-    )
-}
+    );
+};
 
-export default story
+export const DebugOnClose: StoryFn<typeof EbayLightboxDialog> = (args) => {
+    const [open, setOpen] = useState(true);
+    const [showButton, setShowButton] = useState(true);
+
+    return (
+        <div>
+            <button className="btn btn--secondary" onClick={() => setOpen(!open)}>
+                Open Dialog
+            </button>
+            <EbayLightboxDialog
+                {...args}
+                bannerImgSrc="http://ir.ebaystatic.com/cr/v/c1/skin/image-treatment/mountain.jpeg"
+                bannerImgPosition="top"
+                open={open}
+                onOpen={() => action("onOpen")()}
+                onClose={() => {
+                    action("onClose")();
+                    setOpen(false);
+                }}
+                a11yCloseText="Close"
+            >
+                <EbayDialogHeader>Heading Text</EbayDialogHeader>
+                {textParagraph}
+                <p>{showButton && <button onClick={() => setShowButton(false)}>Hide me</button>}</p>
+            </EbayLightboxDialog>
+        </div>
+    );
+};
+
+export default story;


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes # N/A

<!-- Select which type of PR this is -->
- [ ] This PR contains CSS changes
- [x] This PR does not contain CSS changes

## Description

Under certain conditions, clicking a button inside a dialog causes the dialog to incorrectly close. A key condition that must be met is that the clicked element disappears from the DOM after being clicked. That causes [this condition](https://github.com/eBay/evo-web/blob/f52a6dded13308d7bb569cf5049b19cf85e34b53/packages/ebayui-core-react/src/ebay-dialog-base/components/dialogBase.tsx#L101) to pass because `!drawerBaseEl.current.contains(e.target)` evaluates to true since `e.target` has been removed from the DOM.

This PR adds an additional check to that conditional to validate that `e.target` is still _somewhere_ in the document. If it's not, then the dialog does not close. If it _is_ still in the document, then that indicates that the user indeed clicked outside the dialog, and thus it should close. 

For some reason I have been unable to repro this bug with a smaller use case, so I'm not sure what other conditions contribute to it in the first place. But regardless, this fix seems appropriate.

## Notes
<!-- Be sure to mention anything unusual, out-of-scope or new technical debt, etc -->

## Screenshots
<!-- Upload screenshots of UI before & after these changes -->

## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [ ] I verify the build is in a non-broken state
- [ ] I verify all changes are within scope of the linked issue

<!-- For Markup Changes -->
- [ ] I verify the markup will not be a breaking change (if not a major release)
- [ ] I verify the MIND pattern for the component has been created/revised

<!-- For CSS changes -->
- [ ] I regenerated all CSS files under dist folder
- [ ] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [ ] I tested the UI in dark mode and RTL mode
- [ ] I added/updated/removed Storybook coverage as appropriate
