### PR TITLE
Adding value into pagination item

### DIFF
--- a/.changeset/loud-dogs-dig.md
+++ b/.changeset/loud-dogs-dig.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ui-core-react": minor
+---
+
+fix(pagination): allowing to use value in onSelect event

--- a/packages/ebayui-core-react/src/ebay-pagination/README.md
+++ b/packages/ebayui-core-react/src/ebay-pagination/README.md
@@ -53,11 +53,11 @@ import "@ebay/skin/utility.css";
 
 ### EbayPagination Events
 
-| Event        | Data                        | Description                   |
-| ------------ | --------------------------- | ----------------------------- |
-| `onPrevious` | `(Event)`                   | clicked previous arrow button |
-| `onNext`     | `(Event)`                   | clicked next arrow button     |
-| `onSelect`   | `(Event, { value, index })` | page selected clicked         |
+| Event        | Data                        | Description                                                                                |
+| ------------ | --------------------------- | ------------------------------------------------------------------------------------------ |
+| `onPrevious` | `(Event)`                   | clicked previous arrow button                                                              |
+| `onNext`     | `(Event)`                   | clicked next arrow button                                                                  |
+| `onSelect`   | `(Event, { value, index })` | page selected clicked (`value` should be used as `index` is the position in the page list) |
 
 ## EbayPaginationItem Tag
 
@@ -69,12 +69,13 @@ import "@ebay/skin/utility.css";
 
 ### EbayPaginationItem Attributes
 
-| Name       | Type    | Stateful | Description                                                                                                                                             |
-| ---------- | ------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
-| `disabled` | Boolean | No       | Previous/next button is disabled or not                                                                                                                 |
-| `href`     | String  | No       | for link that looks like a menu-item; omitting the href will switch to a button                                                                         |
-| `current`  | Boolean | No       | the current page                                                                                                                                        |
-| `type`     | String  | No       | "previous", "next" or "page"(default). To specify if the information entered is for the previous or next arrow button or a page. If the `type='previous | next'`isn't provided the previous/next arrow buttons will be taken as`disabled` |
+| Name       | Type    | Stateful | Description                                                                                                                                                                                                                                  |
+| ---------- | ------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `disabled` | Boolean | No       | Previous/next button is disabled or not                                                                                                                                                                                                      |
+| `href`     | String  | No       | for link that looks like a menu-item; omitting the href will switch to a button                                                                                                                                                              |
+| `current`  | Boolean | No       | the current page                                                                                                                                                                                                                             |
+| `type`     | String  | No       | "previous", "next" or "page"(default). To specify if the information entered is for the previous or next arrow button or a page. If the `type='previous \| next'` isn't provided the previous/next arrow buttons will be taken as `disabled` |
+| `value`    | Number  | No       | the page identification                                                                                                                                                                                                                      |
 
 Notes:
 

--- a/packages/ebayui-core-react/src/ebay-pagination/__tests__/index.spec.tsx
+++ b/packages/ebayui-core-react/src/ebay-pagination/__tests__/index.spec.tsx
@@ -57,7 +57,9 @@ describe("<EbayPagination>", () => {
                     </Item>
                     <Item href="#">4</Item>
                     <Item href="#">5</Item>
-                    <Item href="#">6</Item>
+                    <Item href="#" value={6}>
+                        6
+                    </Item>
                     <Item type="next" href="#" />
                 </EbayPagination>,
             );
@@ -83,6 +85,14 @@ describe("<EbayPagination>", () => {
             fireEvent.click(wrapper.getAllByRole("link")[1]);
 
             expect(spyOnSelect).toHaveBeenCalledWith(eventOfType("click"), { value: "", index: 2 });
+            expect(spyOnPrev).not.toHaveBeenCalled();
+            expect(spyOnNext).not.toHaveBeenCalled();
+        });
+
+        it("should trigger onSelect() with value from page", () => {
+            fireEvent.click(wrapper.getByText("6"));
+
+            expect(spyOnSelect).toHaveBeenCalledWith(eventOfType("click"), { value: 6, index: 5 });
             expect(spyOnPrev).not.toHaveBeenCalled();
             expect(spyOnNext).not.toHaveBeenCalled();
         });

--- a/packages/ebayui-core-react/src/ebay-pagination/pagination-item.tsx
+++ b/packages/ebayui-core-react/src/ebay-pagination/pagination-item.tsx
@@ -43,10 +43,11 @@ const EbayPaginationItem: FC<PaginationItemProps> = ({
     className,
     style,
     forwardedRef,
+    value,
     ...rest
 }) => {
     const handlePageNumber = (e) => {
-        onSelect(e, { value: e.currentTarget?.innerText || "", index: pageIndex });
+        onSelect(e, { value: value || e.currentTarget?.innerText || "", index: pageIndex });
     };
 
     const handleNextPage = (e) => {


### PR DESCRIPTION
<!-- Select which type of PR this is -->
- [ ] This PR contains CSS changes
- [X] This PR does not contain CSS changes

## Description
This change allows you to set the `value` of each EbayPaginationItem, then the `onSelect` even will have the proper identification of the page, this will allow have a different value than the representation of the page number (isn't a problem right now because we don't have the website on countries that numeral representation is different than latin)

Also this is fixing the README about `value` vs `index` and including the newish property documentation.
