### PR TITLE
fix(site): removed 90vw width as it was uncentering content in main evo page

### DIFF
--- a/src/routes/+layout.style.scss
+++ b/src/routes/+layout.style.scss
@@ -7,7 +7,6 @@
     justify-content: center;
     flex-direction: column;
     height: 90vh;
-    width: 90vw;
 }
 
 .main .layout-grid {


### PR DESCRIPTION


<!-- Insert GitHub issue number below -->
n/a, I just kept noticing it and it was bothering me 😬 . Can create an issue for tracking purposes if needed.

<!-- Select which type of PR this is -->
- [x] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
<!-- Briefly describe the proposed changes -->
Just got rid of the `width` CSS property in the evo placeholder page because it was off center and driving me crazy 😆 

## Notes
<!-- Be sure to mention anything unusual, out-of-scope or new technical debt, etc -->

## Screenshots

### Before
<img width="1670" alt="Screenshot 2025-06-18 at 1 37 33 PM" src="https://github.com/user-attachments/assets/3dd291be-d3fb-40ed-aa81-95af23c6939a" />

### After
<img width="1672" alt="Screenshot 2025-06-18 at 1 37 25 PM" src="https://github.com/user-attachments/assets/403b4df9-d6fe-4234-95d7-b53a9fad7489" />

## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [x] I verify the build is in a non-broken state
- [x] I verify all changes are within scope of the linked issue

<!-- For Markup Changes -->
- [ ] I verify the markup will not be a breaking change (if not a major release)
- [ ] I verify the MIND pattern for the component has been created/revised

<!-- For CSS changes -->
- [ ] I regenerated all CSS files under dist folder
- [ ] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [ ] I tested the UI in dark mode and RTL mode
- [ ] I added/updated/removed Storybook coverage as appropriate
