### PR TITLE
fix(progress-bar-expressive): update colors to use logo colors for both light and dark mode

### DIFF
--- a/packages/skin/dist/progress-bar-expressive/progress-bar-expressive.css
+++ b/packages/skin/dist/progress-bar-expressive/progress-bar-expressive.css
@@ -1,8 +1,8 @@
 :root {
-    --progress-bar-expressive-color-1: #e53238;
-    --progress-bar-expressive-color-2: #0064d2;
-    --progress-bar-expressive-color-3: #f5af02;
-    --progress-bar-expressive-color-4: #86b817;
+    --progress-bar-expressive-color-1: var(--color-red-500);
+    --progress-bar-expressive-color-2: var(--color-blue-500);
+    --progress-bar-expressive-color-3: var(--color-yellow-400);
+    --progress-bar-expressive-color-4: var(--color-green-500);
     --progress-bar-expressive-line-border-radius: 2px;
     --progress-bar-expressive-line-count: 12;
     --progress-bar-expressive-line-gap: var(--spacing-50);
@@ -23,14 +23,6 @@
     --progress-bar-expressive-line-width-c4: 12%;
     --progress-bar-expressive-message-animatein-duration: 833ms;
     --progress-bar-expressive-message-animateout-duration: 400ms;
-}
-@media (prefers-color-scheme: dark) {
-    :root {
-        --progress-bar-expressive-color-1: #f0343b;
-        --progress-bar-expressive-color-2: #0078fc;
-        --progress-bar-expressive-color-3: #e8a502;
-        --progress-bar-expressive-color-4: #86b817;
-    }
 }
 
 .progress-bar-expressive {

--- a/packages/skin/src/sass/progress-bar-expressive/progress-bar-expressive.scss
+++ b/packages/skin/src/sass/progress-bar-expressive/progress-bar-expressive.scss
@@ -1,10 +1,11 @@
 @import "../variables/variables";
 
 :root {
-    --progress-bar-expressive-color-1: #e53238;
-    --progress-bar-expressive-color-2: #0064d2;
-    --progress-bar-expressive-color-3: #f5af02;
-    --progress-bar-expressive-color-4: #86b817;
+    /* Default to logo colors (no variation in dark mode). */
+    --progress-bar-expressive-color-1: var(--color-red-500);
+    --progress-bar-expressive-color-2: var(--color-blue-500);
+    --progress-bar-expressive-color-3: var(--color-yellow-400);
+    --progress-bar-expressive-color-4: var(--color-green-500);
     --progress-bar-expressive-line-border-radius: 2px;
     --progress-bar-expressive-line-count: 12;
     --progress-bar-expressive-line-gap: var(--spacing-50);
@@ -29,13 +30,6 @@
     --progress-bar-expressive-line-width-c4: 12%;
     --progress-bar-expressive-message-animatein-duration: 833ms;
     --progress-bar-expressive-message-animateout-duration: 400ms;
-
-    @media (prefers-color-scheme: dark) {
-        --progress-bar-expressive-color-1: #f0343b;
-        --progress-bar-expressive-color-2: #0078fc;
-        --progress-bar-expressive-color-3: #e8a502;
-        --progress-bar-expressive-color-4: #86b817;
-    }
 }
 
 .progress-bar-expressive {


### PR DESCRIPTION
<!-- Select which type of PR this is -->
- [x] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
Ensuring the colors used for the expressive progress bar match logo colors (red 500, blue 500, yellow 400 and green 500), per:  https://playbook.ebay.com/foundations/color#overview. Also making sure that they do not vary in light/dark mode (confirmed with the design team).

## Note

Had a very difficult time getting everything installed and couldn't get the preview site running. However, I _could_ at least run the build process after pinning to an older version of `yargs@17.7.2` due to issues with commonjs vs. esm imports that I didn't have time to diverge into, sorry.

## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [x] I verify the build is in a non-broken state
- [?] I verify all changes are within scope of the linked issue

<!-- For Markup Changes -->
- [ ] I verify the markup will not be a breaking change (if not a major release)
- [ ] I verify the MIND pattern for the component has been created/revised

<!-- For CSS changes -->
- [x] I regenerated all CSS files under dist folder
- [ ] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [ ] I tested the UI in dark mode and RTL mode
- [ ] I added/updated/removed Storybook coverage as appropriate
