### PR TITLE
chore(react): disable axe-core automatic runs to improve storybook pe…

### DIFF
--- a/packages/ebayui-core-react/.gitignore
+++ b/packages/ebayui-core-react/.gitignore
@@ -26,3 +26,4 @@ junit.xml
 coverage
 /.vscode
 /_site
+/storybook-static

--- a/packages/ebayui-core-react/.storybook/preview.jsx
+++ b/packages/ebayui-core-react/.storybook/preview.jsx
@@ -15,6 +15,14 @@ export default {
             </StrictMode>
         )
     ],
+    globals: {
+        a11y: {
+            // Disable automatic a11y runs as it impacts performance of storybook.
+            // This started after a change introduced in v8.5.0 that runs the axe-core tests
+            // in sequence instead of parallel.
+            manual: true
+        }
+    },
     parameters: {
         controls: { expanded: true },
         options: {


### PR DESCRIPTION
…rformance

<!-- Insert GitHub issue number below -->
Fixes #

<!-- Select which type of PR this is -->
- [ ] This PR contains CSS changes
- [x] This PR does not contain CSS changes

## Description
This PR removes the auto runs of axe tests on storybook as it causes performance issues. [This change](https://github.com/storybookjs/storybook/commit/a08302164a7b82ead3dccaaaad47c38d35dbe76a) on storybook/a11y-addon was introduced on 8.5.0 that executes axe tests in sequence and not in parallel, causing the slowness on loading every story. Bellow is the performance flame chart where each task on a11y-addon takes around 6s for every group of stories that is executing.

<img width="1327" alt="Screenshot 2025-05-29 at 8 40 47 AM" src="https://github.com/user-attachments/assets/c60d6397-a0a0-45f0-a8a5-462d7036374c" />

## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [ ] I verify the build is in a non-broken state
- [ ] I verify all changes are within scope of the linked issue

<!-- For Markup Changes -->
- [ ] I verify the markup will not be a breaking change (if not a major release)
- [ ] I verify the MIND pattern for the component has been created/revised

<!-- For CSS changes -->
- [ ] I regenerated all CSS files under dist folder
- [ ] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [ ] I tested the UI in dark mode and RTL mode
- [ ] I added/updated/removed Storybook coverage as appropriate
