### PR TITLE
docs(lightbox-dialog): associate lightbox-dialog with DS bottom-sheet

### DIFF
--- a/.changeset/afraid-ties-follow.md
+++ b/.changeset/afraid-ties-follow.md
@@ -1,0 +1,5 @@
+---
+"@ebay/skin": patch
+---
+
+docs(lightbox-dialog): associate lightbox-dialog with DS bottom-sheet

--- a/packages/skin/src/routes/_index/component/lightbox-dialog/+page.marko
+++ b/packages/skin/src/routes/_index/component/lightbox-dialog/+page.marko
@@ -1069,9 +1069,15 @@
 </div>
 export const metadata = {
     component: "lightbox-dialog",
-    "ds-component": {
-        name: "dialog",
-        version: 4.1,
-    },
+    "ds-component": [
+        {
+            name: "dialog",
+            version: 4.1,
+        },
+        {
+            name: "bottom-sheet",
+            version: 3.0
+        }
+    ],
     submodules: ["button", "icon-button"],
 };


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #177 

<!-- Select which type of PR this is -->
- [ ] This PR contains CSS changes
- [x] This PR does not contain CSS changes

## Description
Updating the Design System mapping for `lightbox-dialog` to link to both the design system `dialog` and `bottom-sheet` components, so it can show up in the list of resources for Bottom Sheet in Playbook: https://playbook.ebay.com/design-system/components/bottom-sheet/?tab=develop

## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [ ] I verify the build is in a non-broken state  -- ❗  **I had to use `--no-verify` when pushing up these changes, as there were unrelated issues in the husky pre-push script related to the react package**
- [x] I verify all changes are within scope of the linked issue