### PR TITLE
fix(react:date-textbox): derive selected dates instead of updating as state

### DIFF
--- a/.changeset/itchy-lands-listen.md
+++ b/.changeset/itchy-lands-listen.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ui-core-react": patch
+---
+
+fix(react:date-textbox): derive selected dates instead of updating as states

--- a/packages/ebayui-core-react/src/ebay-date-textbox/__tests__/index.spec.tsx
+++ b/packages/ebayui-core-react/src/ebay-date-textbox/__tests__/index.spec.tsx
@@ -1,3 +1,4 @@
+/// <reference types="@testing-library/jest-dom" />
 import React from "react";
 
 import { fireEvent, render, screen } from "@testing-library/react";
@@ -140,5 +141,23 @@ describe("<EbayDateTextbox />", () => {
         expect(() => {
             render(<EbayDateTextbox value="invalid" />);
         }).not.toThrow();
+    });
+
+    it("should select the calendar correctly when the value is changed externally", () => {
+        const { container, rerender } = render(<EbayDateTextbox value="2024-01-01" rangeEnd="2024-01-10" />);
+        fireEvent.click(screen.getByLabelText("open calendar"));
+
+        expect(container.querySelector("input")).toHaveValue("2024-01-01");
+
+        const selectedDays = container.querySelectorAll(".calendar__cell--selected");
+        expect(selectedDays[0]).toHaveTextContent("1");
+        expect(selectedDays[1]).toHaveTextContent("10");
+
+        rerender(<EbayDateTextbox value="2024-01-12" rangeEnd="2024-01-15" />);
+        expect(container.querySelector("input")).toHaveValue("2024-01-12");
+
+        const updatedSelectedDays = container.querySelectorAll(".calendar__cell--selected");
+        expect(updatedSelectedDays[0]).toHaveTextContent("12");
+        expect(updatedSelectedDays[1]).toHaveTextContent("15");
     });
 });

--- a/packages/ebayui-core-react/src/ebay-date-textbox/date-textbox.tsx
+++ b/packages/ebayui-core-react/src/ebay-date-textbox/date-textbox.tsx
@@ -54,8 +54,8 @@ const EbayDateTextbox: FC<EbayDateTextboxProps> = ({
     const valueToRender = isControlled(controlledValue) ? controlledValue : internalValue;
     const rangeEndToRender = isControlled(controlledRangeEnd) ? controlledRangeEnd : internalRangeEnd;
 
-    const [firstSelected, setFirstSelected] = useState(() => dateArgToISO(valueToRender));
-    const [secondSelected, setSecondSelected] = useState(() => dateArgToISO(rangeEndToRender));
+    const firstSelected = dateArgToISO(valueToRender);
+    const secondSelected = dateArgToISO(rangeEndToRender);
     const [isPopoverOpen, setIsPopoverOpen] = useState<boolean>(false);
     const [numMonths, setNumMonths] = useState(1);
 
@@ -106,10 +106,8 @@ const EbayDateTextbox: FC<EbayDateTextboxProps> = ({
         const iso = isNaN(date.getTime()) ? null : toISO(date);
 
         if (index === 0) {
-            setFirstSelected(iso);
             setInternalValue(iso || "");
         } else {
-            setSecondSelected(iso);
             setInternalRangeEnd(iso || "");
         }
 
@@ -126,7 +124,6 @@ const EbayDateTextbox: FC<EbayDateTextboxProps> = ({
     };
 
     const handlePopoverSelect = (event: MouseEvent<HTMLInputElement>, { iso }: { iso: DayISO }) => {
-        setFirstSelected(iso);
         setInternalValue(iso);
 
         if (range) {
@@ -139,24 +136,17 @@ const EbayDateTextbox: FC<EbayDateTextboxProps> = ({
             if (firstSelected && secondSelected) {
                 // both were selected reset selection
                 setInternalRangeEnd("");
-                setSecondSelected(null);
                 eventData.rangeEnd = null;
             } else if (selected) {
                 // exactly one was selected; fiture out the order
                 if (selected < iso) {
-                    setFirstSelected(selected);
                     setInternalValue(selected);
-
                     setInternalRangeEnd(iso);
-                    setSecondSelected(iso);
                     eventData.rangeStart = selected;
                     eventData.rangeEnd = iso;
                 } else {
-                    setFirstSelected(iso);
                     setInternalValue(iso);
-
                     setInternalRangeEnd(selected);
-                    setSecondSelected(selected);
                     eventData.rangeStart = iso;
                     eventData.rangeEnd = selected;
                 }


### PR DESCRIPTION

<!-- Select which type of PR this is -->
- [ ] This PR contains CSS changes
- [x] This PR does not contain CSS changes

## Description
- Change to derive first and second selected dates instead of storing in a state

## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [ ] I verify the build is in a non-broken state
- [ ] I verify all changes are within scope of the linked issue

<!-- For Markup Changes -->
- [ ] I verify the markup will not be a breaking change (if not a major release)
- [ ] I verify the MIND pattern for the component has been created/revised

<!-- For CSS changes -->
- [ ] I regenerated all CSS files under dist folder
- [ ] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [ ] I tested the UI in dark mode and RTL mode
- [ ] I added/updated/removed Storybook coverage as appropriate
