### PR TITLE
feat(panel-dialog): added prev button

### DIFF
--- a/.changeset/seven-knives-grow.md
+++ b/.changeset/seven-knives-grow.md
@@ -1,0 +1,6 @@
+---
+"@ebay/ebayui-core": minor
+"@ebay/skin": minor
+---
+
+feat(panel-dialog): added prev button

--- a/packages/ebayui-core/src/components/components/ebay-dialog-base/index.marko
+++ b/packages/ebayui-core/src/components/components/ebay-dialog-base/index.marko
@@ -113,7 +113,7 @@ $ const {
             <if(prevButton)>
                 <button
                     ...processHtmlAttributes(prevButtonHtmlInput)
-                    class=["icon-btn", "lightbox-dialog__prev", prevButtonClass]
+                    class=["icon-btn", `${classPrefix}__prev`, prevButtonClass]
                     type="button"
                     aria-label=prevButtonA11yText
                     on-click("emit", "prevButtonClick")

--- a/packages/ebayui-core/src/components/ebay-panel-dialog/examples/with-footer.marko
+++ b/packages/ebayui-core/src/components/ebay-panel-dialog/examples/with-footer.marko
@@ -1,0 +1,45 @@
+<ebay-panel-dialog
+    a11yCloseText="Close Dialog"
+    open=state.open
+    on-close("closeDialog")
+    on-open("emit", "open")
+    ...input
+>
+    <@header>Heading</@header>
+    <@footer>
+        <button class="btn">
+            Button 1
+        </button>
+        <button class="btn">
+            Button 2
+        </button>
+    </@footer>
+    <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    </p>
+    <p>
+        <a href="http://www.ebay.com">
+            www.ebay.com
+        </a>
+    </p>
+</ebay-panel-dialog>
+
+<ebay-button on-click("openDialog")>
+    Open Dialog
+</ebay-button>
+class {
+    declare state: {
+        open: boolean;
+    };
+
+    onCreate() {
+        this.state = { open: false };
+    }
+    openDialog() {
+        this.state.open = true;
+    }
+    closeDialog() {
+        this.state.open = false;
+        this.emit("close");
+    }
+}

--- a/packages/ebayui-core/src/components/ebay-panel-dialog/examples/with-prev-button.marko
+++ b/packages/ebayui-core/src/components/ebay-panel-dialog/examples/with-prev-button.marko
@@ -1,0 +1,42 @@
+<ebay-panel-dialog
+    a11yCloseText="Close Dialog"
+    open=state.open
+    onClose("closeDialog")
+    onOpen("emit", "open")
+    onPrevButtonClick("emit", "prev-button-click")
+    ...input
+>
+    <@header>Heading</@header>
+
+    <@prev-button a11y-text="Go back">
+        <ebay-chevron-left-16-icon/>
+    </@prev-button>
+    <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    </p>
+    <p>
+        <a href="http://www.ebay.com">
+            www.ebay.com
+        </a>
+    </p>
+</ebay-panel-dialog>
+
+<ebay-button on-click("openDialog")>
+    Open Dialog
+</ebay-button>
+class {
+    declare state: {
+        open: boolean;
+    };
+
+    onCreate() {
+        this.state = { open: false };
+    }
+    openDialog() {
+        this.state.open = true;
+    }
+    closeDialog() {
+        this.state.open = false;
+        this.emit("close");
+    }
+}

--- a/packages/ebayui-core/src/components/ebay-panel-dialog/index.marko
+++ b/packages/ebayui-core/src/components/ebay-panel-dialog/index.marko
@@ -5,6 +5,7 @@ static {
         position?: "start" | "end";
         "on-open"?: () => void;
         "on-close"?: () => void;
+        "on-prevButtonClick"?: () => void;
     }
 }
 $ const {
@@ -19,6 +20,7 @@ export interface Input extends WithNormalizedProps<PanelDialogInput> {}
     classPrefix="panel-dialog"
     onOpen("emit", "open")
     onClose("emit", "close")
+    onPrevButtonClick("emit", "prevButtonClick")
     class=[inputClass, "panel-dialog--mask-fade-slow"]
     windowClass=[
         "panel-dialog__window--slide",

--- a/packages/ebayui-core/src/components/ebay-panel-dialog/marko-tag.json
+++ b/packages/ebayui-core/src/components/ebay-panel-dialog/marko-tag.json
@@ -27,6 +27,15 @@
         },
         "@html-attributes": "expression"
     },
+    "@prevButton <prev-button>": {
+        "attribute-groups": ["html-attributes"],
+        "@*": {
+            "targetProperty": null,
+            "type": "expression"
+        },
+        "@a11y-text": "string",
+        "@html-attributes": "expression"
+    },
     "@footer <footer>": {
         "attribute-groups": ["html-attributes"],
         "@*": {
@@ -35,5 +44,5 @@
         },
         "@html-attributes": "expression"
     },
-    "description": "[view documentation](https://ebay.github.io/evo-web/ebayui-core/?path=/story/dialogs-ebay-panel-dialog)"
+    "description": "[view documentation](https://ebay.github.io/ebayui-core/?path=/story/dialogs-ebay-panel-dialog)"
 }

--- a/packages/ebayui-core/src/components/ebay-panel-dialog/marko-tag.json
+++ b/packages/ebayui-core/src/components/ebay-panel-dialog/marko-tag.json
@@ -44,5 +44,5 @@
         },
         "@html-attributes": "expression"
     },
-    "description": "[view documentation](https://ebay.github.io/ebayui-core/?path=/story/dialogs-ebay-panel-dialog)"
+    "description": "[view documentation](https://ebay.github.io/evo-web/ebayui-core/?path=/story/dialogs-ebay-panel-dialog)"
 }

--- a/packages/ebayui-core/src/components/ebay-panel-dialog/panel-dialog.stories.ts
+++ b/packages/ebayui-core/src/components/ebay-panel-dialog/panel-dialog.stories.ts
@@ -1,7 +1,14 @@
+import {
+    buildExtensionTemplate,
+} from "../../common/storybook/utils";
 import { Story } from "@storybook/marko";
 import { tagToString } from "../../common/storybook/storybook-code-source";
 import Readme from "./README.md";
 import Component from "./examples/default.marko";
+import WithPrevButtonTemplate from "./examples/with-prev-button.marko";
+import WithPrevButtonCode from "./examples/with-prev-button.marko?raw";
+import WithFooterTemplate from "./examples/with-footer.marko";
+import WithFooterCode from "./examples/with-footer.marko?raw";
 import type { Input } from "./index.marko";
 
 const Template: Story<Input> = (args) => ({
@@ -54,6 +61,15 @@ export default {
             control: { type: "text" },
             description: "A11y text for close button and mask.",
         },
+        prevButton: {
+            name: "@prevButton",
+            control: { type: "object" },
+            table: {
+                category: "@attribute tags",
+            },
+            description:
+                "Previous button, shows up before header. Usually a chevron-left icon.",
+        },
         onOpen: {
             action: "on-open",
             description: "Triggered on dialog opened",
@@ -74,6 +90,16 @@ export default {
                 },
             },
         },
+        onPrevButtonClick: {
+            action: "on-prev-button-click",
+            description: "Triggered when previous button is clicked",
+            table: {
+                category: "Events",
+                defaultValue: {
+                    summary: "",
+                },
+            },
+        },
     },
 };
 
@@ -87,4 +113,14 @@ Default.parameters = {
             code: tagToString("ebay-panel-dialog", Default.args),
         },
     },
-};
+}
+
+export const WithPrevButton = buildExtensionTemplate(
+    WithPrevButtonTemplate,
+    WithPrevButtonCode,
+);
+
+export const WithFooter = buildExtensionTemplate(
+    WithFooterTemplate,
+    WithFooterCode,
+);

--- a/packages/ebayui-core/src/components/ebay-panel-dialog/test/__snapshots__/test.server.js.snap
+++ b/packages/ebayui-core/src/components/ebay-panel-dialog/test/__snapshots__/test.server.js.snap
@@ -2,6 +2,7 @@
 
 exports[`dialog > passes through additional html attributes 1`] = `
 <div
+  aria-labelledby="s0-0-0-dialog-title"
   aria-modal="true"
   class="panel-dialog class1 panel-dialog--mask-fade-slow"
   data-passed-through="true"
@@ -10,344 +11,6 @@ exports[`dialog > passes through additional html attributes 1`] = `
   role="dialog"
   style="color:red"
   type="number"
->
-  <div
-    class="panel-dialog__window panel-dialog__window--slide"
-  >
-    <div
-      class="panel-dialog__header"
-    >
-      <!--F#14-->
-      <button
-        class="icon-btn panel-dialog__close"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="icon icon--16"
-          focusable="false"
-        >
-          <defs>
-            <symbol
-              id="icon-close-16"
-              viewBox="0 0 16 16"
-            >
-              <path
-                d="M2.293 2.293a1 1 0 0 1 1.414 0L8 6.586l4.293-4.293a1 1 0 1 1 1.414 1.414L9.414 8l4.293 4.293a1 1 0 0 1-1.414 1.414L8 9.414l-4.293 4.293a1 1 0 0 1-1.414-1.414L6.586 8 2.293 3.707a1 1 0 0 1 0-1.414Z"
-              />
-            </symbol>
-          </defs>
-          <use
-            href="#icon-close-16"
-          />
-        </svg>
-      </button>
-      <!--F/-->
-    </div>
-    <div
-      class="panel-dialog__main"
-    >
-      <!--F#16-->
-      <!--F/-->
-    </div>
-  </div>
-</div>
-`;
-
-exports[`dialog > passes through additional html attributes 2`] = `
-<div
-  aria-modal="true"
-  class="panel-dialog class1 panel-dialog--mask-fade-slow"
-  data-passed-through="true"
-  data-testid="AttributePassthrough"
-  hidden=""
-  role="dialog"
-  style="color:red"
-  type="number"
->
-  <div
-    class="panel-dialog__window panel-dialog__window--slide"
-  >
-    <div
-      class="panel-dialog__header"
-    >
-      <!--F#14-->
-      <button
-        class="icon-btn panel-dialog__close"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="icon icon--16"
-          focusable="false"
-        >
-          <defs>
-            <symbol
-              id="icon-close-16"
-              viewBox="0 0 16 16"
-            >
-              <path
-                d="M2.293 2.293a1 1 0 0 1 1.414 0L8 6.586l4.293-4.293a1 1 0 1 1 1.414 1.414L9.414 8l4.293 4.293a1 1 0 0 1-1.414 1.414L8 9.414l-4.293 4.293a1 1 0 0 1-1.414-1.414L6.586 8 2.293 3.707a1 1 0 0 1 0-1.414Z"
-              />
-            </symbol>
-          </defs>
-          <use
-            href="#icon-close-16"
-          />
-        </svg>
-      </button>
-      <!--F/-->
-    </div>
-    <div
-      class="panel-dialog__main"
-    >
-      <!--F#16-->
-      <!--F/-->
-    </div>
-  </div>
-</div>
-`;
-
-exports[`dialog > renders basic version 1`] = `
-<div
-  aria-modal="true"
-  class="panel-dialog panel-dialog--mask-fade-slow"
-  hidden=""
-  role="dialog"
->
-  <div
-    class="panel-dialog__window panel-dialog__window--slide"
-  >
-    <div
-      class="panel-dialog__header"
-    >
-      <!--F#14-->
-      <button
-        aria-label="close"
-        class="icon-btn panel-dialog__close"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="icon icon--16"
-          focusable="false"
-        >
-          <defs>
-            <symbol
-              id="icon-close-16"
-              viewBox="0 0 16 16"
-            >
-              <path
-                d="M2.293 2.293a1 1 0 0 1 1.414 0L8 6.586l4.293-4.293a1 1 0 1 1 1.414 1.414L9.414 8l4.293 4.293a1 1 0 0 1-1.414 1.414L8 9.414l-4.293 4.293a1 1 0 0 1-1.414-1.414L6.586 8 2.293 3.707a1 1 0 0 1 0-1.414Z"
-              />
-            </symbol>
-          </defs>
-          <use
-            href="#icon-close-16"
-          />
-        </svg>
-      </button>
-      <!--F/-->
-    </div>
-    <div
-      class="panel-dialog__main"
-    >
-      <!--F#16-->
-      body content
-      <!--F/-->
-    </div>
-  </div>
-</div>
-`;
-
-exports[`dialog > renders basic version 2`] = `
-<button
-  aria-label="close"
-  class="icon-btn panel-dialog__close"
-  type="button"
->
-  <svg
-    aria-hidden="true"
-    class="icon icon--16"
-    focusable="false"
-  >
-    <defs>
-      <symbol
-        id="icon-close-16"
-        viewBox="0 0 16 16"
-      >
-        <path
-          d="M2.293 2.293a1 1 0 0 1 1.414 0L8 6.586l4.293-4.293a1 1 0 1 1 1.414 1.414L9.414 8l4.293 4.293a1 1 0 0 1-1.414 1.414L8 9.414l-4.293 4.293a1 1 0 0 1-1.414-1.414L6.586 8 2.293 3.707a1 1 0 0 1 0-1.414Z"
-        />
-      </symbol>
-    </defs>
-    <use
-      href="#icon-close-16"
-    />
-  </svg>
-</button>
-`;
-
-exports[`dialog > renders basic version 3`] = `
-<div
-  class="panel-dialog__main"
->
-  <!--F#16-->
-  body content
-  <!--F/-->
-</div>
-`;
-
-exports[`dialog > renders in open state 1`] = `
-<div
-  aria-modal="true"
-  class="panel-dialog panel-dialog--mask-fade-slow"
-  role="dialog"
->
-  <div
-    class="panel-dialog__window panel-dialog__window--slide"
-  >
-    <div
-      class="panel-dialog__header"
-    >
-      <!--F#14-->
-      <button
-        aria-label="close"
-        class="icon-btn panel-dialog__close"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="icon icon--16"
-          focusable="false"
-        >
-          <defs>
-            <symbol
-              id="icon-close-16"
-              viewBox="0 0 16 16"
-            >
-              <path
-                d="M2.293 2.293a1 1 0 0 1 1.414 0L8 6.586l4.293-4.293a1 1 0 1 1 1.414 1.414L9.414 8l4.293 4.293a1 1 0 0 1-1.414 1.414L8 9.414l-4.293 4.293a1 1 0 0 1-1.414-1.414L6.586 8 2.293 3.707a1 1 0 0 1 0-1.414Z"
-              />
-            </symbol>
-          </defs>
-          <use
-            href="#icon-close-16"
-          />
-        </svg>
-      </button>
-      <!--F/-->
-    </div>
-    <div
-      class="panel-dialog__main"
-    >
-      <!--F#16-->
-      body content
-      <!--F/-->
-    </div>
-  </div>
-</div>
-`;
-
-exports[`dialog > renders with end type 1`] = `
-<div
-  aria-modal="true"
-  class="panel-dialog panel-dialog--mask-fade-slow"
-  role="dialog"
->
-  <div
-    class="panel-dialog__window panel-dialog__window--slide panel-dialog__window--end"
-  >
-    <div
-      class="panel-dialog__header"
-    >
-      <!--F#14-->
-      <button
-        class="icon-btn panel-dialog__close"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="icon icon--16"
-          focusable="false"
-        >
-          <defs>
-            <symbol
-              id="icon-close-16"
-              viewBox="0 0 16 16"
-            >
-              <path
-                d="M2.293 2.293a1 1 0 0 1 1.414 0L8 6.586l4.293-4.293a1 1 0 1 1 1.414 1.414L9.414 8l4.293 4.293a1 1 0 0 1-1.414 1.414L8 9.414l-4.293 4.293a1 1 0 0 1-1.414-1.414L6.586 8 2.293 3.707a1 1 0 0 1 0-1.414Z"
-              />
-            </symbol>
-          </defs>
-          <use
-            href="#icon-close-16"
-          />
-        </svg>
-      </button>
-      <!--F/-->
-    </div>
-    <div
-      class="panel-dialog__main"
-    >
-      <!--F#16-->
-      <!--F/-->
-    </div>
-  </div>
-</div>
-`;
-
-exports[`dialog > renders with end type 2`] = `
-<div
-  class="panel-dialog__window panel-dialog__window--slide panel-dialog__window--end"
->
-  <div
-    class="panel-dialog__header"
-  >
-    <!--F#14-->
-    <button
-      class="icon-btn panel-dialog__close"
-      type="button"
-    >
-      <svg
-        aria-hidden="true"
-        class="icon icon--16"
-        focusable="false"
-      >
-        <defs>
-          <symbol
-            id="icon-close-16"
-            viewBox="0 0 16 16"
-          >
-            <path
-              d="M2.293 2.293a1 1 0 0 1 1.414 0L8 6.586l4.293-4.293a1 1 0 1 1 1.414 1.414L9.414 8l4.293 4.293a1 1 0 0 1-1.414 1.414L8 9.414l-4.293 4.293a1 1 0 0 1-1.414-1.414L6.586 8 2.293 3.707a1 1 0 0 1 0-1.414Z"
-            />
-          </symbol>
-        </defs>
-        <use
-          href="#icon-close-16"
-        />
-      </svg>
-    </button>
-    <!--F/-->
-  </div>
-  <div
-    class="panel-dialog__main"
-  >
-    <!--F#16-->
-    <!--F/-->
-  </div>
-</div>
-`;
-
-exports[`dialog > renders with header and footer 1`] = `
-<div
-  aria-labelledby="s0-0-dialog-title"
-  aria-modal="true"
-  class="panel-dialog panel-dialog--mask-fade-slow"
-  hidden=""
-  role="dialog"
 >
   <div
     class="panel-dialog__window panel-dialog__window--slide"
@@ -358,16 +21,16 @@ exports[`dialog > renders with header and footer 1`] = `
       <!--F#13-->
       <h2
         class="panel-dialog__title"
-        id="s0-0-dialog-title"
+        id="s0-0-0-dialog-title"
       >
         <!--F#2-->
-        title content
+        Heading
         <!--F/-->
       </h2>
       <!--F/-->
       <!--F#14-->
       <button
-        aria-label="close"
+        aria-label="Close Panel"
         class="icon-btn panel-dialog__close"
         type="button"
       >
@@ -397,108 +60,356 @@ exports[`dialog > renders with header and footer 1`] = `
       class="panel-dialog__main"
     >
       <!--F#16-->
-      body content
+      <!--F#1-->
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+      </p>
+      <p>
+        <a
+          href="http://www.ebay.com"
+        >
+          www.ebay.com
+        </a>
+      </p>
       <!--F/-->
-    </div>
-    <div
-      class="panel-dialog__footer"
-    >
-      <!--F#20-->
-      footer content
       <!--F/-->
     </div>
   </div>
 </div>
 `;
 
-exports[`dialog > renders with header and footer 2`] = `
-<button
-  aria-label="close"
-  class="icon-btn panel-dialog__close"
-  type="button"
->
-  <svg
-    aria-hidden="true"
-    class="icon icon--16"
-    focusable="false"
-  >
-    <defs>
-      <symbol
-        id="icon-close-16"
-        viewBox="0 0 16 16"
-      >
-        <path
-          d="M2.293 2.293a1 1 0 0 1 1.414 0L8 6.586l4.293-4.293a1 1 0 1 1 1.414 1.414L9.414 8l4.293 4.293a1 1 0 0 1-1.414 1.414L8 9.414l-4.293 4.293a1 1 0 0 1-1.414-1.414L6.586 8 2.293 3.707a1 1 0 0 1 0-1.414Z"
-        />
-      </symbol>
-    </defs>
-    <use
-      href="#icon-close-16"
-    />
-  </svg>
-</button>
-`;
-
-exports[`dialog > renders with header and footer 3`] = `
+exports[`dialog > passes through additional html attributes 2`] = `
 <div
-  class="panel-dialog__main"
+  aria-labelledby="s0-0-0-dialog-title"
+  aria-modal="true"
+  class="panel-dialog class1 panel-dialog--mask-fade-slow"
+  data-passed-through="true"
+  data-testid="AttributePassthrough"
+  hidden=""
+  role="dialog"
+  style="color:red"
+  type="number"
 >
-  <!--F#16-->
-  body content
-  <!--F/-->
-</div>
-`;
-
-exports[`dialog > renders with header and footer 4`] = `
-<div
-  class="panel-dialog__header"
->
-  <!--F#13-->
-  <h2
-    class="panel-dialog__title"
-    id="s0-0-dialog-title"
+  <div
+    class="panel-dialog__window panel-dialog__window--slide"
   >
-    <!--F#2-->
-    title content
-    <!--F/-->
-  </h2>
-  <!--F/-->
-  <!--F#14-->
-  <button
-    aria-label="close"
-    class="icon-btn panel-dialog__close"
-    type="button"
-  >
-    <svg
-      aria-hidden="true"
-      class="icon icon--16"
-      focusable="false"
+    <div
+      class="panel-dialog__header"
     >
-      <defs>
-        <symbol
-          id="icon-close-16"
-          viewBox="0 0 16 16"
+      <!--F#13-->
+      <h2
+        class="panel-dialog__title"
+        id="s0-0-0-dialog-title"
+      >
+        <!--F#2-->
+        Heading
+        <!--F/-->
+      </h2>
+      <!--F/-->
+      <!--F#14-->
+      <button
+        aria-label="Close Panel"
+        class="icon-btn panel-dialog__close"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="icon icon--16"
+          focusable="false"
         >
-          <path
-            d="M2.293 2.293a1 1 0 0 1 1.414 0L8 6.586l4.293-4.293a1 1 0 1 1 1.414 1.414L9.414 8l4.293 4.293a1 1 0 0 1-1.414 1.414L8 9.414l-4.293 4.293a1 1 0 0 1-1.414-1.414L6.586 8 2.293 3.707a1 1 0 0 1 0-1.414Z"
+          <defs>
+            <symbol
+              id="icon-close-16"
+              viewBox="0 0 16 16"
+            >
+              <path
+                d="M2.293 2.293a1 1 0 0 1 1.414 0L8 6.586l4.293-4.293a1 1 0 1 1 1.414 1.414L9.414 8l4.293 4.293a1 1 0 0 1-1.414 1.414L8 9.414l-4.293 4.293a1 1 0 0 1-1.414-1.414L6.586 8 2.293 3.707a1 1 0 0 1 0-1.414Z"
+              />
+            </symbol>
+          </defs>
+          <use
+            href="#icon-close-16"
           />
-        </symbol>
-      </defs>
-      <use
-        href="#icon-close-16"
-      />
-    </svg>
-  </button>
-  <!--F/-->
+        </svg>
+      </button>
+      <!--F/-->
+    </div>
+    <div
+      class="panel-dialog__main"
+    >
+      <!--F#16-->
+      <!--F#1-->
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+      </p>
+      <p>
+        <a
+          href="http://www.ebay.com"
+        >
+          www.ebay.com
+        </a>
+      </p>
+      <!--F/-->
+      <!--F/-->
+    </div>
+  </div>
 </div>
 `;
 
-exports[`dialog > renders with header and footer 5`] = `
-<div
-  class="panel-dialog__footer"
->
-  <!--F#20-->
-  footer content
-  <!--F/-->
-</div>
+exports[`dialog > renders basic version 1`] = `
+"[36m<DocumentFragment>[39m
+  [36m<div[39m
+    [33maria-labelledby[39m=[32m"s0-0-0-dialog-title"[39m
+    [33maria-modal[39m=[32m"true"[39m
+    [33mclass[39m=[32m"panel-dialog panel-dialog--mask-fade-slow"[39m
+    [33mhidden[39m=[32m""[39m
+    [33mrole[39m=[32m"dialog"[39m
+  [36m>[39m
+    [36m<div[39m
+      [33mclass[39m=[32m"panel-dialog__window panel-dialog__window--slide"[39m
+    [36m>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"panel-dialog__header"[39m
+      [36m>[39m
+        [36m<h2[39m
+          [33mclass[39m=[32m"panel-dialog__title"[39m
+          [33mid[39m=[32m"s0-0-0-dialog-title"[39m
+        [36m>[39m
+          [0mHeading[0m
+        [36m</h2>[39m
+        [36m<button[39m
+          [33maria-label[39m=[32m"Close Panel"[39m
+          [33mclass[39m=[32m"icon-btn panel-dialog__close"[39m
+          [33mtype[39m=[32m"button"[39m
+        [36m>[39m
+          [36m<svg[39m
+            [33maria-hidden[39m=[32m"true"[39m
+            [33mclass[39m=[32m"icon icon--16"[39m
+            [33mfocusable[39m=[32m"false"[39m
+          [36m>[39m
+            [36m<defs>[39m
+              [36m<symbol[39m
+                [33mid[39m=[32m"icon-close-16"[39m
+                [33mviewBox[39m=[32m"0 0 16 16"[39m
+              [36m>[39m
+                [36m<path[39m
+                  [33md[39m=[32m"M2.293 2.293a1 1 0 0 1 1.414 0L8 6.586l4.293-4.293a1 1 0 1 1 1.414 1.414L9.414 8l4.293 4.293a1 1 0 0 1-1.414 1.414L8 9.414l-4.293 4.293a1 1 0 0 1-1.414-1.414L6.586 8 2.293 3.707a1 1 0 0 1 0-1.414Z"[39m
+                [36m/>[39m
+              [36m</symbol>[39m
+            [36m</defs>[39m
+            [36m<use[39m
+              [33mhref[39m=[32m"#icon-close-16"[39m
+            [36m/>[39m
+          [36m</svg>[39m
+        [36m</button>[39m
+      [36m</div>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"panel-dialog__main"[39m
+      [36m>[39m
+        [36m<p>[39m
+          [0mLorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.[0m
+        [36m</p>[39m
+        [36m<p>[39m
+          [36m<a[39m
+            [33mhref[39m=[32m"http://www.ebay.com"[39m
+          [36m>[39m
+            [0mwww.ebay.com[0m
+          [36m</a>[39m
+        [36m</p>[39m
+      [36m</div>[39m
+    [36m</div>[39m
+  [36m</div>[39m
+  [36m<button[39m
+    [33mclass[39m=[32m"btn btn--secondary"[39m
+    [33mdata-ebayui[39m=[32m""[39m
+    [33mtype[39m=[32m"button"[39m
+  [36m>[39m
+    [0mOpen Dialog[0m
+  [36m</button>[39m
+[36m</DocumentFragment>[39m"
+`;
+
+exports[`dialog > renders with footer 1`] = `
+"[36m<DocumentFragment>[39m
+  [36m<div[39m
+    [33maria-labelledby[39m=[32m"s0-0-0-dialog-title"[39m
+    [33maria-modal[39m=[32m"true"[39m
+    [33mclass[39m=[32m"panel-dialog panel-dialog--mask-fade-slow"[39m
+    [33mhidden[39m=[32m""[39m
+    [33mrole[39m=[32m"dialog"[39m
+  [36m>[39m
+    [36m<div[39m
+      [33mclass[39m=[32m"panel-dialog__window panel-dialog__window--slide"[39m
+    [36m>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"panel-dialog__header"[39m
+      [36m>[39m
+        [36m<h2[39m
+          [33mclass[39m=[32m"panel-dialog__title"[39m
+          [33mid[39m=[32m"s0-0-0-dialog-title"[39m
+        [36m>[39m
+          [0mHeading[0m
+        [36m</h2>[39m
+        [36m<button[39m
+          [33maria-label[39m=[32m"Close Dialog"[39m
+          [33mclass[39m=[32m"icon-btn panel-dialog__close"[39m
+          [33mtype[39m=[32m"button"[39m
+        [36m>[39m
+          [36m<svg[39m
+            [33maria-hidden[39m=[32m"true"[39m
+            [33mclass[39m=[32m"icon icon--16"[39m
+            [33mfocusable[39m=[32m"false"[39m
+          [36m>[39m
+            [36m<defs>[39m
+              [36m<symbol[39m
+                [33mid[39m=[32m"icon-close-16"[39m
+                [33mviewBox[39m=[32m"0 0 16 16"[39m
+              [36m>[39m
+                [36m<path[39m
+                  [33md[39m=[32m"M2.293 2.293a1 1 0 0 1 1.414 0L8 6.586l4.293-4.293a1 1 0 1 1 1.414 1.414L9.414 8l4.293 4.293a1 1 0 0 1-1.414 1.414L8 9.414l-4.293 4.293a1 1 0 0 1-1.414-1.414L6.586 8 2.293 3.707a1 1 0 0 1 0-1.414Z"[39m
+                [36m/>[39m
+              [36m</symbol>[39m
+            [36m</defs>[39m
+            [36m<use[39m
+              [33mhref[39m=[32m"#icon-close-16"[39m
+            [36m/>[39m
+          [36m</svg>[39m
+        [36m</button>[39m
+      [36m</div>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"panel-dialog__main"[39m
+      [36m>[39m
+        [36m<p>[39m
+          [0mLorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.[0m
+        [36m</p>[39m
+        [36m<p>[39m
+          [36m<a[39m
+            [33mhref[39m=[32m"http://www.ebay.com"[39m
+          [36m>[39m
+            [0mwww.ebay.com[0m
+          [36m</a>[39m
+        [36m</p>[39m
+      [36m</div>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"panel-dialog__footer"[39m
+      [36m>[39m
+        [36m<button[39m
+          [33mclass[39m=[32m"btn"[39m
+        [36m>[39m
+          [0mButton 1[0m
+        [36m</button>[39m
+        [36m<button[39m
+          [33mclass[39m=[32m"btn"[39m
+        [36m>[39m
+          [0mButton 2[0m
+        [36m</button>[39m
+      [36m</div>[39m
+    [36m</div>[39m
+  [36m</div>[39m
+  [36m<button[39m
+    [33mclass[39m=[32m"btn btn--secondary"[39m
+    [33mdata-ebayui[39m=[32m""[39m
+    [33mtype[39m=[32m"button"[39m
+  [36m>[39m
+    [0mOpen Dialog[0m
+  [36m</button>[39m
+[36m</DocumentFragment>[39m"
+`;
+
+exports[`dialog > renders with previous button 1`] = `
+"[36m<DocumentFragment>[39m
+  [36m<div[39m
+    [33maria-labelledby[39m=[32m"s0-0-0-dialog-title"[39m
+    [33maria-modal[39m=[32m"true"[39m
+    [33mclass[39m=[32m"panel-dialog panel-dialog--mask-fade-slow"[39m
+    [33mhidden[39m=[32m""[39m
+    [33mrole[39m=[32m"dialog"[39m
+  [36m>[39m
+    [36m<div[39m
+      [33mclass[39m=[32m"panel-dialog__window panel-dialog__window--slide"[39m
+    [36m>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"panel-dialog__header"[39m
+      [36m>[39m
+        [36m<button[39m
+          [33maria-label[39m=[32m"Go back"[39m
+          [33mclass[39m=[32m"icon-btn panel-dialog__prev"[39m
+          [33mtype[39m=[32m"button"[39m
+        [36m>[39m
+          [36m<svg[39m
+            [33maria-hidden[39m=[32m"true"[39m
+            [33mclass[39m=[32m"icon icon--16"[39m
+            [33mfocusable[39m=[32m"false"[39m
+          [36m>[39m
+            [36m<defs>[39m
+              [36m<symbol[39m
+                [33mid[39m=[32m"icon-chevron-left-16"[39m
+                [33mviewBox[39m=[32m"0 0 16 16"[39m
+              [36m>[39m
+                [36m<path[39m
+                  [33md[39m=[32m"M3.293 8.708a1 1 0 0 1 0-1.415l6-6a1 1 0 0 1 1.414 1.414L5.414 8l5.293 5.293a1 1 0 0 1-1.414 1.414l-6-6Z"[39m
+                [36m/>[39m
+              [36m</symbol>[39m
+            [36m</defs>[39m
+            [36m<use[39m
+              [33mhref[39m=[32m"#icon-chevron-left-16"[39m
+            [36m/>[39m
+          [36m</svg>[39m
+        [36m</button>[39m
+        [36m<h2[39m
+          [33mclass[39m=[32m"panel-dialog__title"[39m
+          [33mid[39m=[32m"s0-0-0-dialog-title"[39m
+        [36m>[39m
+          [0mHeading[0m
+        [36m</h2>[39m
+        [36m<button[39m
+          [33maria-label[39m=[32m"Close Dialog"[39m
+          [33mclass[39m=[32m"icon-btn panel-dialog__close"[39m
+          [33mtype[39m=[32m"button"[39m
+        [36m>[39m
+          [36m<svg[39m
+            [33maria-hidden[39m=[32m"true"[39m
+            [33mclass[39m=[32m"icon icon--16"[39m
+            [33mfocusable[39m=[32m"false"[39m
+          [36m>[39m
+            [36m<defs>[39m
+              [36m<symbol[39m
+                [33mid[39m=[32m"icon-close-16"[39m
+                [33mviewBox[39m=[32m"0 0 16 16"[39m
+              [36m>[39m
+                [36m<path[39m
+                  [33md[39m=[32m"M2.293 2.293a1 1 0 0 1 1.414 0L8 6.586l4.293-4.293a1 1 0 1 1 1.414 1.414L9.414 8l4.293 4.293a1 1 0 0 1-1.414 1.414L8 9.414l-4.293 4.293a1 1 0 0 1-1.414-1.414L6.586 8 2.293 3.707a1 1 0 0 1 0-1.414Z"[39m
+                [36m/>[39m
+              [36m</symbol>[39m
+            [36m</defs>[39m
+            [36m<use[39m
+              [33mhref[39m=[32m"#icon-close-16"[39m
+            [36m/>[39m
+          [36m</svg>[39m
+        [36m</button>[39m
+      [36m</div>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"panel-dialog__main"[39m
+      [36m>[39m
+        [36m<p>[39m
+          [0mLorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.[0m
+        [36m</p>[39m
+        [36m<p>[39m
+          [36m<a[39m
+            [33mhref[39m=[32m"http://www.ebay.com"[39m
+          [36m>[39m
+            [0mwww.ebay.com[0m
+          [36m</a>[39m
+        [36m</p>[39m
+      [36m</div>[39m
+    [36m</div>[39m
+  [36m</div>[39m
+  [36m<button[39m
+    [33mclass[39m=[32m"btn btn--secondary"[39m
+    [33mdata-ebayui[39m=[32m""[39m
+    [33mtype[39m=[32m"button"[39m
+  [36m>[39m
+    [0mOpen Dialog[0m
+  [36m</button>[39m
+[36m</DocumentFragment>[39m"
 `;

--- a/packages/ebayui-core/src/components/ebay-panel-dialog/test/test.server.js
+++ b/packages/ebayui-core/src/components/ebay-panel-dialog/test/test.server.js
@@ -1,58 +1,24 @@
-import { describe, it, expect } from "vitest";
+import { describe, it } from "vitest";
 
-import { render } from "@marko/testing-library";
+import { composeStories } from "@storybook/marko";
+import { snapshotHTML } from "../../../common/test-utils/snapshots";
 import { testPassThroughAttributes } from "../../../common/test-utils/server";
-import template from "../index.marko";
-import * as mock from "./mock";
+import * as stories from "../panel-dialog.stories"; // import all stories from the stories file
+const { Default, WithPrevButton, WithFooter } = composeStories(stories);
+const htmlSnap = snapshotHTML(__dirname);
 
 describe("dialog", () => {
     it("renders basic version", async () => {
-        const input = mock.Dialog;
-        const { getByRole, getByLabelText, getByText } = await render(
-            template,
-            input,
-        );
-        const dialog = getByRole("dialog", { hidden: true });
-
-        expect(dialog).toMatchSnapshot();
-        expect(getByLabelText(input.a11yCloseText)).toMatchSnapshot();
-        expect(getByText(input.renderBody.text)).toMatchSnapshot();
+        await htmlSnap(Default);
     });
 
-    it("renders with header and footer", async () => {
-        const input = mock.headerFooterDialog;
-        const { getByRole, getByLabelText, getByText } = await render(
-            template,
-            input,
-        );
-        const dialog = getByRole("dialog", { hidden: true });
-
-        expect(dialog).toMatchSnapshot();
-        expect(getByLabelText(input.a11yCloseText)).toMatchSnapshot();
-        expect(getByText(input.renderBody.text)).toMatchSnapshot();
-        expect(
-            getByText(input.header.renderBody.text).parentElement,
-        ).toMatchSnapshot();
-        expect(getByText(input.footer.renderBody.text)).toMatchSnapshot();
+    it("renders with previous button", async () => {
+        await htmlSnap(WithPrevButton);
     });
 
-    it("renders in open state", async () => {
-        const input = mock.dialogOpen;
-        const { getByRole } = await render(template, input);
-        expect(getByRole("dialog")).toMatchSnapshot();
+    it("renders with footer", async () => {
+        await htmlSnap(WithFooter);
     });
 
-    it(`renders with end type`, async () => {
-        const { getByRole } = await render(template, {
-            position: "end",
-            open: true,
-        });
-        const $dialog = getByRole("dialog");
-        const $window = $dialog.children[0];
-
-        expect($dialog).toMatchSnapshot();
-        expect($window).toMatchSnapshot();
-    });
-
-    testPassThroughAttributes(template);
+    testPassThroughAttributes(Default);
 });

--- a/packages/skin/dist/panel-dialog/panel-dialog.css
+++ b/packages/skin/dist/panel-dialog/panel-dialog.css
@@ -94,7 +94,8 @@
 .panel-dialog__footer > :not(:first-child) {
     margin-top: var(--spacing-200);
 }
-button.icon-btn.panel-dialog__close {
+button.icon-btn.panel-dialog__close,
+button.icon-btn.panel-dialog__prev {
     align-self: flex-start;
     border: 0;
     height: 32px;
@@ -103,6 +104,10 @@ button.icon-btn.panel-dialog__close {
     position: relative;
     width: 32px;
     z-index: 1;
+}
+
+button.icon-btn.panel-dialog__prev {
+    margin-inline-end: var(--spacing-200);
 }
 
 .panel-dialog__title:not(:first-child) {
@@ -169,6 +174,10 @@ button.icon-btn.panel-dialog__close {
 .panel-dialog--hide-init .panel-dialog__window--slide,
 .panel-dialog--show .panel-dialog__window--slide {
     transform: translateX(0);
+}
+
+[dir="rtl"] button.icon-btn.panel-dialog__prev .icon {
+    transform: rotate(180deg);
 }
 @media (min-width: 512px) {
     .panel-dialog__window {

--- a/packages/skin/src/routes/_index/component/panel-dialog/+page.marko
+++ b/packages/skin/src/routes/_index/component/panel-dialog/+page.marko
@@ -142,7 +142,7 @@
                         >
                             <svg
                                 aria-hidden="true"
-                                class="icon icon--chevron-left-16"
+                                class="icon icon--16"
                                 height="16"
                                 width="16"
                             >
@@ -202,7 +202,7 @@
                     >
                         <svg
                             aria-hidden="true"
-                            class="icon icon--chevron-left-16"
+                            class="icon icon--16"
                             height="16"
                             width="16"
                         >

--- a/packages/skin/src/routes/_index/component/panel-dialog/+page.marko
+++ b/packages/skin/src/routes/_index/component/panel-dialog/+page.marko
@@ -109,6 +109,138 @@
         </div>
     </highlight-code>
 
+    <h3 id="panel-dialog-prev">
+        Panel dialog with Previous button
+    </h3>
+    <p>
+        If you want to add a previous button to the panel dialog, add the icon button before the dialog heading tag.
+    </p>
+
+    <div class="demo">
+        <div class="demo__inner">
+            <button
+                class="btn btn--primary dialog-button"
+                data-makeup-for="dialog-left-panel-prev"
+                type="button"
+            >
+                Open Panel
+            </button>
+            <div
+                aria-labelledby="panel-dialog-prev-title"
+                aria-modal="true"
+                class="panel-dialog"
+                hidden
+                id="dialog-left-panel-prev"
+                role="dialog"
+            >
+                <div class="panel-dialog__window">
+                    <div class="panel-dialog__header">
+                        <button
+                            aria-label="Go back"
+                            class="icon-btn panel-dialog__prev"
+                            type="button"
+                        >
+                            <svg
+                                aria-hidden="true"
+                                class="icon icon--chevron-left-16"
+                                height="16"
+                                width="16"
+                            >
+                                <icon-symbol name="chevron-left-16"/>
+                            </svg>
+                        </button>
+                        <h2
+                            id="panel-dialog-prev-title"
+                            class="large-text-1 bold-text"
+                        >
+                            Heading
+                        </h2>
+                        <button
+                            aria-label="Close dialog"
+                            class="icon-btn panel-dialog__close"
+                            type="button"
+                        >
+                            <svg
+                                aria-hidden="true"
+                                class="icon icon--16"
+                                height="16"
+                                width="16"
+                            >
+                                <icon-symbol name="close-16"/>
+                            </svg>
+                        </button>
+                    </div>
+                    <div class="panel-dialog__main">
+                        <p>
+                            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+                        </p>
+                        <p>
+                            <a href="https://www.ebay.com">
+                                www.ebay.com
+                            </a>
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <highlight-code type="html">
+        <div
+            aria-labelledby="dialog-title"
+            aria-modal="true"
+            class="panel-dialog"
+            hidden
+            role="dialog"
+        >
+            <div class="panel-dialog__window">
+                <div class="panel-dialog__header">
+                    <button
+                        aria-label="Go back"
+                        class="icon-btn panel-dialog__prev"
+                        type="button"
+                    >
+                        <svg
+                            aria-hidden="true"
+                            class="icon icon--chevron-left-16"
+                            height="16"
+                            width="16"
+                        >
+                            <icon-symbol name="chevron-left-16"/>
+                        </svg>
+                    </button>
+                    <h2 id="dialog-title" class="large-text-1 bold-text">
+                        Heading
+                    </h2>
+                    <button
+                        aria-label="Close dialog"
+                        class="icon-btn panel-dialog__close"
+                        type="button"
+                    >
+                        <svg
+                            aria-hidden="true"
+                            class="icon icon--16"
+                            height="16"
+                            width="16"
+                        >
+                            <use href="#icon-close-16"/>
+                        </svg>
+                    </button>
+                </div>
+                <div class="panel-dialog__main">
+                    <p>
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+                    </p>
+                    <p>
+                        <a href="https://www.ebay.com">
+                            www.ebay.com
+                        </a>
+                    </p>
+                </div>
+            </div>
+        </div>
+    </highlight-code>
+
     <h3 id="panel-dialog-footer">
         Panel dialog with footer
     </h3>

--- a/packages/skin/src/sass/panel-dialog/panel-dialog.scss
+++ b/packages/skin/src/sass/panel-dialog/panel-dialog.scss
@@ -49,6 +49,7 @@
 
 /* inherits from .icon-btn */
 /* Might need to see to add a small icon btn */
+button.icon-btn.panel-dialog__prev,
 button.icon-btn.panel-dialog__close {
     align-self: flex-start;
     border: 0;
@@ -58,6 +59,10 @@ button.icon-btn.panel-dialog__close {
     position: relative;
     width: 32px;
     z-index: 1;
+}
+
+button.icon-btn.panel-dialog__prev {
+    margin-inline-end: var(--spacing-200);
 }
 
 .panel-dialog__title {
@@ -127,6 +132,12 @@ button.icon-btn.panel-dialog__close {
 
     .panel-dialog__window--slide {
         transform: translateX(0);
+    }
+}
+
+[dir="rtl"] {
+    button.icon-btn.panel-dialog__prev .icon {
+        transform: rotate(180deg);
     }
 }
 

--- a/packages/skin/src/sass/panel-dialog/stories/panel-dialog.stories.js
+++ b/packages/skin/src/sass/panel-dialog/stories/panel-dialog.stories.js
@@ -270,3 +270,31 @@ export const panelStartWithHeaderOverflow = () => `
     </div>
 </div>
 `;
+
+export const panelWithPrev = () => `
+<div aria-labelledby="panel-title" aria-modal="true" class="panel-dialog" role="dialog">
+    <div class="panel-dialog__window">
+        <div class="panel-dialog__header">
+            <button class="icon-btn panel-dialog__prev" type="button" aria-label="Go back">
+                <svg class="icon icon--16" aria-hidden="true">
+                    <use href="#icon-chevron-left-16"></use>
+                </svg>
+            </button>
+            <h2 id="panel-title">Left Panel</h2>
+            <button class="icon-btn panel-dialog__close" type="button" aria-label="Close Dialog">
+                <svg class="icon icon--16" aria-hidden="true">
+                    <use href="#icon-close-16"></use>
+                </svg>
+            </button>
+        </div>
+        <div class="panel-dialog__main">
+            <h3>Heading</h3>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <h3>Heading</h3>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+        </div>
+    </div>
+</div>
+`;


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #165 

<!-- Select which type of PR this is -->
- [x] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
<!-- Briefly describe the proposed changes -->
- Updated panel dialog styles with prev button styles
- Added a new @prev-button attribute tag to the `ebay-panel-dialog` component, allowing users to include a navigation button for going back to previous screens 
- Updated panel dialog stories, examples and snapshots.

## Notes
- I had trouble performing percy snapshot test. Ran into few issues.

## Screenshots
<!-- Upload screenshots of UI before & after these changes -->
<img width="418" alt="image" src="https://github.com/user-attachments/assets/e1a6c12c-2f44-4e4a-bd6a-a1a1bc65ee27" />

## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [x] I verify the build is in a non-broken state
- [x] I verify all changes are within scope of the linked issue

<!-- For Markup Changes -->
- [x] I verify the markup will not be a breaking change (if not a major release)
- [x] I verify the MIND pattern for the component has been created/revised

<!-- For CSS changes -->
- [x] I regenerated all CSS files under dist folder
- [x] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [x] I tested the UI in dark mode and RTL mode
- [x] I added/updated/removed Storybook coverage as appropriate
