### PR TITLE
fix(react:filter-menu): avoid checking the item when disabled and fix handlers

### DIFF
--- a/.changeset/spotty-moles-hunt.md
+++ b/.changeset/spotty-moles-hunt.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ui-core-react": patch
+---
+
+fix(react:filter-menu): avoid checking the item when disabled and fix event handlers

--- a/packages/ebayui-core-react/src/ebay-filter-menu/__tests__/index.stories.tsx
+++ b/packages/ebayui-core-react/src/ebay-filter-menu/__tests__/index.stories.tsx
@@ -133,3 +133,13 @@ export const WithFooterButton: StoryFn<typeof EbayFilterMenu> = (args) => (
         <EbayFilterMenuFooterButton>Apply</EbayFilterMenuFooterButton>
     </EbayFilterMenu>
 );
+
+export const WithDisabledItem: StoryFn<typeof EbayFilterMenu> = (args) => (
+    <EbayFilterMenu variant="form" {...args}>
+        <EbayFilterMenuItem value="item 1">item 1</EbayFilterMenuItem>
+        <EbayFilterMenuItem value="item 2">item 2</EbayFilterMenuItem>
+        <EbayFilterMenuItem value="item 3" disabled>
+            item 3
+        </EbayFilterMenuItem>
+    </EbayFilterMenu>
+);

--- a/packages/ebayui-core-react/src/ebay-filter-menu/__tests__/render.spec.tsx
+++ b/packages/ebayui-core-react/src/ebay-filter-menu/__tests__/render.spec.tsx
@@ -1,9 +1,10 @@
 import React from "react";
 import { composeStories } from "@storybook/react-vite";
 import * as stories from "./index.stories";
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
-const { Default, WithSearch, WithFooterButton } = composeStories(stories);
+const { Default, WithSearch, WithFooterButton, WithDisabledItem } = composeStories(stories);
 
 jest.mock("../../common/random-id");
 
@@ -21,5 +22,54 @@ describe("<EbayFilterMenu /> rendering", () => {
     it("renders WithFooterButton story correctly", () => {
         const { container } = render(<WithFooterButton />);
         expect(container).toMatchSnapshot();
+    });
+
+    it("shouldn't change 'checked' for disabled items", async () => {
+        render(<WithDisabledItem />);
+
+        const disabledItem = screen.getByText("item 3").closest("label")!.querySelector("input");
+
+        expect(disabledItem!.checked).toBe(false);
+        await userEvent.click(disabledItem!);
+        expect(disabledItem!.checked).toBe(false);
+
+        disabledItem?.focus();
+        await userEvent.keyboard("{Enter}");
+        expect(disabledItem!.checked).toBe(false);
+    });
+
+    it('should change "checked" when the Space key is pressed', async () => {
+        render(<Default variant="form" />);
+
+        const checkbox = screen.getByText("item 1").closest("label")?.querySelector("input");
+
+        expect(checkbox?.checked).toBe(false);
+
+        checkbox?.focus();
+        await userEvent.keyboard("{ }");
+        expect(checkbox?.checked).toBe(true);
+    });
+
+    it('should change "checked" when the Enter key is pressed', async () => {
+        render(<Default variant="form" />);
+
+        const checkbox = screen.getByText("item 1").closest("label")?.querySelector("input");
+
+        expect(checkbox?.checked).toBe(false);
+
+        checkbox?.focus();
+        await userEvent.keyboard("{Enter}");
+        expect(checkbox?.checked).toBe(true);
+    });
+
+    it('should change "checked" when the label is pressed', async () => {
+        render(<Default variant="form" />);
+
+        const label = screen.getByText("item 1").closest("label");
+        const checkbox = label?.querySelector("input");
+
+        expect(checkbox?.checked).toBe(false);
+        await userEvent.click(label!);
+        expect(checkbox?.checked).toBe(true);
     });
 });

--- a/packages/ebayui-core-react/src/ebay-filter-menu/filter-menu.tsx
+++ b/packages/ebayui-core-react/src/ebay-filter-menu/filter-menu.tsx
@@ -154,9 +154,9 @@ const EbayFilterMenu: FC<EbayFilterMenuProps> = ({
     ) => {
         const target = event.target as HTMLInputElement;
         // When the item is clicked, an event click is triggered on the Label and
-        // then on the checkbox. We need to ignore the click event on the checkbox
+        // then on the checkbox. We need to ignore the click event on the label
         // to avoid triggering the onClick event twice.
-        if (isForm && target.type === "checkbox") {
+        if (isForm && !target.type) {
             return;
         }
 
@@ -229,6 +229,10 @@ const EbayFilterMenu: FC<EbayFilterMenuProps> = ({
                             __variant: variant,
                             checked: isRadio ? index === checkedIndex : checkedItems[index],
                             onClick: (event, { checked, value }) => {
+                                if (item.props.disabled) {
+                                    return;
+                                }
+
                                 item.props.onClick?.(event, { checked, value });
                                 handleItemClick(event, {
                                     checked,
@@ -236,8 +240,13 @@ const EbayFilterMenu: FC<EbayFilterMenuProps> = ({
                                 });
                             },
                             onKeyDown: (event: KeyboardEvent<HTMLLabelElement & HTMLDivElement>) => {
+                                if (item.props.disabled) {
+                                    return;
+                                }
+
                                 item.props.onKeyDown?.(event);
-                                if (event.key === "Enter" || event.key === " ") {
+                                // For "Space" key, the onClick event is triggered on checkboxes, so we ignore on forms
+                                if (event.key === "Enter" || (event.key === " " && !isForm)) {
                                     const currentChecked = isRadio ? index === checkedIndex : checkedItems[index];
                                     handleItemClick(event, {
                                         checked: !currentChecked,


### PR DESCRIPTION
<!-- Select which type of PR this is -->
- [ ] This PR contains CSS changes
- [x] This PR does not contain CSS changes

## Description
- Make sure to check that the item is not `disabled` before triggering click/keydown events
- Remove "Space" keydown on checkboxes since the onClick is triggered instead
- Correctly check the field when clicking on the label and/or the input field

## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [ ] I verify the build is in a non-broken state
- [ ] I verify all changes are within scope of the linked issue

<!-- For Markup Changes -->
- [ ] I verify the markup will not be a breaking change (if not a major release)
- [ ] I verify the MIND pattern for the component has been created/revised

<!-- For CSS changes -->
- [ ] I regenerated all CSS files under dist folder
- [ ] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [ ] I tested the UI in dark mode and RTL mode
- [ ] I added/updated/removed Storybook coverage as appropriate
