### PR TITLE
chore(percy): added automated targeted Percy build on PRs and releases

### DIFF
--- a/.github/workflows/baseline-visual-regression.yml
+++ b/.github/workflows/baseline-visual-regression.yml
@@ -1,0 +1,67 @@
+# This workflow runs Percy visual regression tests after a PR tagged with "package: skin"
+# is merged into the main branch. It extracts the list of stories from the PR body
+# and runs snapshots for those stories to update the visual regression baselines.
+
+name: Percy Merged Visual Regression Baselines
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  post-merge-snapshots:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checkout the repository
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      # Set up Node.js
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      # Install dependencies
+      - name: Install dependencies
+        run: npm install
+        working-directory: ./packages/skin
+
+      # Extract target stories from PR body
+      - name: Extract target stories
+        id: extract_stories
+        run: |
+          # Get the last merged PR details
+          PR_BODY=$(gh pr view $(git log -1 --pretty=format:"%s" | grep -oP '#\d+') --json body -q '.body')
+          if [[ $PR_BODY == *"package: skin"* ]]; then
+            STORIES=$(echo "$PR_BODY" | awk '/Percy Stories/{getline; print}')
+            if [ -z "$STORIES" ]; then
+              echo "No Percy Stories found in PR body."
+              exit 0
+            fi
+            echo "stories=$STORIES" >> $GITHUB_ENV
+          else
+            echo "No relevant PR found for package: skin."
+            exit 0
+          fi
+        working-directory: ./packages/skin
+
+      # Debug: Print extracted stories
+      - name: Debug extracted stories
+        run: echo "Extracted stories: $stories"
+        working-directory: ./packages/skin
+
+      # Run Percy for the extracted stories
+      - name: Run Percy visual tests
+        env:
+          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
+        run: |
+          if [ -z "$stories" ]; then
+            echo "No target stories found. Skipping Percy tests."
+            exit 0
+          fi
+          echo "Running Percy for stories: $stories"
+          npm run snapshots "$stories"
+        working-directory: ./packages/skin

--- a/.github/workflows/pr-visual-regression.yml
+++ b/.github/workflows/pr-visual-regression.yml
@@ -1,0 +1,58 @@
+# This workflow runs Percy visual regression tests for pull requests. It extracts the list of stories
+# from the PR body and runs snapshots for those stories to validate visual changes before merging.
+# If Percy detects visual differences, the workflow fails to block merging.
+
+name: Percy PR Visual Regression Tests
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - edited
+      - labeled
+
+jobs:
+  visual-regression:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checkout the repository
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      # Set up Node.js
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      # Install dependencies
+      - name: Install dependencies
+        run: npm install
+        working-directory: ./packages/skin
+
+      # Extract target stories from PR body
+      - name: Extract target stories
+        id: extract_stories
+        run: |
+          STORIES=$(echo "${{ github.event.pull_request.body }}" | awk '/Percy Stories/{getline; print}')
+          if [ -z "$STORIES" ]; then
+            echo "No Percy Stories found in PR body."
+            exit 0
+          fi
+          echo "stories=$STORIES" >> $GITHUB_ENV
+        working-directory: ./packages/skin
+
+      # Debug: Print extracted stories
+      - name: Debug extracted stories
+        run: echo "Extracted stories: $stories"
+        working-directory: ./packages/skin
+
+      # Run Percy for the extracted stories
+      - name: Run Percy visual tests
+        env:
+          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
+        run: npm run snapshots --stories "$stories"
+        working-directory: ./packages/skin


### PR DESCRIPTION
This PR automates targeted Percy visual regression runs for specific stories on PRs as well as running the new baselines for those specific stories after PRs are merged to main.

## Current Approach with Explicit Story Definitions

Here's the current process built into the scripts:

1. Update the PR with the label, package: skin
2. Update the PR template to include this "kickoff" string at the bottom:
Percy Stories
(replace this with the Percy stories, like so: Toggle Button,Button,Filter Button)
3. On PR updates, commits, label additions, the automation will run if it sees the "kickoff" string and is labeled correctly
4. It will pick up the stories mentioned and run Percy for those stories.
5. If visual regression fails, it will trigger an error in build and block PR merging. This step more or less triggers a manual step to check the build in Percy and validate they are expected changes.
Thoughts? I'm happy to change the process if a simpler one can be offered. The main hurdle here were the scripts to get these going, and based on how the testing pans out, I think I may have solved that piece. Not having to run Percy locally and automating runs should improve workflow.

## A Potential Secondary Approach Using Implied Stories from Files Changed

With this approach, the system will find the files that are changed, find a way to map the files changed to their respective story names (this is what Percy needs), and then use that list for the targeted build.

The difficulty with this approach is either assuming file names of the changes will follow the same exact pattern as the Story names, or (if not assuming it), it would need to have a file name:story name mapping somewhere. It would be more automated with less manual effort, but possibly more difficult to pull off.