### PR TITLE
docs(skin): update github repo links

### DIFF
--- a/packages/skin/CONTRIBUTING.md
+++ b/packages/skin/CONTRIBUTING.md
@@ -50,7 +50,7 @@ This page contains instructions and guidelines for anybody contributing code to 
 
 ## Contribution Steps
 
-Before writing any code, please submit a new issue to [GitHub](https://github.com/eBay/skin/issues). Or, if you want to work on an _existing_ issue, please request to do so on the relevant ticket.
+Before writing any code, please submit a new issue to [GitHub](https://github.com/eBay/evo-web/issues). Or, if you want to work on an _existing_ issue, please request to do so on the relevant ticket.
 
 We **strongly** advise you to only begin working on issues that are assigned specifically to you and that are part of the upcoming milestone, otherwise your work may end up being in vain.
 

--- a/packages/skin/src/components/site-footer.marko
+++ b/packages/skin/src/components/site-footer.marko
@@ -16,7 +16,7 @@ style {
                 </a>
             </li>
             <li>
-                <a role="menuitem" href="https://github.com/eBay/skin">
+                <a role="menuitem" href="https://github.com/eBay/evo-web/tree/main/packages/skin">
                     Repo
                 </a>
             </li>

--- a/packages/skin/src/components/site-header.marko
+++ b/packages/skin/src/components/site-header.marko
@@ -241,7 +241,7 @@ import { components } from "./components.marko";
                             <li>
                                 <a
                                     role="menuitem"
-                                    href="https://github.com/eBay/skin"
+                                    href="https://github.com/eBay/evo-web/tree/main/packages/skin"
                                 >
                                     Repo
                                 </a>

--- a/packages/skin/src/routes/_index/component/flag/+page.marko
+++ b/packages/skin/src/routes/_index/component/flag/+page.marko
@@ -31,11 +31,11 @@ import flags from "../../../../components/data/flags.json";
     <h3>Including an Flag</h3>
     <p>
         A flag can be referenced from the
-        <a href="https://raw.githubusercontent.com/eBay/skin/master/src/svg/flags.svg">
+        <a href="https://raw.githubusercontent.com/eBay/evo-web/main/packages/skin/src/svg/flags.svg">
             flags svg
         </a>
          file. We also provide individual flags as SVGs located in this
-        <a href="https://github.com/eBay/skin/tree/master/src/svg/flag">
+        <a href="https://github.com/eBay/evo-web/tree/main/packages/skin/src/svg/flag">
             directory
         </a>
         . You can include these on your page as raw SVGs as needed.

--- a/packages/skin/src/routes/_index/component/icon/+page.marko
+++ b/packages/skin/src/routes/_index/component/icon/+page.marko
@@ -69,7 +69,7 @@ import iconJSON from "../../../../components/data/icons.json";
     </p>
     <p>
         We also provide individual icons as SVGs located in this
-        <a href="https://github.com/eBay/skin/tree/master/src/svg/icon">
+        <a href="https://github.com/eBay/evo-web/tree/main/packages/skin/src/svg/icon">
             directory
         </a>
         . You can include these on your page as raw SVGs as needed.

--- a/packages/skin/src/routes/_index/component/svg/+page.marko
+++ b/packages/skin/src/routes/_index/component/svg/+page.marko
@@ -7,7 +7,7 @@
     </h2>
     <p>
         The SVG module imports an
-        <a href="https://github.com/eBay/skin/tree/master/src/svg">
+        <a href="https://github.com/eBay/evo-web/tree/main/packages/skin/src/svg">
             external SVG source
         </a>
          containing all symbol definitions.

--- a/packages/skin/src/routes/_index/sitemap+page.marko
+++ b/packages/skin/src/routes/_index/sitemap+page.marko
@@ -45,7 +45,7 @@ style {
                 </a>
             </li>
             <li>
-                <a role="menuitem" href="https://github.com/eBay/skin">
+                <a role="menuitem" href="https://github.com/eBay/evo-web/tree/main/packages/skin">
                     Repo
                 </a>
             </li>

--- a/packages/skin/src/sass/bundles/skin-default.scss
+++ b/packages/skin/src/sass/bundles/skin-default.scss
@@ -1,8 +1,8 @@
 /*!
-Skin
-Copyright 2017 eBay! Inc. All rights reserved.
-Licensed under the BSD License.
-https://github.com/eBay/skin/blob/master/LICENSE.txt
+evo-web/skin
+Copyright 2018 eBay! Inc. All rights reserved.
+Licensed under the MIT License.
+https://github.com/eBay/evo-web/blob/master/LICENSE
 "*/
 @import "../../tokens/evo-core";
 @import "../../tokens/evo-light";

--- a/packages/skin/src/sass/bundles/skin-full.scss
+++ b/packages/skin/src/sass/bundles/skin-full.scss
@@ -1,8 +1,8 @@
 /*!
-Skin
-Copyright 2017 eBay! Inc. All rights reserved.
-Licensed under the BSD License.
-https://github.com/eBay/skin/blob/master/LICENSE.txt
+evo-web/skin
+Copyright 2018 eBay! Inc. All rights reserved.
+Licensed under the MIT License.
+https://github.com/eBay/evo-web/blob/master/LICENSE
 */
 @import "../../tokens/evo-core";
 @import "../../tokens/evo-light";


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #197 

<!-- Select which type of PR this is -->
- [ ] This PR contains CSS changes
- [x] This PR does not contain CSS changes

## Description
<!-- Briefly describe the proposed changes -->
- The changes include GitHub repository references throughout the Skin package documentation and source files to reflect the migration from the standalone eBay/skin repository to the monorepo at eBay/evo-web.
-  Updated SVG asset references to point to the new monorepo.

## Notes
<!-- Be sure to mention anything unusual, out-of-scope or new technical debt, etc -->
- Also updated the LICENSE text for skin. Not sure if this what I updated is the right way.

## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [x] I verify the build is in a non-broken state
- [x] I verify all changes are within scope of the linked issue

