### PR TITLE
chore(ai): added the initial shared instructions for copilot

### DIFF
--- a/.github/instructions/skin-css-prompt.instructions.md
+++ b/.github/instructions/skin-css-prompt.instructions.md
@@ -1,0 +1,18 @@
+---
+applyTo: "**/*.scss"
+---
+
+Coding standards, domain knowledge, and preferences that AI should follow.
+
+Always use BEM (Block Element Modifier) naming conventions for all CSS/SCSS selectors.
+Prioritize semantic HTML5 elements for all components.
+
+Ensure all components are responsive and mobile-friendly, using
+
+CSS Grid or Flexbox for layout.
+
+Use CSS variables for colors, spacing, and typography to maintain consistency across the application.
+
+Ensure optimal accessibility (a11y) by following WCAG 2.1 AA guidelines.
+
+Ensure all interactive elements have clear focus states and keyboard navigation support.

--- a/.github/instructions/skin-css-prompt.instructions.md
+++ b/.github/instructions/skin-css-prompt.instructions.md
@@ -2,6 +2,8 @@
 applyTo: "**/*.scss"
 ---
 
+Follow our styleguide: https://github.com/eBay/evo-web/blob/main/packages/skin/STYLEGUIDE.md
+
 Coding standards, domain knowledge, and preferences that AI should follow.
 
 Always use BEM (Block Element Modifier) naming conventions for all CSS/SCSS selectors.

--- a/.github/instructions/skin-html-prompt.instructions.md
+++ b/.github/instructions/skin-html-prompt.instructions.md
@@ -2,6 +2,8 @@
 applyTo: "**/*.marko"
 ---
 
+Follow our styleguide: https://github.com/eBay/evo-web/blob/main/packages/skin/STYLEGUIDE.md
+
 Coding standards, domain knowledge, and preferences that AI should follow.
 
 Always use BEM (Block Element Modifier) naming conventions for all HTML classes and CSS/SCSS selectors.

--- a/.github/instructions/skin-html-prompt.instructions.md
+++ b/.github/instructions/skin-html-prompt.instructions.md
@@ -1,0 +1,21 @@
+---
+applyTo: "**/*.marko"
+---
+
+Coding standards, domain knowledge, and preferences that AI should follow.
+
+Always use BEM (Block Element Modifier) naming conventions for all HTML classes and CSS/SCSS selectors.
+
+Prioritize semantic HTML5 elements for all components.
+
+Ensure all components are responsive and mobile-friendly, using CSS Grid or Flexbox for layout.
+
+Use CSS variables for colors, spacing, and typography to maintain consistency across the application.
+
+Ensure optimal accessibility (a11y) by following WCAG 2.1 AA guidelines.
+
+Ensure all interactive elements have clear focus states and keyboard navigation support.
+
+Use ARIA roles and attributes where necessary to enhance accessibility.
+
+Adhere to WCAG 2.1 AA contrast ratios for text and backgrounds.

--- a/packages/skin/CONTRIBUTING.md
+++ b/packages/skin/CONTRIBUTING.md
@@ -19,7 +19,7 @@ This page contains instructions and guidelines for anybody contributing code to 
     - [Commit Message Format](#commit-message-format)
     - [Pull Requests](#pull-requests)
     - [Naming Scheme](#naming-scheme)
-    - [Style Guide](#style-guide)
+    - [Style Guide](https://github.com/eBay/evo-web/new/main/packages/skin/STYLEGUIDE.md))
     - [LESS API (deprecated)](#less-api-deprecated)
     - [Custom Property API](#custom-property-api)
         - [Core Tokens](#core-tokens)
@@ -58,7 +58,7 @@ Here is a rough overview of steps required when contributing code to skin:
 
 - GitHub team members must create a new branch in the Skin repo. Non-team members should create their own fork.
 - Please ensure you branch off from the correct milestone branch! See branching strategy section below.
-- Skin adopts the [BEM](https://css-tricks.com/bem-101/) methodology (a popular naming convention for classes in HTML and CSS). Please familiarize yourself with our style guide in the section below.
+- Skin adopts the [BEM](https://css-tricks.com/bem-101/) methodology (a popular naming convention for classes in HTML and CSS). Please familiarize yourself with our [style guide](https://github.com/eBay/evo-web/new/main/packages/skin/STYLEGUIDE.md).
 - After making changes to `.less` files, ensure that no new CSS lint warnings or errors are introduced
 - Add or update the corresponding website documentation. More information in the [documentation](#documentation) section below.
 - Push commit(s) to the upstream branch. Ensure new dist files (i.e. the compiled CSS files) are included!
@@ -242,30 +242,7 @@ eBay Skin is an implementation of the [eBay MIND Patterns](https://ebay.gitbook.
 
 ## Style Guide
 
-When contributing to Skin, please bear the following guidelines in mind:
-
-- Ensure all markup adheres to our [accessibility patterns](https://ebay.gitbooks.io/mindpatterns/content/)
-- Ensure all markup is valid HTML
-- Leverage ARIA roles, states and properties for styling hooks wherever possible. This safeguards against non-accessible markup (NOTE: this will increase specificity, but we accept this as a worthwhile trade off)
-- Use BEM syntax for modifiers (double-dash) and nested classes (double-underscore)
-- Use the `<svg>` tag for icons
-- Never use the `<i>` tag for icons
-- Harness CSS margin-collapse wherever possible.
-- Most block-level modules will require margin top and bottom as a sensible default
-- Do not use presentational class names, e.g. `.btn--green` should be `.btn--secondary` for example
-- Do not combine classes into a single class name, e.g. `btn-sec` should be `btn btn--sec`, this allows cascades without advanced attribute selectors or pre-processors
-- Do not chain BEM modifiers (e.g. `.btn--large.btn--primary`). This is a code smell.
-- Do not use ambiguous or global class names, e.g. `.large` should be `.btn--large`
-- Do not use class `.disabled` to disable buttons or form elements, use the HTML `disabled` property instead
-- Do not wrap inputs with labels, use explicit labels instead (e.g. use the `for` and `id` attributes)
-- Do not use `href="#"` or `href="javascript"` in examples, use `href="http://www.ebay.com"` or any other dummy URL
-- Every `<img>` tag must have an `alt` attribute, with **no** exceptions. The value can be an empty string for presentational images.
-- Avoid naming conflicts with other grid systems (e.g. Bootstap Grids)
-- Keep LESS pre-processor usage restricted to variables, mixins and basic nesting (see below). 9 times out of 10 advanced features of pre-processors can be avoided by using CSS properly.
-- Avoid too much nesting/indenting of LESS selectors as it can reduce human scan-ability of code and can also result in suboptimal compiled CSS. Try and restrict nesting to pseudo selectors only (e.g. `:focus`, `::after`).
-- Avoid over specificity (unless required for accessibility safeguarding). The fewer rules required to check for a given element, the faster style resolution will be. This is the key to dramatically increasing performance.
-  [https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Writing_efficient_CSS](https://web.archive.org/web/20161029110643/https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Writing_efficient_CSS)
-- Please do not commit commented out code to production.
+When contributing to Skin, please ensure you follow our [style guide](https://github.com/eBay/evo-web/new/main/packages/skin/STYLEGUIDE.md).
 
 ## LESS API (deprecated)
 

--- a/packages/skin/CONTRIBUTING.md
+++ b/packages/skin/CONTRIBUTING.md
@@ -19,7 +19,7 @@ This page contains instructions and guidelines for anybody contributing code to 
     - [Commit Message Format](#commit-message-format)
     - [Pull Requests](#pull-requests)
     - [Naming Scheme](#naming-scheme)
-    - [Style Guide](https://github.com/eBay/evo-web/new/main/packages/skin/STYLEGUIDE.md))
+    - [Style Guide](https://github.com/eBay/evo-web/new/main/packages/skin/STYLEGUIDE.md)
     - [LESS API (deprecated)](#less-api-deprecated)
     - [Custom Property API](#custom-property-api)
         - [Core Tokens](#core-tokens)

--- a/packages/skin/CONTRIBUTING.md
+++ b/packages/skin/CONTRIBUTING.md
@@ -19,7 +19,7 @@ This page contains instructions and guidelines for anybody contributing code to 
     - [Commit Message Format](#commit-message-format)
     - [Pull Requests](#pull-requests)
     - [Naming Scheme](#naming-scheme)
-    - [Style Guide](https://github.com/eBay/evo-web/new/main/packages/skin/STYLEGUIDE.md)
+    - [Style Guide](https://github.com/eBay/evo-web/blob/main/packages/skin/STYLEGUIDE.md)
     - [LESS API (deprecated)](#less-api-deprecated)
     - [Custom Property API](#custom-property-api)
         - [Core Tokens](#core-tokens)
@@ -58,7 +58,7 @@ Here is a rough overview of steps required when contributing code to skin:
 
 - GitHub team members must create a new branch in the Skin repo. Non-team members should create their own fork.
 - Please ensure you branch off from the correct milestone branch! See branching strategy section below.
-- Skin adopts the [BEM](https://css-tricks.com/bem-101/) methodology (a popular naming convention for classes in HTML and CSS). Please familiarize yourself with our [style guide](https://github.com/eBay/evo-web/new/main/packages/skin/STYLEGUIDE.md).
+- Skin adopts the [BEM](https://css-tricks.com/bem-101/) methodology (a popular naming convention for classes in HTML and CSS). Please familiarize yourself with our [style guide](https://github.com/eBay/evo-web/blob/main/packages/skin/STYLEGUIDE.md).
 - After making changes to `.less` files, ensure that no new CSS lint warnings or errors are introduced
 - Add or update the corresponding website documentation. More information in the [documentation](#documentation) section below.
 - Push commit(s) to the upstream branch. Ensure new dist files (i.e. the compiled CSS files) are included!
@@ -242,7 +242,7 @@ eBay Skin is an implementation of the [eBay MIND Patterns](https://ebay.gitbook.
 
 ## Style Guide
 
-When contributing to Skin, please ensure you follow our [style guide](https://github.com/eBay/evo-web/new/main/packages/skin/STYLEGUIDE.md).
+When contributing to Skin, please ensure you follow our [style guide](https://github.com/eBay/evo-web/blob/main/packages/skin/STYLEGUIDE.md).
 
 ## LESS API (deprecated)
 

--- a/packages/skin/STYLEGUIDE.md
+++ b/packages/skin/STYLEGUIDE.md
@@ -1,0 +1,25 @@
+# Style Guide
+
+When contributing to Skin, please bear the following guidelines in mind:
+
+- Ensure all markup adheres to our [accessibility patterns](https://ebay.gitbooks.io/mindpatterns/content/)
+- Ensure all markup is valid HTML
+- Leverage ARIA roles, states and properties for styling hooks wherever possible. This safeguards against non-accessible markup (NOTE: this will increase specificity, but we accept this as a worthwhile trade off)
+- Use BEM syntax for modifiers (double-dash) and nested classes (double-underscore)
+- Use the `<svg>` tag for icons
+- Never use the `<i>` tag for icons
+- Harness CSS margin-collapse wherever possible.
+- Do not use presentational class names, e.g. `.btn--green` should be `.btn--secondary` for example
+- Do not combine classes into a single class name, e.g. `btn-sec` should be `btn btn--sec`, this allows cascades without advanced attribute selectors or pre-processors
+- Do not chain BEM modifiers (e.g. `.btn--large.btn--primary`). This is a code smell.
+- Do not use ambiguous or global class names, e.g. `.large` should be `.btn--large`
+- Do not use class `.disabled` to disable buttons or form elements, use the HTML `disabled` property instead
+- Do not wrap inputs with labels, use explicit labels instead (e.g. use the `for` and `id` attributes)
+- Do not use `href="#"` or `href="javascript"` in examples, use `href="http://www.ebay.com"` or any other dummy URL
+- Every `<img>` tag must have an `alt` attribute, with **no** exceptions. The value can be an empty string for presentational images.
+- Avoid naming conflicts with other grid systems (e.g. Bootstap Grids)
+- Keep LESS pre-processor usage restricted to variables, mixins and basic nesting (see below). 9 times out of 10 advanced features of pre-processors can be avoided by using CSS properly.
+- Avoid too much nesting/indenting of LESS selectors as it can reduce human scan-ability of code and can also result in suboptimal compiled CSS. Try and restrict nesting to pseudo selectors only (e.g. `:focus`, `::after`).
+- Avoid over specificity (unless required for accessibility safeguarding). The fewer rules required to check for a given element, the faster style resolution will be. This is the key to dramatically increasing performance.
+  [https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Writing_efficient_CSS](https://web.archive.org/web/20161029110643/https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Writing_efficient_CSS)
+- Please do not commit commented out code to production.


### PR DESCRIPTION
## Shared Copilot Instructions

This is for adding a shared set of Copilot instructions for use on local machines.

### How to Use

1. Click on "Add Context"
2. From the selection, select "Instructions..."
3. Load the prompt instruction file(s) from `.github/instructions`

Your Copilot interactions will then take the instructions as context.

### Updates

Feel free to suggest changes. These were just the initial set of instructions that came to mind for the `scss` and `html`.
