### PR TITLE
fix(lightbox-dialog): wide variant has incorrect max-width

### DIFF
--- a/.changeset/sad-stars-hope.md
+++ b/.changeset/sad-stars-hope.md
@@ -1,5 +1,5 @@
 ---
-"@ebay/skin": minor
+"@ebay/skin": patch
 ---
 
 fix(lightbox-dialog): wide variant has incorrect max-width

--- a/packages/skin/dist/lightbox-dialog/lightbox-dialog.css
+++ b/packages/skin/dist/lightbox-dialog/lightbox-dialog.css
@@ -306,7 +306,7 @@ button.icon-btn.lightbox-dialog__prev {
     .lightbox-dialog__window {
         border-radius: var(--lightbox-border-radius, var(--border-radius-100));
         margin: auto;
-        max-width: calc(88% - var(--spacing-400));
+        max-width: 88%;
     }
     .lightbox-dialog--narrow .lightbox-dialog__window {
         max-width: var(--dialog-lightbox-narrow-max-width);
@@ -341,10 +341,7 @@ button.icon-btn.lightbox-dialog__prev {
         max-width: var(--dialog-lightbox-max-width);
     }
     .lightbox-dialog--wide .lightbox-dialog__window {
-        max-width: min(
-            var(--dialog-lightbox-wide-max-width),
-            88% - var(--spacing-400)
-        );
+        max-width: 88%;
     }
     .lightbox-dialog--wide .lightbox-dialog__image {
         height: 256px;
@@ -353,5 +350,10 @@ button.icon-btn.lightbox-dialog__prev {
         .lightbox-dialog__header
         > * {
         margin-top: 256px;
+    }
+}
+@media (min-width: 1024px) {
+    .lightbox-dialog--wide .lightbox-dialog__window {
+        max-width: var(--dialog-lightbox-wide-max-width);
     }
 }

--- a/packages/skin/src/sass/lightbox-dialog/lightbox-dialog.scss
+++ b/packages/skin/src/sass/lightbox-dialog/lightbox-dialog.scss
@@ -159,7 +159,7 @@ button.icon-btn.lightbox-dialog__prev {
     .lightbox-dialog__window {
         @include lightbox-dialog-window-large();
 
-        max-width: calc(88% - var(--spacing-400));
+        max-width: 88%;
     }
 
     .lightbox-dialog--narrow .lightbox-dialog__window {
@@ -179,10 +179,7 @@ button.icon-btn.lightbox-dialog__prev {
     }
 
     .lightbox-dialog--wide .lightbox-dialog__window {
-        max-width: min(
-            var(--dialog-lightbox-wide-max-width),
-            calc(88% - var(--spacing-400))
-        );
+        max-width: 88%;
     }
 
     .lightbox-dialog--wide .lightbox-dialog__image {
@@ -193,5 +190,11 @@ button.icon-btn.lightbox-dialog__prev {
         .lightbox-dialog__header
         > * {
         margin-top: 256px;
+    }
+}
+
+@media (min-width: $_screen-size-LG) {
+    .lightbox-dialog--wide .lightbox-dialog__window {
+        max-width: var(--dialog-lightbox-wide-max-width);
     }
 }

--- a/packages/skin/src/sass/mixins/private/_dialog-mixins.scss
+++ b/packages/skin/src/sass/mixins/private/_dialog-mixins.scss
@@ -55,6 +55,7 @@
 }
 
 // This should become the new ligtbox-dialog-window mixin
+// TODO refactor code to not to use calc and use spacing tokens instead
 @mixin lightbox-dialog-window-centered() {
     @include dialog-window();
     @include border-radius-token(lightbox-border-radius, border-radius-100);


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #201

<!-- Select which type of PR this is -->
- [x] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
<!-- Briefly describe the proposed changes -->
- Fixed an issue in wide variant of `lightbox-dialog` where it is extending beyond viewport width on smaller screens
- Added responsive width constraint using min() function to prevent overflow that respects both maximum width (896px) and viewport constraints

## Notes
<!-- Be sure to mention anything unusual, out-of-scope or new technical debt, etc -->

## Screenshots
<!-- Upload screenshots of UI before & after these changes -->
**Before**
<img width="866" alt="image" src="https://github.com/user-attachments/assets/f068ea4f-4b46-48e5-91e0-4d456954c1bc" />

**After**
<img width="866" alt="image" src="https://github.com/user-attachments/assets/20518376-17ec-4ecb-89e3-2ea2416eec89" />


## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [x] I verify the build is in a non-broken state
- [x] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [x] I regenerated all CSS files under dist folder
- [x] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [x] I tested the UI in dark mode and RTL mode
- [ ] I added/updated/removed Storybook coverage as appropriate
