### PR TITLE
fix(react:dialog): fix close handler call when the clicked element is removed from the DOM

### DIFF
--- a/.changeset/crazy-singers-train.md
+++ b/.changeset/crazy-singers-train.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ui-core-react": patch
+---
+
+fix(react:dialog): Fix close handler call when the clicked element is removed from the DOM

--- a/packages/ebayui-core-react/smoke-tests/react-16/index.js
+++ b/packages/ebayui-core-react/smoke-tests/react-16/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
 const React = require('react')
 const ReactDOMServer = require('react-dom/server')
 const { EbayButton } = require('@ebay/ui-core-react/ebay-button')

--- a/packages/ebayui-core-react/src/ebay-dialog-base/__tests__/index.spec.tsx
+++ b/packages/ebayui-core-react/src/ebay-dialog-base/__tests__/index.spec.tsx
@@ -5,8 +5,6 @@ import DialogBase from '../components/dialogBase'
 import EbayDialogHeader from '../components/dialog-header'
 import { HeaderFooterDialog } from './mocks'
 
-jest.useFakeTimers()
-
 describe('DialogBase', () => {
     it('should use id from header', () => {
         const wrapper = render(
@@ -70,12 +68,11 @@ describe('DialogBase', () => {
                 )
             })
             it('when btn cliked then it should trigger onCloseBtnClick event', () => {
-                fireEvent.click(wrapper.container.querySelector('.drawer-dialog__close'))
+                fireEvent.click(wrapper.container.querySelector('.drawer-dialog__close')!)
                 expect(spyCloseBtnClick).toHaveBeenCalled()
             })
             it('when background clicked then it should trigger onBackgroundClick event', () => {
-                jest.runAllTimers()
-                document.body.click()
+                fireEvent.click(wrapper.container.querySelector('.drawer-dialog')!)
                 expect(spyBackgroundClick).toHaveBeenCalled()
             })
         })

--- a/packages/ebayui-core-react/src/ebay-dialog-base/components/dialogBase.tsx
+++ b/packages/ebayui-core-react/src/ebay-dialog-base/components/dialogBase.tsx
@@ -19,7 +19,6 @@ import { useDialogAnimation, TransitionElement } from './animation'
 import { DialogCloseEvent, DialogCloseEventHandler } from '../types'
 import { EbayDialogHeaderProps } from './dialog-header'
 
-
 export type WindowType = 'compact'
 type ClassPrefix = 'fullscreen-dialog' | 'lightbox-dialog' | 'panel-dialog'
     | 'drawer-dialog' | 'toast-dialog' | 'alert-dialog' | 'confirm-dialog'
@@ -95,27 +94,12 @@ export const DialogBase: FC<DialogBaseProps<HTMLElement>> = ({
         setRandomId(randomId())
     }, [])
 
-    useEffect(() => {
-        let timeout: number
-        const handleBackgroundClick = (e: DocumentEventMap['click']) => {
-            if (drawerBaseEl.current && !drawerBaseEl.current.contains(e.target)) {
-                onBackgroundClick(e as unknown as DialogCloseEvent)
-            }
+    const handleBackgroundClick = (e) => {
+        props.onClick?.(e)
+        if (drawerBaseEl.current && !drawerBaseEl.current.contains(e.target)) {
+            onBackgroundClick(e as unknown as DialogCloseEvent)
         }
-        if (open && buttonPosition !== 'hidden') {
-            // On React 18 useEffect hooks runs synchronous instead of asynchronous as React 17 or prior
-            // causing the event listener to be attached to the document at the same time that the dialog
-            // opens. Adding a timeout so the event is attached after the click event that opened the modal
-            // is finished.
-            timeout = window.setTimeout(() => {
-                document.addEventListener('click', handleBackgroundClick, false)
-            })
-        }
-        return () => {
-            clearTimeout(timeout)
-            document.removeEventListener('click', handleBackgroundClick, false)
-        }
-    }, [onBackgroundClick, open])
+    }
 
     useEffect(() => {
         if (open && isModal) {
@@ -201,6 +185,7 @@ export const DialogBase: FC<DialogBaseProps<HTMLElement>> = ({
             aria-live={!isModal ? 'polite' : undefined}
             ref={dialogRef}
             onKeyDown={onKeyDown as (event: KeyboardEvent<HTMLElement>) => void}
+            onClick={open && buttonPosition !== 'hidden' ? handleBackgroundClick : props.onClick}
         >
             <div className={classNames(windowClassName, windowClass)} ref={drawerBaseEl}>
                 {top}


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #144

<!-- Select which type of PR this is -->
- [ ] This PR contains CSS changes
- [x] This PR does not contain CSS changes

## Description
<!-- Briefly describe the proposed changes -->
Change how we handle background click by using the mask as the click handler target. The current approach of adding an event listener in the `document` conflicts on how React handles the states update in the DOM causing issues when apps do state changes that impact in the UI visibility. For example, clicking an `Edit` button, will replace that button with a different `Save` button. This issue has to do how the Event loops works and how the state update is made by React. When clicking a button, each event handler (added with `element.addEventListener`) is going to be considered as a different task in the event loop (unless `element.click()` is being used). React schedules their DOM updates in a micro task, and that micro task will execute before the next task on the event loop, causing the document event handler to be executed after the  state was updated so the element doesn't exists anymore in the page.

The sequence is the following:

```
TASK (onClick -> setState (scheduleMicrotask)) ---> MICROTASK(DOM update) ---> TASK (document click handler)
```

That is because we used to manually add the event handler with `document.addEventListener()`

Note: The behavior is different if `element.click()` is used, the sequence will be :

```
TASK (onClick -> setState (scheduleMicrotask) --> document click handler) ---> MICROTASK(DOM update)
```
_(that is why is not possible to simulate in unit test since a `element.dispatchEvent` is used)_

This PR changes the click event to the mask of the dialog, so everything is being considered in the same React event handler task and the state is properly considered.

## Notes
<!-- Be sure to mention anything unusual, out-of-scope or new technical debt, etc -->

## Screenshots
<!-- Upload screenshots of UI before & after these changes -->

## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [ ] I verify the build is in a non-broken state
- [ ] I verify all changes are within scope of the linked issue

<!-- For Markup Changes -->
- [ ] I verify the markup will not be a breaking change (if not a major release)
- [ ] I verify the MIND pattern for the component has been created/revised

<!-- For CSS changes -->
- [ ] I regenerated all CSS files under dist folder
- [ ] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [ ] I tested the UI in dark mode and RTL mode
- [ ] I added/updated/removed Storybook coverage as appropriate
