### PR TITLE
fix(icons): fixed ebay balance icons

### DIFF
--- a/.changeset/full-tigers-find.md
+++ b/.changeset/full-tigers-find.md
@@ -1,0 +1,5 @@
+---
+"@ebay/skin": patch
+---
+
+Icons fix patch

--- a/packages/skin/dist/svg/icon/icon-ebay-balance-12-colored.svg
+++ b/packages/skin/dist/svg/icon/icon-ebay-balance-12-colored.svg
@@ -7,6 +7,7 @@
     rx="1.5"
     fill="#fff"
     stroke="#191919"
+    stroke-width="1"
   />
   <path
     fill-rule="evenodd"

--- a/packages/skin/dist/svg/icon/icon-ebay-balance-18-colored.svg
+++ b/packages/skin/dist/svg/icon/icon-ebay-balance-18-colored.svg
@@ -7,6 +7,7 @@
     rx="1.5"
     fill="#fff"
     stroke="#191919"
+    stroke-width="1"
   />
   <path
     fill-rule="evenodd"

--- a/packages/skin/dist/svg/icon/icon-ebay-balance-24-colored.svg
+++ b/packages/skin/dist/svg/icon/icon-ebay-balance-24-colored.svg
@@ -7,6 +7,7 @@
     rx="1.5"
     fill="#fff"
     stroke="#191919"
+    stroke-width="1"
   />
   <path
     fill-rule="evenodd"

--- a/packages/skin/dist/svg/icon/icon-ebay-balance-32-colored.svg
+++ b/packages/skin/dist/svg/icon/icon-ebay-balance-32-colored.svg
@@ -7,6 +7,7 @@
     rx="1.5"
     fill="#fff"
     stroke="#191919"
+    stroke-width="1"
   />
   <path
     fill-rule="evenodd"

--- a/packages/skin/dist/svg/icons.svg
+++ b/packages/skin/dist/svg/icons.svg
@@ -3081,6 +3081,7 @@
       rx="1.5"
       fill="#fff"
       stroke="#191919"
+      stroke-width="1"
     />
     <path
       fill-rule="evenodd"
@@ -3116,6 +3117,7 @@
       rx="1.5"
       fill="#fff"
       stroke="#191919"
+      stroke-width="1"
     />
     <path
       fill-rule="evenodd"
@@ -3151,6 +3153,7 @@
       rx="1.5"
       fill="#fff"
       stroke="#191919"
+      stroke-width="1"
     />
     <path
       fill-rule="evenodd"
@@ -3186,6 +3189,7 @@
       rx="1.5"
       fill="#fff"
       stroke="#191919"
+      stroke-width="1"
     />
     <path
       fill-rule="evenodd"

--- a/packages/skin/src/components/data/icons.json
+++ b/packages/skin/src/components/data/icons.json
@@ -3,20 +3,13 @@
         "prefix": "icon",
         "largeDocs": ["ebay-money-back-guarantee-logo-16-colored"],
         "list": [
-            { "name": "add-16", "size": "16", "height": "16", "width": "16" },
+            { "name": "add-24", "size": "24", "height": "24", "width": "24" },
             { "name": "add-12", "size": "12", "height": "12", "width": "12" },
             {
                 "name": "add-image-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
-            },
-            { "name": "add-24", "size": "24", "height": "24", "width": "24" },
-            {
-                "name": "afterpay-12-colored",
-                "size": "12-colored",
-                "height": "12",
-                "width": "20"
             },
             {
                 "name": "afterpay-18-colored",
@@ -25,17 +18,30 @@
                 "width": "30"
             },
             {
+                "name": "afterpay-12-colored",
+                "size": "12-colored",
+                "height": "12",
+                "width": "20"
+            },
+            { "name": "add-16", "size": "16", "height": "16", "width": "16" },
+            {
+                "name": "afterpay-24-colored",
+                "size": "24-colored",
+                "height": "24",
+                "width": "38"
+            },
+            {
                 "name": "afterpay-32-colored",
                 "size": "32-colored",
                 "height": "32",
                 "width": "50"
             },
-            { "name": "ai-16", "size": "16", "height": "16", "width": "16" },
             { "name": "ai-20", "size": "20", "height": "20", "width": "20" },
+            { "name": "ai-16", "size": "16", "height": "16", "width": "16" },
             { "name": "ai-24", "size": "24", "height": "24", "width": "24" },
             {
-                "name": "ai-spectrum-16-colored",
-                "size": "16-colored",
+                "name": "ai-filled-16",
+                "size": "16",
                 "height": "16",
                 "width": "16"
             },
@@ -52,8 +58,8 @@
                 "width": "24"
             },
             {
-                "name": "ai-filled-16",
-                "size": "16",
+                "name": "ai-spectrum-16-colored",
+                "size": "16-colored",
                 "height": "16",
                 "width": "16"
             },
@@ -76,22 +82,10 @@
                 "width": "16"
             },
             {
-                "name": "afterpay-24-colored",
-                "size": "24-colored",
-                "height": "24",
-                "width": "38"
-            },
-            {
                 "name": "ai-spectrum-filled-20-colored",
                 "size": "20-colored",
                 "height": "20",
                 "width": "20"
-            },
-            {
-                "name": "ai-spectrum-filled-24-colored",
-                "size": "24-colored",
-                "height": "24",
-                "width": "24"
             },
             {
                 "name": "ai-spectrum-thin-16-colored",
@@ -100,10 +94,28 @@
                 "width": "16"
             },
             {
+                "name": "ai-thin-16",
+                "size": "16",
+                "height": "16",
+                "width": "16"
+            },
+            {
+                "name": "ai-spectrum-filled-24-colored",
+                "size": "24-colored",
+                "height": "24",
+                "width": "24"
+            },
+            {
                 "name": "ai-tools-16",
                 "size": "16",
                 "height": "16",
                 "width": "16"
+            },
+            {
+                "name": "ai-tools-24",
+                "size": "24",
+                "height": "24",
+                "width": "24"
             },
             {
                 "name": "ai-tools-20",
@@ -118,22 +130,16 @@
                 "width": "20"
             },
             {
-                "name": "alipay-cn-24-colored",
-                "size": "24-colored",
-                "height": "24",
-                "width": "38"
-            },
-            {
-                "name": "ai-tools-24",
-                "size": "24",
-                "height": "24",
-                "width": "24"
-            },
-            {
                 "name": "alipay-cn-18-colored",
                 "size": "18-colored",
                 "height": "18",
                 "width": "30"
+            },
+            {
+                "name": "alipay-cn-24-colored",
+                "size": "24-colored",
+                "height": "24",
+                "width": "38"
             },
             {
                 "name": "alipay-cn-32-colored",
@@ -148,19 +154,19 @@
                 "width": "20"
             },
             {
-                "name": "alipay-hk-18-colored",
-                "size": "18-colored",
-                "height": "18",
-                "width": "30"
-            },
-            {
                 "name": "alipay-hk-24-colored",
                 "size": "24-colored",
                 "height": "24",
                 "width": "38"
             },
             {
-                "name": "amex-18-colored",
+                "name": "alipay-hk-32-colored",
+                "size": "32-colored",
+                "height": "32",
+                "width": "50"
+            },
+            {
+                "name": "alipay-hk-18-colored",
                 "size": "18-colored",
                 "height": "18",
                 "width": "30"
@@ -172,10 +178,10 @@
                 "width": "20"
             },
             {
-                "name": "ai-thin-16",
-                "size": "16",
-                "height": "16",
-                "width": "16"
+                "name": "amex-18-colored",
+                "size": "18-colored",
+                "height": "18",
+                "width": "30"
             },
             {
                 "name": "amex-24-colored",
@@ -197,22 +203,28 @@
                 "width": "24"
             },
             {
+                "name": "apple-pay-12-colored",
+                "size": "12-colored",
+                "height": "12",
+                "width": "20"
+            },
+            {
                 "name": "apple-pay-24-colored",
                 "size": "24-colored",
                 "height": "24",
                 "width": "38"
             },
             {
-                "name": "apple-pay-18-colored",
-                "size": "18-colored",
-                "height": "18",
-                "width": "30"
-            },
-            {
                 "name": "apple-pay-32-colored",
                 "size": "32-colored",
                 "height": "32",
                 "width": "50"
+            },
+            {
+                "name": "apple-pay-18-colored",
+                "size": "18-colored",
+                "height": "18",
+                "width": "30"
             },
             {
                 "name": "archive-16",
@@ -233,22 +245,16 @@
                 "width": "12"
             },
             {
-                "name": "apple-pay-12-colored",
-                "size": "12-colored",
-                "height": "12",
-                "width": "20"
+                "name": "arrow-left-16",
+                "size": "16",
+                "height": "16",
+                "width": "16"
             },
             {
                 "name": "arrow-left-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
-            },
-            {
-                "name": "arrow-left-16",
-                "size": "16",
-                "height": "16",
-                "width": "16"
             },
             {
                 "name": "arrow-right-12",
@@ -269,10 +275,10 @@
                 "width": "16"
             },
             {
-                "name": "arrows-3d-24",
-                "size": "24",
-                "height": "24",
-                "width": "24"
+                "name": "arrow-right-20",
+                "size": "20",
+                "height": "20",
+                "width": "20"
             },
             {
                 "name": "arrow-right-24",
@@ -281,20 +287,14 @@
                 "width": "24"
             },
             {
-                "name": "arrow-right-20",
-                "size": "20",
-                "height": "20",
-                "width": "20"
+                "name": "arrows-3d-24",
+                "size": "24",
+                "height": "24",
+                "width": "24"
             },
             {
                 "name": "arrows-3d-16",
                 "size": "16",
-                "height": "16",
-                "width": "16"
-            },
-            {
-                "name": "arrows-expand-24",
-                "size": "24",
                 "height": "16",
                 "width": "16"
             },
@@ -305,22 +305,16 @@
                 "width": "24"
             },
             {
-                "name": "attention-16",
-                "size": "16",
+                "name": "arrows-3d-filled-64-colored",
+                "size": "64-colored",
+                "height": "64",
+                "width": "64"
+            },
+            {
+                "name": "arrows-expand-24",
+                "size": "24",
                 "height": "16",
                 "width": "16"
-            },
-            {
-                "name": "alipay-hk-32-colored",
-                "size": "32-colored",
-                "height": "32",
-                "width": "50"
-            },
-            {
-                "name": "article-24",
-                "size": "24",
-                "height": "24",
-                "width": "24"
             },
             {
                 "name": "article-16",
@@ -329,10 +323,16 @@
                 "width": "16"
             },
             {
-                "name": "arrows-3d-filled-64-colored",
-                "size": "64-colored",
-                "height": "64",
-                "width": "64"
+                "name": "article-24",
+                "size": "24",
+                "height": "24",
+                "width": "24"
+            },
+            {
+                "name": "attention-16",
+                "size": "16",
+                "height": "16",
+                "width": "16"
             },
             {
                 "name": "attention-24",
@@ -341,10 +341,10 @@
                 "width": "24"
             },
             {
-                "name": "attention-filled-24",
-                "size": "24",
-                "height": "24",
-                "width": "24"
+                "name": "attention-64",
+                "size": "64",
+                "height": "64",
+                "width": "64"
             },
             {
                 "name": "attention-filled-16",
@@ -353,10 +353,10 @@
                 "width": "16"
             },
             {
-                "name": "attention-64",
-                "size": "64",
-                "height": "64",
-                "width": "64"
+                "name": "attention-filled-24",
+                "size": "24",
+                "height": "24",
+                "width": "24"
             },
             { "name": "atv-16", "size": "16", "height": "16", "width": "16" },
             { "name": "atv-24", "size": "24", "height": "24", "width": "24" },
@@ -367,19 +367,25 @@
                 "width": "16"
             },
             {
+                "name": "audio-high-20",
+                "size": "20",
+                "height": "20",
+                "width": "20"
+            },
+            {
                 "name": "audio-high-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
             },
             {
-                "name": "audio-off-16",
+                "name": "audio-low-16",
                 "size": "16",
                 "height": "16",
                 "width": "16"
             },
             {
-                "name": "audio-low-16",
+                "name": "audio-off-16",
                 "size": "16",
                 "height": "16",
                 "width": "16"
@@ -397,8 +403,8 @@
                 "width": "24"
             },
             {
-                "name": "authenticity-guarantee-filled-16-colored",
-                "size": "16-colored",
+                "name": "authenticity-guarantee-16",
+                "size": "16",
                 "height": "16",
                 "width": "16"
             },
@@ -409,22 +415,16 @@
                 "width": "24"
             },
             {
+                "name": "authenticity-guarantee-filled-16-colored",
+                "size": "16-colored",
+                "height": "16",
+                "width": "16"
+            },
+            {
                 "name": "authenticity-guarantee-filled-24-colored",
                 "size": "24-colored",
                 "height": "24",
                 "width": "24"
-            },
-            {
-                "name": "audio-high-20",
-                "size": "20",
-                "height": "20",
-                "width": "20"
-            },
-            {
-                "name": "authenticity-guarantee-16",
-                "size": "16",
-                "height": "16",
-                "width": "16"
             },
             {
                 "name": "auto-adjust-24",
@@ -451,10 +451,10 @@
                 "width": "20"
             },
             {
-                "name": "bancontact-32-colored",
-                "size": "32-colored",
-                "height": "32",
-                "width": "50"
+                "name": "bancontact-18-colored",
+                "size": "18-colored",
+                "height": "18",
+                "width": "30"
             },
             {
                 "name": "bancontact-24-colored",
@@ -462,7 +462,13 @@
                 "height": "24",
                 "width": "38"
             },
-            { "name": "bank-64", "size": "64", "height": "64", "width": "64" },
+            {
+                "name": "bancontact-32-colored",
+                "size": "32-colored",
+                "height": "32",
+                "width": "50"
+            },
+            { "name": "bank-16", "size": "16", "height": "16", "width": "16" },
             { "name": "bank-24", "size": "24", "height": "24", "width": "24" },
             {
                 "name": "bank-account-12-colored",
@@ -470,6 +476,13 @@
                 "height": "12",
                 "width": "20"
             },
+            {
+                "name": "bank-account-18-colored",
+                "size": "18-colored",
+                "height": "18",
+                "width": "30"
+            },
+            { "name": "bank-64", "size": "64", "height": "64", "width": "64" },
             {
                 "name": "bank-account-24-colored",
                 "size": "24-colored",
@@ -489,31 +502,24 @@
                 "width": "16"
             },
             {
-                "name": "bank-account-18-colored",
-                "size": "18-colored",
-                "height": "18",
-                "width": "30"
-            },
-            { "name": "bids-16", "size": "16", "height": "16", "width": "16" },
-            { "name": "bids-24", "size": "24", "height": "24", "width": "24" },
-            {
-                "name": "bancontact-18-colored",
-                "size": "18-colored",
-                "height": "18",
-                "width": "30"
-            },
-            { "name": "bank-16", "size": "16", "height": "16", "width": "16" },
-            { "name": "boat-24", "size": "24", "height": "24", "width": "24" },
-            { "name": "boat-16", "size": "16", "height": "16", "width": "16" },
-            {
                 "name": "bar-chart-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
             },
-            { "name": "book-16", "size": "16", "height": "16", "width": "16" },
-            { "name": "book-24", "size": "24", "height": "24", "width": "24" },
+            { "name": "bids-16", "size": "16", "height": "16", "width": "16" },
             { "name": "bids-64", "size": "64", "height": "64", "width": "64" },
+            { "name": "boat-16", "size": "16", "height": "16", "width": "16" },
+            { "name": "bids-24", "size": "24", "height": "24", "width": "24" },
+            { "name": "book-16", "size": "16", "height": "16", "width": "16" },
+            { "name": "boat-24", "size": "24", "height": "24", "width": "24" },
+            {
+                "name": "bookmark-16",
+                "size": "16",
+                "height": "16",
+                "width": "16"
+            },
+            { "name": "book-24", "size": "24", "height": "24", "width": "24" },
             {
                 "name": "bookmark-24",
                 "size": "24",
@@ -525,6 +531,12 @@
                 "size": "16",
                 "height": "16",
                 "width": "16"
+            },
+            {
+                "name": "bookmark-filled-24",
+                "size": "24",
+                "height": "24",
+                "width": "24"
             },
             {
                 "name": "brand-authorized-seller-16",
@@ -539,19 +551,7 @@
                 "width": "24"
             },
             {
-                "name": "bookmark-filled-24",
-                "size": "24",
-                "height": "24",
-                "width": "24"
-            },
-            {
                 "name": "brightness-16",
-                "size": "16",
-                "height": "16",
-                "width": "16"
-            },
-            {
-                "name": "bookmark-16",
                 "size": "16",
                 "height": "16",
                 "width": "16"
@@ -563,10 +563,10 @@
                 "width": "20"
             },
             {
-                "name": "calendar-64",
-                "size": "64",
-                "height": "64",
-                "width": "64"
+                "name": "brightness-24",
+                "size": "24",
+                "height": "24",
+                "width": "24"
             },
             {
                 "name": "calendar-16",
@@ -575,28 +575,28 @@
                 "width": "16"
             },
             {
-                "name": "brightness-24",
-                "size": "24",
-                "height": "24",
-                "width": "24"
-            },
-            {
                 "name": "calendar-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
             },
             {
-                "name": "camera-24",
-                "size": "24",
-                "height": "24",
-                "width": "24"
+                "name": "calendar-64",
+                "size": "64",
+                "height": "64",
+                "width": "64"
             },
             {
                 "name": "camera-16",
                 "size": "16",
                 "height": "16",
                 "width": "16"
+            },
+            {
+                "name": "camera-24",
+                "size": "24",
+                "height": "24",
+                "width": "24"
             },
             {
                 "name": "camera-64",
@@ -619,16 +619,22 @@
                 "width": "24"
             },
             {
+                "name": "carnet-12-colored",
+                "size": "12-colored",
+                "height": "12",
+                "width": "20"
+            },
+            {
                 "name": "card-stack-64",
                 "size": "64",
                 "height": "64",
                 "width": "64"
             },
             {
-                "name": "carnet-32-colored",
-                "size": "32-colored",
-                "height": "32",
-                "width": "50"
+                "name": "carnet-18-colored",
+                "size": "18-colored",
+                "height": "18",
+                "width": "30"
             },
             {
                 "name": "carnet-24-colored",
@@ -637,19 +643,20 @@
                 "width": "38"
             },
             {
-                "name": "carnet-12-colored",
-                "size": "12-colored",
-                "height": "12",
-                "width": "20"
+                "name": "carnet-32-colored",
+                "size": "32-colored",
+                "height": "32",
+                "width": "50"
             },
-            { "name": "cart-16", "size": "16", "height": "16", "width": "16" },
-            { "name": "cart-20", "size": "20", "height": "20", "width": "20" },
             {
                 "name": "carryon-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
             },
+            { "name": "cart-16", "size": "16", "height": "16", "width": "16" },
+            { "name": "cart-20", "size": "20", "height": "20", "width": "20" },
+            { "name": "cart-24", "size": "24", "height": "24", "width": "24" },
             {
                 "name": "cart-add-16",
                 "size": "16",
@@ -657,7 +664,6 @@
                 "width": "16"
             },
             { "name": "cart-64", "size": "64", "height": "64", "width": "64" },
-            { "name": "cart-24", "size": "24", "height": "24", "width": "24" },
             {
                 "name": "cart-add-20",
                 "size": "20",
@@ -669,6 +675,12 @@
                 "size": "24",
                 "height": "24",
                 "width": "24"
+            },
+            {
+                "name": "cashapp-18-colored",
+                "size": "18-colored",
+                "height": "18",
+                "width": "30"
             },
             {
                 "name": "cashapp-24-colored",
@@ -683,22 +695,16 @@
                 "width": "50"
             },
             {
+                "name": "categories-16",
+                "size": "16",
+                "height": "16",
+                "width": "16"
+            },
+            {
                 "name": "cashapp-12-colored",
                 "size": "12-colored",
                 "height": "12",
                 "width": "20"
-            },
-            {
-                "name": "carnet-18-colored",
-                "size": "18-colored",
-                "height": "18",
-                "width": "30"
-            },
-            {
-                "name": "cashapp-18-colored",
-                "size": "18-colored",
-                "height": "18",
-                "width": "30"
             },
             {
                 "name": "categories-24",
@@ -730,7 +736,7 @@
                 "height": "32",
                 "width": "50"
             },
-            { "name": "ccd-top", "height": "25", "width": "35" },
+            { "name": "ccd-charger-included", "height": "78", "width": "58" },
             {
                 "name": "ccd-charger-not-included",
                 "height": "78",
@@ -742,35 +748,29 @@
                 "height": "24",
                 "width": "24"
             },
+            { "name": "ccd-top", "height": "25", "width": "35" },
             {
                 "name": "certified-recycled-16",
                 "size": "16",
                 "height": "16",
                 "width": "16"
             },
-            { "name": "ccd-charger-included", "height": "78", "width": "58" },
             { "name": "chair-16", "size": "16", "height": "16", "width": "16" },
-            { "name": "chat-64", "size": "64", "height": "64", "width": "64" },
+            { "name": "chair-24", "size": "24", "height": "24", "width": "24" },
             { "name": "chat-16", "size": "16", "height": "16", "width": "16" },
             { "name": "chat-24", "size": "24", "height": "24", "width": "24" },
+            { "name": "chat-64", "size": "64", "height": "64", "width": "64" },
             {
                 "name": "check-in-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
             },
-            { "name": "chair-24", "size": "24", "height": "24", "width": "24" },
             {
                 "name": "checkbox-mixed-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
-            },
-            {
-                "name": "categories-16",
-                "size": "16",
-                "height": "16",
-                "width": "16"
             },
             {
                 "name": "checkmark-24",
@@ -797,6 +797,12 @@
                 "width": "20"
             },
             {
+                "name": "chevron-down-24",
+                "size": "24",
+                "height": "24",
+                "width": "24"
+            },
+            {
                 "name": "chevron-left-12",
                 "size": "12",
                 "height": "12",
@@ -809,12 +815,6 @@
                 "width": "16"
             },
             {
-                "name": "chevron-down-24",
-                "size": "24",
-                "height": "24",
-                "width": "24"
-            },
-            {
                 "name": "chevron-left-20",
                 "size": "20",
                 "height": "20",
@@ -825,6 +825,12 @@
                 "size": "24",
                 "height": "24",
                 "width": "24"
+            },
+            {
+                "name": "chevron-right-12",
+                "size": "12",
+                "height": "12",
+                "width": "12"
             },
             {
                 "name": "chevron-right-16",
@@ -851,19 +857,7 @@
                 "width": "12"
             },
             {
-                "name": "chevron-up-20",
-                "size": "20",
-                "height": "20",
-                "width": "20"
-            },
-            {
                 "name": "chevron-up-16",
-                "size": "16",
-                "height": "16",
-                "width": "16"
-            },
-            {
-                "name": "chinese-coin-16",
                 "size": "16",
                 "height": "16",
                 "width": "16"
@@ -874,21 +868,27 @@
                 "height": "24",
                 "width": "24"
             },
-            { "name": "clear-16", "size": "16", "height": "16", "width": "16" },
+            {
+                "name": "chinese-coin-16",
+                "size": "16",
+                "height": "16",
+                "width": "16"
+            },
             {
                 "name": "chinese-coin-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
             },
+            {
+                "name": "chevron-up-20",
+                "size": "20",
+                "height": "20",
+                "width": "20"
+            },
+            { "name": "clear-16", "size": "16", "height": "16", "width": "16" },
             { "name": "clear-20", "size": "20", "height": "20", "width": "20" },
             { "name": "clear-24", "size": "24", "height": "24", "width": "24" },
-            {
-                "name": "chevron-right-12",
-                "size": "12",
-                "height": "12",
-                "width": "12"
-            },
             {
                 "name": "click-to-call-16",
                 "size": "16",
@@ -901,9 +901,9 @@
                 "height": "24",
                 "width": "24"
             },
-            { "name": "clock-64", "size": "64", "height": "64", "width": "64" },
             { "name": "clock-16", "size": "16", "height": "16", "width": "16" },
             { "name": "clock-24", "size": "24", "height": "24", "width": "24" },
+            { "name": "clock-64", "size": "64", "height": "64", "width": "64" },
             {
                 "name": "clock-fast-16",
                 "size": "16",
@@ -911,14 +911,15 @@
                 "width": "16"
             },
             { "name": "close-12", "size": "12", "height": "12", "width": "13" },
-            { "name": "close-16", "size": "16", "height": "16", "width": "16" },
             {
                 "name": "clock-fast-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
             },
+            { "name": "close-16", "size": "16", "height": "16", "width": "16" },
             { "name": "close-20", "size": "20", "height": "20", "width": "20" },
+            { "name": "close-24", "size": "24", "height": "24", "width": "24" },
             {
                 "name": "closed-caption-16",
                 "size": "16",
@@ -932,13 +933,6 @@
                 "width": "20"
             },
             { "name": "coin-24", "size": "24", "height": "24", "width": "24" },
-            { "name": "close-24", "size": "24", "height": "24", "width": "24" },
-            {
-                "name": "collections-16",
-                "size": "16",
-                "height": "16",
-                "width": "16"
-            },
             {
                 "name": "coin-battery-48",
                 "size": "48",
@@ -946,7 +940,7 @@
                 "width": "48"
             },
             {
-                "name": "confirmation-16",
+                "name": "collections-16",
                 "size": "16",
                 "height": "16",
                 "width": "16"
@@ -968,6 +962,12 @@
                 "size": "24",
                 "height": "24",
                 "width": "24"
+            },
+            {
+                "name": "confirmation-16",
+                "size": "16",
+                "height": "16",
+                "width": "16"
             },
             {
                 "name": "confirmation-24",
@@ -994,14 +994,33 @@
                 "width": "16"
             },
             {
+                "name": "confirmation-filled-24",
+                "size": "24",
+                "height": "24",
+                "width": "24"
+            },
+            {
                 "name": "contract-16",
                 "size": "16",
                 "height": "16",
                 "width": "16"
             },
+            {
+                "name": "contrast-24",
+                "size": "24",
+                "height": "24",
+                "width": "24"
+            },
             { "name": "copy-16", "size": "16", "height": "16", "width": "16" },
             {
-                "name": "confirmation-filled-24",
+                "name": "coupon-16",
+                "size": "16",
+                "height": "16",
+                "width": "16"
+            },
+            { "name": "copy-24", "size": "24", "height": "24", "width": "24" },
+            {
+                "name": "coupon-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
@@ -1012,7 +1031,6 @@
                 "height": "16",
                 "width": "16"
             },
-            { "name": "copy-24", "size": "24", "height": "24", "width": "24" },
             {
                 "name": "credit-card-24",
                 "size": "24",
@@ -1020,24 +1038,18 @@
                 "width": "24"
             },
             {
-                "name": "coupon-16",
-                "size": "16",
-                "height": "16",
-                "width": "16"
+                "name": "credit-card-64",
+                "size": "64",
+                "height": "64",
+                "width": "64"
             },
+            { "name": "crop-24", "size": "24", "height": "24", "width": "24" },
             {
                 "name": "customize-16",
                 "size": "16",
                 "height": "16",
                 "width": "16"
             },
-            {
-                "name": "coupon-24",
-                "size": "24",
-                "height": "24",
-                "width": "24"
-            },
-            { "name": "crop-24", "size": "24", "height": "24", "width": "24" },
             {
                 "name": "customize-24",
                 "size": "24",
@@ -1051,22 +1063,22 @@
                 "width": "16"
             },
             {
-                "name": "delete-24",
-                "size": "24",
-                "height": "24",
-                "width": "24"
-            },
-            {
                 "name": "delete-20",
                 "size": "20",
                 "height": "20",
                 "width": "20"
             },
             {
-                "name": "credit-card-64",
-                "size": "64",
-                "height": "64",
-                "width": "64"
+                "name": "delete-24",
+                "size": "24",
+                "height": "24",
+                "width": "24"
+            },
+            {
+                "name": "density-compact-24",
+                "size": "24",
+                "height": "24",
+                "width": "24"
             },
             {
                 "name": "density-default-16",
@@ -1075,10 +1087,10 @@
                 "width": "16"
             },
             {
-                "name": "density-compact-24",
-                "size": "24",
-                "height": "24",
-                "width": "24"
+                "name": "density-compact-16",
+                "size": "16",
+                "height": "16",
+                "width": "16"
             },
             {
                 "name": "density-relaxed-16",
@@ -1099,58 +1111,16 @@
                 "width": "24"
             },
             {
-                "name": "diamond-24",
-                "size": "24",
-                "height": "24",
-                "width": "24"
-            },
-            {
-                "name": "density-compact-16",
-                "size": "16",
-                "height": "16",
-                "width": "16"
-            },
-            {
-                "name": "diners-24-colored",
-                "size": "24-colored",
-                "height": "24",
-                "width": "38"
-            },
-            {
                 "name": "diamond-16",
                 "size": "16",
                 "height": "16",
                 "width": "16"
             },
             {
-                "name": "direct-debit-24-colored",
-                "size": "24-colored",
+                "name": "diamond-24",
+                "size": "24",
                 "height": "24",
-                "width": "38"
-            },
-            {
-                "name": "diners-32-colored",
-                "size": "32-colored",
-                "height": "32",
-                "width": "50"
-            },
-            {
-                "name": "direct-debit-18-colored",
-                "size": "18-colored",
-                "height": "18",
-                "width": "30"
-            },
-            {
-                "name": "direct-debit-32-colored",
-                "size": "32-colored",
-                "height": "32",
-                "width": "50"
-            },
-            {
-                "name": "direct-from-brand-16",
-                "size": "16",
-                "height": "16",
-                "width": "16"
+                "width": "24"
             },
             {
                 "name": "diners-12-colored",
@@ -1165,16 +1135,46 @@
                 "width": "30"
             },
             {
-                "name": "discount-16",
+                "name": "diners-32-colored",
+                "size": "32-colored",
+                "height": "32",
+                "width": "50"
+            },
+            {
+                "name": "diners-24-colored",
+                "size": "24-colored",
+                "height": "24",
+                "width": "38"
+            },
+            {
+                "name": "direct-debit-12-colored",
+                "size": "12-colored",
+                "height": "12",
+                "width": "20"
+            },
+            {
+                "name": "direct-debit-18-colored",
+                "size": "18-colored",
+                "height": "18",
+                "width": "30"
+            },
+            {
+                "name": "direct-debit-24-colored",
+                "size": "24-colored",
+                "height": "24",
+                "width": "38"
+            },
+            {
+                "name": "direct-debit-32-colored",
+                "size": "32-colored",
+                "height": "32",
+                "width": "50"
+            },
+            {
+                "name": "direct-from-brand-16",
                 "size": "16",
                 "height": "16",
                 "width": "16"
-            },
-            {
-                "name": "discord-24",
-                "size": "24",
-                "height": "24",
-                "width": "24"
             },
             {
                 "name": "direct-from-brand-24",
@@ -1183,7 +1183,31 @@
                 "width": "24"
             },
             {
+                "name": "discord-24",
+                "size": "24",
+                "height": "24",
+                "width": "24"
+            },
+            {
+                "name": "discount-16",
+                "size": "16",
+                "height": "16",
+                "width": "16"
+            },
+            {
                 "name": "discount-24",
+                "size": "24",
+                "height": "24",
+                "width": "24"
+            },
+            {
+                "name": "discount-auto-16",
+                "size": "16",
+                "height": "16",
+                "width": "16"
+            },
+            {
+                "name": "discount-auto-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
@@ -1193,18 +1217,6 @@
                 "size": "12-colored",
                 "height": "12",
                 "width": "20"
-            },
-            {
-                "name": "direct-debit-12-colored",
-                "size": "12-colored",
-                "height": "12",
-                "width": "20"
-            },
-            {
-                "name": "discount-auto-24",
-                "size": "24",
-                "height": "24",
-                "width": "24"
             },
             {
                 "name": "discover-24-colored",
@@ -1219,31 +1231,25 @@
                 "width": "30"
             },
             {
-                "name": "dollar-16",
-                "size": "16",
-                "height": "16",
-                "width": "16"
-            },
-            {
                 "name": "discover-32-colored",
                 "size": "32-colored",
                 "height": "32",
                 "width": "50"
             },
             {
-                "name": "discount-auto-16",
+                "name": "dollar-16",
                 "size": "16",
                 "height": "16",
                 "width": "16"
             },
             {
-                "name": "dollar-off-24",
+                "name": "dollar-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
             },
             {
-                "name": "dollar-24",
+                "name": "dollar-off-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
@@ -1267,16 +1273,16 @@
                 "width": "24"
             },
             {
-                "name": "drag-drop-24",
-                "size": "24",
-                "height": "24",
-                "width": "24"
-            },
-            {
                 "name": "drag-drop-16",
                 "size": "16",
                 "height": "16",
                 "width": "16"
+            },
+            {
+                "name": "ebay-balance-18-colored",
+                "size": "18-colored",
+                "height": "18",
+                "width": "30"
             },
             {
                 "name": "ebay-balance-32-colored",
@@ -1297,7 +1303,19 @@
                 "width": "48"
             },
             {
-                "name": "ebay-international-shipping-24",
+                "name": "drag-drop-24",
+                "size": "24",
+                "height": "24",
+                "width": "24"
+            },
+            {
+                "name": "ebay-balance-24-colored",
+                "size": "24-colored",
+                "height": "24",
+                "width": "38"
+            },
+            {
+                "name": "ebay-for-charity-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
@@ -1309,16 +1327,10 @@
                 "width": "16"
             },
             {
-                "name": "ebay-balance-24-colored",
-                "size": "24-colored",
+                "name": "ebay-international-shipping-24",
+                "size": "24",
                 "height": "24",
-                "width": "38"
-            },
-            {
-                "name": "ebay-international-shipping-16",
-                "size": "16",
-                "height": "16",
-                "width": "16"
+                "width": "24"
             },
             {
                 "name": "ebay-international-shipping-64",
@@ -1327,13 +1339,19 @@
                 "width": "64"
             },
             {
-                "name": "ebay-balance-18-colored",
-                "size": "18-colored",
-                "height": "18",
-                "width": "30"
+                "name": "ebay-international-shipping-16",
+                "size": "16",
+                "height": "16",
+                "width": "16"
             },
             {
-                "name": "ebay-for-charity-24",
+                "name": "ebay-live-16",
+                "size": "16",
+                "height": "16",
+                "width": "16"
+            },
+            {
+                "name": "ebay-live-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
@@ -1343,12 +1361,6 @@
                 "size": "16-colored",
                 "height": "16",
                 "width": "40"
-            },
-            {
-                "name": "ebay-live-24",
-                "size": "24",
-                "height": "24",
-                "width": "24"
             },
             {
                 "name": "ebay-mastercard-12-colored",
@@ -1363,31 +1375,25 @@
                 "width": "38"
             },
             {
-                "name": "ebay-money-back-guarantee-logo-16-colored",
-                "size": "16-colored",
-                "height": "16",
-                "width": "147"
-            },
-            {
-                "name": "ebay-plus-16",
-                "size": "16",
-                "height": "16",
-                "width": "16"
-            },
-            {
                 "name": "ebay-mastercard-32-colored",
                 "size": "32-colored",
                 "height": "32",
                 "width": "50"
             },
             {
-                "name": "ebay-plus-24",
-                "size": "24",
-                "height": "24",
-                "width": "24"
+                "name": "ebay-money-back-guarantee-logo-16-colored",
+                "size": "16-colored",
+                "height": "16",
+                "width": "147"
             },
             {
-                "name": "ebay-live-16",
+                "name": "ebay-mastercard-18-colored",
+                "size": "18-colored",
+                "height": "18",
+                "width": "30"
+            },
+            {
+                "name": "ebay-plus-16",
                 "size": "16",
                 "height": "16",
                 "width": "16"
@@ -1399,10 +1405,10 @@
                 "width": "58"
             },
             {
-                "name": "ebay-preloved-16",
-                "size": "16",
-                "height": "16",
-                "width": "16"
+                "name": "ebay-plus-24",
+                "size": "24",
+                "height": "24",
+                "width": "24"
             },
             {
                 "name": "ebay-plus-logo-dark-16-colored",
@@ -1411,22 +1417,10 @@
                 "width": "58"
             },
             {
-                "name": "ebay-mastercard-18-colored",
-                "size": "18-colored",
-                "height": "18",
-                "width": "30"
-            },
-            {
-                "name": "ebay-refurbished-16",
+                "name": "ebay-preloved-16",
                 "size": "16",
                 "height": "16",
                 "width": "16"
-            },
-            {
-                "name": "ebay-refurbished-24",
-                "size": "24",
-                "height": "24",
-                "width": "24"
             },
             {
                 "name": "ebay-preloved-24",
@@ -1435,10 +1429,16 @@
                 "width": "24"
             },
             {
-                "name": "eftpos-18-colored",
-                "size": "18-colored",
-                "height": "18",
-                "width": "30"
+                "name": "ebay-refurbished-24",
+                "size": "24",
+                "height": "24",
+                "width": "24"
+            },
+            {
+                "name": "ebay-refurbished-16",
+                "size": "16",
+                "height": "16",
+                "width": "16"
             },
             {
                 "name": "eftpos-12-colored",
@@ -1447,10 +1447,10 @@
                 "width": "20"
             },
             {
-                "name": "eftpos-32-colored",
-                "size": "32-colored",
-                "height": "32",
-                "width": "50"
+                "name": "eftpos-18-colored",
+                "size": "18-colored",
+                "height": "18",
+                "width": "30"
             },
             {
                 "name": "eftpos-24-colored",
@@ -1459,16 +1459,16 @@
                 "width": "38"
             },
             {
+                "name": "eftpos-32-colored",
+                "size": "32-colored",
+                "height": "32",
+                "width": "50"
+            },
+            {
                 "name": "elo-18-colored",
                 "size": "18-colored",
                 "height": "18",
                 "width": "30"
-            },
-            {
-                "name": "elo-32-colored",
-                "size": "32-colored",
-                "height": "32",
-                "width": "50"
             },
             {
                 "name": "elo-12-colored",
@@ -1483,10 +1483,10 @@
                 "width": "38"
             },
             {
-                "name": "escrow-card-24-colored",
-                "size": "24-colored",
-                "height": "24",
-                "width": "38"
+                "name": "elo-32-colored",
+                "size": "32-colored",
+                "height": "32",
+                "width": "50"
             },
             {
                 "name": "escrow-card-12-colored",
@@ -1501,19 +1501,25 @@
                 "width": "30"
             },
             {
+                "name": "escrow-card-24-colored",
+                "size": "24-colored",
+                "height": "24",
+                "width": "38"
+            },
+            {
                 "name": "escrow-card-32-colored",
                 "size": "32-colored",
                 "height": "32",
                 "width": "50"
             },
+            { "name": "euro-16", "size": "16", "height": "16", "width": "16" },
+            { "name": "euro-24", "size": "24", "height": "24", "width": "24" },
             {
                 "name": "european-conformity-48",
                 "size": "48",
                 "height": "48",
                 "width": "48"
             },
-            { "name": "euro-16", "size": "16", "height": "16", "width": "16" },
-            { "name": "euro-24", "size": "24", "height": "24", "width": "24" },
             {
                 "name": "exclude-16",
                 "size": "16",
@@ -1527,25 +1533,13 @@
                 "width": "24"
             },
             {
-                "name": "expand-16",
-                "size": "16",
-                "height": "16",
-                "width": "16"
-            },
-            {
-                "name": "explore-16",
-                "size": "16",
-                "height": "16",
-                "width": "16"
-            },
-            {
                 "name": "exclude-64",
                 "size": "64",
                 "height": "64",
                 "width": "64"
             },
             {
-                "name": "external-link-16",
+                "name": "expand-16",
                 "size": "16",
                 "height": "16",
                 "width": "16"
@@ -1557,10 +1551,16 @@
                 "width": "24"
             },
             {
-                "name": "external-link-24",
-                "size": "24",
-                "height": "24",
-                "width": "24"
+                "name": "explore-16",
+                "size": "16",
+                "height": "16",
+                "width": "16"
+            },
+            {
+                "name": "external-link-16",
+                "size": "16",
+                "height": "16",
+                "width": "16"
             },
             {
                 "name": "external-link-20",
@@ -1569,7 +1569,7 @@
                 "width": "20"
             },
             {
-                "name": "face-happiest-24",
+                "name": "external-link-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
@@ -1577,16 +1577,16 @@
             { "name": "eye-16", "size": "16", "height": "16", "width": "16" },
             { "name": "eye-24", "size": "24", "height": "24", "width": "24" },
             {
+                "name": "face-happiest-24",
+                "size": "24",
+                "height": "24",
+                "width": "24"
+            },
+            {
                 "name": "face-happy-16",
                 "size": "16",
                 "height": "16",
                 "width": "16"
-            },
-            {
-                "name": "face-sad-24",
-                "size": "24",
-                "height": "24",
-                "width": "24"
             },
             {
                 "name": "face-happy-24",
@@ -1601,16 +1601,16 @@
                 "width": "24"
             },
             {
-                "name": "face-saddest-24",
+                "name": "face-sad-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
             },
             {
-                "name": "fall-leaf-16",
-                "size": "16",
-                "height": "16",
-                "width": "16"
+                "name": "face-saddest-24",
+                "size": "24",
+                "height": "24",
+                "width": "24"
             },
             {
                 "name": "facebook-24",
@@ -1625,13 +1625,13 @@
                 "width": "24"
             },
             {
-                "name": "fall-leaf-24",
-                "size": "24",
-                "height": "24",
-                "width": "24"
+                "name": "fall-leaf-16",
+                "size": "16",
+                "height": "16",
+                "width": "16"
             },
             {
-                "name": "feedback-24",
+                "name": "fall-leaf-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
@@ -1649,16 +1649,10 @@
                 "width": "20"
             },
             {
-                "name": "feedback-negative-16",
-                "size": "16",
-                "height": "16",
-                "width": "16"
-            },
-            {
-                "name": "feedback-neutral-16",
-                "size": "16",
-                "height": "16",
-                "width": "16"
+                "name": "feedback-24",
+                "size": "24",
+                "height": "24",
+                "width": "24"
             },
             {
                 "name": "feedback-error-16",
@@ -1669,6 +1663,18 @@
             {
                 "name": "feedback-error-24",
                 "size": "24",
+                "height": "16",
+                "width": "16"
+            },
+            {
+                "name": "feedback-negative-16",
+                "size": "16",
+                "height": "16",
+                "width": "16"
+            },
+            {
+                "name": "feedback-neutral-16",
+                "size": "16",
                 "height": "16",
                 "width": "16"
             },
@@ -1684,7 +1690,14 @@
                 "height": "16",
                 "width": "16"
             },
+            {
+                "name": "feedback-received-24",
+                "size": "24",
+                "height": "24",
+                "width": "24"
+            },
             { "name": "file-16", "size": "16", "height": "16", "width": "16" },
+            { "name": "file-24", "size": "24", "height": "24", "width": "24" },
             {
                 "name": "filter-16",
                 "size": "16",
@@ -1692,10 +1705,10 @@
                 "width": "16"
             },
             {
-                "name": "fingerprint-64",
-                "size": "64",
-                "height": "64",
-                "width": "65"
+                "name": "filter-24",
+                "size": "24",
+                "height": "24",
+                "width": "24"
             },
             {
                 "name": "fingerprint-24",
@@ -1703,20 +1716,19 @@
                 "height": "24",
                 "width": "24"
             },
-            { "name": "file-24", "size": "24", "height": "24", "width": "24" },
-            { "name": "flag-24", "size": "24", "height": "24", "width": "24" },
+            {
+                "name": "fingerprint-64",
+                "size": "64",
+                "height": "64",
+                "width": "65"
+            },
             { "name": "flag-16", "size": "16", "height": "16", "width": "16" },
+            { "name": "flag-24", "size": "24", "height": "24", "width": "24" },
             {
                 "name": "flag-filled-16",
                 "size": "16",
                 "height": "16",
                 "width": "16"
-            },
-            {
-                "name": "feedback-received-24",
-                "size": "24",
-                "height": "24",
-                "width": "24"
             },
             {
                 "name": "flag-filled-24",
@@ -1726,19 +1738,25 @@
             },
             { "name": "flash-24", "size": "24", "height": "24", "width": "24" },
             {
-                "name": "filter-24",
-                "size": "24",
-                "height": "24",
-                "width": "24"
-            },
-            {
-                "name": "folder-24",
+                "name": "flash-auto-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
             },
             {
                 "name": "flash-off-24",
+                "size": "24",
+                "height": "24",
+                "width": "24"
+            },
+            {
+                "name": "folder-16",
+                "size": "16",
+                "height": "16",
+                "width": "16"
+            },
+            {
+                "name": "folder-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
@@ -1762,25 +1780,13 @@
                 "width": "16"
             },
             {
-                "name": "flash-auto-24",
+                "name": "forklift-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
-            },
-            {
-                "name": "folder-16",
-                "size": "16",
-                "height": "16",
-                "width": "16"
             },
             { "name": "franc-16", "size": "16", "height": "16", "width": "16" },
             { "name": "franc-24", "size": "24", "height": "24", "width": "24" },
-            {
-                "name": "free-warranty-24",
-                "size": "24",
-                "height": "24",
-                "width": "24"
-            },
             {
                 "name": "free-warranty-16",
                 "size": "16",
@@ -1788,22 +1794,16 @@
                 "width": "16"
             },
             {
+                "name": "free-warranty-24",
+                "size": "24",
+                "height": "24",
+                "width": "24"
+            },
+            {
                 "name": "full-view-16",
                 "size": "16",
                 "height": "16",
                 "width": "16"
-            },
-            {
-                "name": "full-view-filled-24",
-                "size": "24",
-                "height": "24",
-                "width": "24"
-            },
-            {
-                "name": "forklift-24",
-                "size": "24",
-                "height": "24",
-                "width": "24"
             },
             {
                 "name": "full-view-24",
@@ -1818,16 +1818,16 @@
                 "width": "16"
             },
             {
+                "name": "full-view-filled-24",
+                "size": "24",
+                "height": "24",
+                "width": "24"
+            },
+            {
                 "name": "gallery-16",
                 "size": "16",
                 "height": "16",
                 "width": "16"
-            },
-            {
-                "name": "general-card-12-colored",
-                "size": "12-colored",
-                "height": "12",
-                "width": "20"
             },
             {
                 "name": "gallery-24",
@@ -1836,10 +1836,28 @@
                 "width": "24"
             },
             {
+                "name": "general-card-12-colored",
+                "size": "12-colored",
+                "height": "12",
+                "width": "20"
+            },
+            {
+                "name": "general-card-18-colored",
+                "size": "18-colored",
+                "height": "18",
+                "width": "30"
+            },
+            {
                 "name": "general-card-24-colored",
                 "size": "24-colored",
                 "height": "24",
                 "width": "38"
+            },
+            {
+                "name": "generic-card-12-colored",
+                "size": "12-colored",
+                "height": "12",
+                "width": "20"
             },
             {
                 "name": "general-card-32-colored",
@@ -1854,16 +1872,10 @@
                 "width": "30"
             },
             {
-                "name": "generic-card-12-colored",
-                "size": "12-colored",
-                "height": "12",
-                "width": "20"
-            },
-            {
-                "name": "general-card-18-colored",
-                "size": "18-colored",
-                "height": "18",
-                "width": "30"
+                "name": "generic-card-24-colored",
+                "size": "24-colored",
+                "height": "24",
+                "width": "38"
             },
             {
                 "name": "generic-card-32-colored",
@@ -1871,14 +1883,8 @@
                 "height": "32",
                 "width": "50"
             },
-            { "name": "gift-24", "size": "24", "height": "24", "width": "24" },
-            {
-                "name": "generic-card-24-colored",
-                "size": "24-colored",
-                "height": "24",
-                "width": "38"
-            },
             { "name": "gift-16", "size": "16", "height": "16", "width": "16" },
+            { "name": "gift-24", "size": "24", "height": "24", "width": "24" },
             { "name": "gift-64", "size": "64", "height": "64", "width": "64" },
             {
                 "name": "gift-card-12-colored",
@@ -1899,10 +1905,10 @@
                 "width": "38"
             },
             {
-                "name": "girocard-18-colored",
-                "size": "18-colored",
-                "height": "18",
-                "width": "30"
+                "name": "gift-card-32-colored",
+                "size": "32-colored",
+                "height": "32",
+                "width": "50"
             },
             {
                 "name": "girocard-12-colored",
@@ -1911,10 +1917,10 @@
                 "width": "20"
             },
             {
-                "name": "gift-card-32-colored",
-                "size": "32-colored",
-                "height": "32",
-                "width": "50"
+                "name": "girocard-18-colored",
+                "size": "18-colored",
+                "height": "18",
+                "width": "30"
             },
             {
                 "name": "girocard-24-colored",
@@ -1930,6 +1936,18 @@
             },
             {
                 "name": "glasses-24",
+                "size": "24",
+                "height": "24",
+                "width": "24"
+            },
+            {
+                "name": "glasses-64",
+                "size": "64",
+                "height": "64",
+                "width": "64"
+            },
+            {
+                "name": "google-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
@@ -1953,25 +1971,20 @@
                 "width": "38"
             },
             {
-                "name": "google-24",
-                "size": "24",
-                "height": "24",
-                "width": "24"
-            },
-            {
                 "name": "google-pay-32-colored",
                 "size": "32-colored",
                 "height": "32",
                 "width": "50"
             },
-            { "name": "graph-64", "size": "64", "height": "64", "width": "64" },
             { "name": "graph-16", "size": "16", "height": "16", "width": "16" },
+            { "name": "graph-24", "size": "24", "height": "24", "width": "24" },
             {
                 "name": "graph-dynamic-16",
                 "size": "16",
                 "height": "16",
                 "width": "16"
             },
+            { "name": "graph-64", "size": "64", "height": "64", "width": "64" },
             {
                 "name": "graph-dynamic-24",
                 "size": "24",
@@ -1979,15 +1992,13 @@
                 "width": "24"
             },
             {
-                "name": "grid-view-24",
-                "size": "24",
-                "height": "24",
-                "width": "24"
-            },
-            { "name": "graph-24", "size": "24", "height": "24", "width": "24" },
-            { "name": "hand-swipe-40", "height": "40", "width": "40" },
-            {
                 "name": "grid-view-16",
+                "size": "16",
+                "height": "16",
+                "width": "16"
+            },
+            {
+                "name": "grid-view-filled-16",
                 "size": "16",
                 "height": "16",
                 "width": "16"
@@ -1999,16 +2010,17 @@
                 "width": "24"
             },
             {
+                "name": "grid-view-24",
+                "size": "24",
+                "height": "24",
+                "width": "24"
+            },
+            { "name": "hand-swipe-40", "height": "40", "width": "40" },
+            {
                 "name": "handbag-16",
                 "size": "16",
                 "height": "16",
                 "width": "16"
-            },
-            {
-                "name": "glasses-64",
-                "size": "64",
-                "height": "64",
-                "width": "64"
             },
             {
                 "name": "handbag-24",
@@ -2029,19 +2041,13 @@
                 "width": "24"
             },
             {
-                "name": "grid-view-filled-16",
-                "size": "16",
-                "height": "16",
-                "width": "16"
-            },
-            {
                 "name": "headlight-16",
                 "size": "16",
                 "height": "16",
                 "width": "16"
             },
             {
-                "name": "contrast-24",
+                "name": "headlight-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
@@ -2052,20 +2058,20 @@
                 "height": "16",
                 "width": "16"
             },
-            { "name": "heart-20", "size": "20", "height": "20", "width": "20" },
+            {
+                "name": "headphone-24",
+                "size": "24",
+                "height": "24",
+                "width": "24"
+            },
             { "name": "heart-16", "size": "16", "height": "16", "width": "16" },
+            { "name": "heart-20", "size": "20", "height": "20", "width": "20" },
+            { "name": "heart-24", "size": "24", "height": "24", "width": "24" },
             {
                 "name": "heart-filled-16",
                 "size": "16",
                 "height": "16",
                 "width": "16"
-            },
-            { "name": "heart-24", "size": "24", "height": "24", "width": "24" },
-            {
-                "name": "headlight-24",
-                "size": "24",
-                "height": "24",
-                "width": "24"
             },
             {
                 "name": "heart-filled-20",
@@ -2080,18 +2086,19 @@
                 "width": "24"
             },
             { "name": "help-16", "size": "16", "height": "16", "width": "16" },
+            { "name": "help-20", "size": "20", "height": "20", "width": "20" },
             { "name": "help-24", "size": "24", "height": "24", "width": "24" },
-            {
-                "name": "help-outline-20",
-                "size": "20",
-                "height": "20",
-                "width": "20"
-            },
             {
                 "name": "help-outline-16",
                 "size": "16",
                 "height": "16",
                 "width": "16"
+            },
+            {
+                "name": "help-outline-20",
+                "size": "20",
+                "height": "20",
+                "width": "20"
             },
             {
                 "name": "help-outline-24",
@@ -2100,6 +2107,7 @@
                 "width": "24"
             },
             { "name": "hide-16", "size": "16", "height": "16", "width": "16" },
+            { "name": "hide-24", "size": "24", "height": "24", "width": "24" },
             {
                 "name": "history-16",
                 "size": "16",
@@ -2112,35 +2120,35 @@
                 "height": "24",
                 "width": "24"
             },
-            { "name": "hide-24", "size": "24", "height": "24", "width": "24" },
-            {
-                "name": "home-filled-24",
-                "size": "24",
-                "height": "24",
-                "width": "24"
-            },
             {
                 "name": "history-64",
                 "size": "64",
                 "height": "64",
                 "width": "64"
             },
-            { "name": "image-16", "size": "16", "height": "16", "width": "16" },
-            { "name": "image-24", "size": "24", "height": "24", "width": "24" },
-            { "name": "inbox-16", "size": "16", "height": "16", "width": "16" },
             { "name": "home-24", "size": "24", "height": "24", "width": "24" },
-            { "name": "inbox-24", "size": "24", "height": "24", "width": "24" },
             {
-                "name": "information-24",
+                "name": "home-filled-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
             },
+            { "name": "image-16", "size": "16", "height": "16", "width": "16" },
+            { "name": "image-24", "size": "24", "height": "24", "width": "24" },
+            { "name": "image-64", "size": "64", "height": "64", "width": "64" },
+            { "name": "inbox-16", "size": "16", "height": "16", "width": "16" },
+            { "name": "inbox-24", "size": "24", "height": "24", "width": "24" },
             {
                 "name": "information-16",
                 "size": "16",
                 "height": "16",
                 "width": "16"
+            },
+            {
+                "name": "information-24",
+                "size": "24",
+                "height": "24",
+                "width": "24"
             },
             {
                 "name": "information-filled-16",
@@ -2149,19 +2157,7 @@
                 "width": "16"
             },
             {
-                "name": "instagram-24",
-                "size": "24",
-                "height": "24",
-                "width": "24"
-            },
-            {
                 "name": "information-filled-24",
-                "size": "24",
-                "height": "24",
-                "width": "24"
-            },
-            {
-                "name": "inspect-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
@@ -2173,17 +2169,10 @@
                 "width": "16"
             },
             {
-                "name": "interac-18-colored",
-                "size": "18-colored",
-                "height": "18",
-                "width": "30"
-            },
-            { "name": "image-64", "size": "64", "height": "64", "width": "64" },
-            {
-                "name": "interac-24-colored",
-                "size": "24-colored",
+                "name": "inspect-24",
+                "size": "24",
                 "height": "24",
-                "width": "38"
+                "width": "24"
             },
             {
                 "name": "inspect-64",
@@ -2192,30 +2181,29 @@
                 "width": "64"
             },
             {
-                "name": "item-list-24",
+                "name": "instagram-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
             },
             {
-                "name": "item-list-20",
-                "size": "20",
-                "height": "20",
+                "name": "interac-12-colored",
+                "size": "12-colored",
+                "height": "12",
                 "width": "20"
             },
             {
-                "name": "headphone-24",
-                "size": "24",
-                "height": "24",
-                "width": "24"
-            },
-            {
-                "name": "jcb-18-colored",
+                "name": "interac-18-colored",
                 "size": "18-colored",
                 "height": "18",
                 "width": "30"
             },
-            { "name": "help-20", "size": "20", "height": "20", "width": "20" },
+            {
+                "name": "interac-24-colored",
+                "size": "24-colored",
+                "height": "24",
+                "width": "38"
+            },
             {
                 "name": "interac-32-colored",
                 "size": "32-colored",
@@ -2229,10 +2217,16 @@
                 "width": "16"
             },
             {
-                "name": "interac-12-colored",
-                "size": "12-colored",
-                "height": "12",
+                "name": "item-list-20",
+                "size": "20",
+                "height": "20",
                 "width": "20"
+            },
+            {
+                "name": "item-list-24",
+                "size": "24",
+                "height": "24",
+                "width": "24"
             },
             {
                 "name": "jcb-12-colored",
@@ -2241,10 +2235,28 @@
                 "width": "20"
             },
             {
+                "name": "jcb-18-colored",
+                "size": "18-colored",
+                "height": "18",
+                "width": "30"
+            },
+            {
+                "name": "jcb-24-colored",
+                "size": "24-colored",
+                "height": "24",
+                "width": "38"
+            },
+            {
                 "name": "jcb-32-colored",
                 "size": "32-colored",
                 "height": "32",
                 "width": "50"
+            },
+            {
+                "name": "jet-ski-16",
+                "size": "16",
+                "height": "16",
+                "width": "16"
             },
             {
                 "name": "jet-ski-24",
@@ -2253,23 +2265,31 @@
                 "width": "24"
             },
             {
-                "name": "kakao-pay-24-colored",
-                "size": "24-colored",
-                "height": "24",
-                "width": "38"
-            },
-            {
                 "name": "kakao-pay-12-colored",
                 "size": "12-colored",
                 "height": "12",
                 "width": "20"
             },
             {
-                "name": "jet-ski-16",
-                "size": "16",
-                "height": "16",
-                "width": "16"
+                "name": "kakao-pay-18-colored",
+                "size": "18-colored",
+                "height": "18",
+                "width": "30"
             },
+            {
+                "name": "kakao-pay-24-colored",
+                "size": "24-colored",
+                "height": "24",
+                "width": "38"
+            },
+            {
+                "name": "kakao-pay-32-colored",
+                "size": "32-colored",
+                "height": "32",
+                "width": "50"
+            },
+            { "name": "key-16", "size": "16", "height": "16", "width": "16" },
+            { "name": "key-24", "size": "24", "height": "24", "width": "24" },
             {
                 "name": "keyboard-16",
                 "size": "16",
@@ -2283,39 +2303,7 @@
                 "width": "24"
             },
             {
-                "name": "kakao-pay-32-colored",
-                "size": "32-colored",
-                "height": "32",
-                "width": "50"
-            },
-            {
-                "name": "kakao-pay-18-colored",
-                "size": "18-colored",
-                "height": "18",
-                "width": "30"
-            },
-            {
-                "name": "jcb-24-colored",
-                "size": "24-colored",
-                "height": "24",
-                "width": "38"
-            },
-            { "name": "key-24", "size": "24", "height": "24", "width": "24" },
-            {
-                "name": "klarna-black-32-colored",
-                "size": "32-colored",
-                "height": "32",
-                "width": "50"
-            },
-            { "name": "key-16", "size": "16", "height": "16", "width": "16" },
-            {
-                "name": "klarna-black-24-colored",
-                "size": "24-colored",
-                "height": "24",
-                "width": "38"
-            },
-            {
-                "name": "klarna-pink-12-colored",
+                "name": "klarna-black-12-colored",
                 "size": "12-colored",
                 "height": "12",
                 "width": "20"
@@ -2325,6 +2313,24 @@
                 "size": "18-colored",
                 "height": "18",
                 "width": "30"
+            },
+            {
+                "name": "klarna-black-24-colored",
+                "size": "24-colored",
+                "height": "24",
+                "width": "38"
+            },
+            {
+                "name": "klarna-black-32-colored",
+                "size": "32-colored",
+                "height": "32",
+                "width": "50"
+            },
+            {
+                "name": "klarna-pink-12-colored",
+                "size": "12-colored",
+                "height": "12",
+                "width": "20"
             },
             {
                 "name": "klarna-pink-18-colored",
@@ -2339,6 +2345,18 @@
                 "width": "38"
             },
             {
+                "name": "klarna-pink-32-colored",
+                "size": "32-colored",
+                "height": "32",
+                "width": "50"
+            },
+            {
+                "name": "klarna-white-12-colored",
+                "size": "12-colored",
+                "height": "12",
+                "width": "20"
+            },
+            {
                 "name": "klarna-white-18-colored",
                 "size": "18-colored",
                 "height": "18",
@@ -2351,38 +2369,15 @@
                 "width": "38"
             },
             {
-                "name": "klarna-pink-32-colored",
-                "size": "32-colored",
-                "height": "32",
-                "width": "50"
-            },
-            {
-                "name": "klarna-black-12-colored",
-                "size": "12-colored",
-                "height": "12",
-                "width": "20"
-            },
-            {
-                "name": "klarna-white-12-colored",
-                "size": "12-colored",
-                "height": "12",
-                "width": "20"
-            },
-            { "name": "krona-24", "size": "24", "height": "24", "width": "24" },
-            { "name": "lamp-24", "size": "24", "height": "24", "width": "24" },
-            {
                 "name": "klarna-white-32-colored",
                 "size": "32-colored",
                 "height": "32",
                 "width": "50"
             },
+            { "name": "krona-16", "size": "16", "height": "16", "width": "16" },
+            { "name": "krona-24", "size": "24", "height": "24", "width": "24" },
             { "name": "lamp-16", "size": "16", "height": "16", "width": "16" },
-            {
-                "name": "large-box-24",
-                "size": "24",
-                "height": "24",
-                "width": "24"
-            },
+            { "name": "lamp-24", "size": "24", "height": "24", "width": "24" },
             {
                 "name": "large-box-16",
                 "size": "16",
@@ -2390,14 +2385,37 @@
                 "width": "16"
             },
             {
+                "name": "large-box-24",
+                "size": "24",
+                "height": "24",
+                "width": "24"
+            },
+            {
                 "name": "legacy-authenticity-guarantee-48-colored",
                 "size": "48-colored",
                 "height": "48",
                 "width": "48"
             },
-            { "name": "krona-16", "size": "16", "height": "16", "width": "16" },
+            {
+                "name": "legacy-click-to-call-48-colored",
+                "size": "48-colored",
+                "height": "48",
+                "width": "48"
+            },
             {
                 "name": "legacy-escrow-48-colored",
+                "size": "48-colored",
+                "height": "48",
+                "width": "48"
+            },
+            {
+                "name": "legacy-free-warranty-48-colored",
+                "size": "48-colored",
+                "height": "48",
+                "width": "48"
+            },
+            {
+                "name": "legacy-money-back-guarantee-chf-48-colored",
                 "size": "48-colored",
                 "height": "48",
                 "width": "48"
@@ -2415,19 +2433,7 @@
                 "width": "48"
             },
             {
-                "name": "legacy-free-warranty-48-colored",
-                "size": "48-colored",
-                "height": "48",
-                "width": "48"
-            },
-            {
                 "name": "legacy-money-back-guarantee-us-48-colored",
-                "size": "48-colored",
-                "height": "48",
-                "width": "48"
-            },
-            {
-                "name": "legacy-click-to-call-48-colored",
                 "size": "48-colored",
                 "height": "48",
                 "width": "48"
@@ -2445,12 +2451,6 @@
                 "width": "48"
             },
             {
-                "name": "lightning-bolt-16",
-                "size": "16",
-                "height": "16",
-                "width": "16"
-            },
-            {
                 "name": "lightbulb-16",
                 "size": "16",
                 "height": "16",
@@ -2463,13 +2463,14 @@
                 "width": "24"
             },
             {
-                "name": "legacy-money-back-guarantee-chf-48-colored",
-                "size": "48-colored",
-                "height": "48",
-                "width": "48"
+                "name": "lightning-bolt-16",
+                "size": "16",
+                "height": "16",
+                "width": "16"
             },
+            { "name": "link-24", "size": "24", "height": "24", "width": "24" },
             {
-                "name": "list-view-24",
+                "name": "lightning-bolt-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
@@ -2487,10 +2488,10 @@
                 "width": "16"
             },
             {
-                "name": "live-bag-16",
-                "size": "16",
-                "height": "16",
-                "width": "16"
+                "name": "list-view-24",
+                "size": "24",
+                "height": "24",
+                "width": "24"
             },
             {
                 "name": "list-view-filled-16",
@@ -2498,12 +2499,23 @@
                 "height": "16",
                 "width": "16"
             },
-            { "name": "link-24", "size": "24", "height": "24", "width": "24" },
             {
-                "name": "lightning-bolt-24",
+                "name": "list-view-filled-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
+            },
+            {
+                "name": "live-bag-16",
+                "size": "16",
+                "height": "16",
+                "width": "16"
+            },
+            {
+                "name": "live-bag-20",
+                "size": "20",
+                "height": "20",
+                "width": "20"
             },
             {
                 "name": "live-bag-24",
@@ -2512,10 +2524,10 @@
                 "width": "24"
             },
             {
-                "name": "live-bag-20",
-                "size": "20",
-                "height": "20",
-                "width": "20"
+                "name": "live-bag-thin-16",
+                "size": "16",
+                "height": "16",
+                "width": "16"
             },
             {
                 "name": "live-broadcast-20",
@@ -2530,13 +2542,25 @@
                 "width": "24"
             },
             {
+                "name": "live-broadcast-thin-16",
+                "size": "16",
+                "height": "16",
+                "width": "16"
+            },
+            {
+                "name": "live-eye-16",
+                "size": "16",
+                "height": "16",
+                "width": "16"
+            },
+            {
                 "name": "live-eye-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
             },
             {
-                "name": "live-broadcast-thin-16",
+                "name": "location-16",
                 "size": "16",
                 "height": "16",
                 "width": "16"
@@ -2554,28 +2578,16 @@
                 "width": "64"
             },
             {
-                "name": "live-eye-16",
-                "size": "16",
-                "height": "16",
-                "width": "16"
-            },
-            {
-                "name": "location-16",
-                "size": "16",
-                "height": "16",
-                "width": "16"
-            },
-            {
-                "name": "list-view-filled-24",
-                "size": "24",
-                "height": "24",
-                "width": "24"
-            },
-            {
                 "name": "location-arrow-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
+            },
+            {
+                "name": "location-arrow-16",
+                "size": "16",
+                "height": "16",
+                "width": "16"
             },
             { "name": "lock-16", "size": "16", "height": "16", "width": "16" },
             { "name": "lock-24", "size": "24", "height": "24", "width": "24" },
@@ -2596,12 +2608,6 @@
                 "size": "24",
                 "height": "24",
                 "width": "24"
-            },
-            {
-                "name": "location-arrow-16",
-                "size": "16",
-                "height": "16",
-                "width": "16"
             },
             {
                 "name": "maestro-12-colored",
@@ -2627,23 +2633,17 @@
                 "height": "32",
                 "width": "50"
             },
-            { "name": "mail-20", "size": "20", "height": "20", "width": "20" },
-            { "name": "mail-64", "size": "64", "height": "64", "width": "64" },
             { "name": "mail-16", "size": "16", "height": "16", "width": "16" },
+            { "name": "mail-20", "size": "20", "height": "20", "width": "20" },
             {
                 "name": "mail-move-16",
                 "size": "16",
                 "height": "16",
                 "width": "16"
             },
+            { "name": "mail-64", "size": "64", "height": "64", "width": "64" },
             {
                 "name": "mail-move-24",
-                "size": "24",
-                "height": "24",
-                "width": "24"
-            },
-            {
-                "name": "mail-open-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
@@ -2654,20 +2654,12 @@
                 "height": "16",
                 "width": "16"
             },
+            { "name": "mail-24", "size": "24", "height": "24", "width": "24" },
             {
-                "name": "mail-unread-24",
+                "name": "mail-open-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
-            },
-            { "name": "map-20", "size": "20", "height": "20", "width": "20" },
-            { "name": "mail-24", "size": "24", "height": "24", "width": "24" },
-            { "name": "map-16", "size": "16", "height": "16", "width": "16" },
-            {
-                "name": "masonry-view-16",
-                "size": "16",
-                "height": "16",
-                "width": "16"
             },
             {
                 "name": "mail-unread-16",
@@ -2675,14 +2667,29 @@
                 "height": "16",
                 "width": "16"
             },
+            { "name": "map-16", "size": "16", "height": "16", "width": "16" },
+            { "name": "map-20", "size": "20", "height": "20", "width": "20" },
             {
-                "name": "masonry-view-24",
+                "name": "mail-unread-24",
+                "size": "24",
+                "height": "24",
+                "width": "24"
+            },
+            { "name": "map-24", "size": "24", "height": "24", "width": "24" },
+            {
+                "name": "masonry-view-16",
+                "size": "16",
+                "height": "16",
+                "width": "16"
+            },
+            {
+                "name": "masonry-view-filled-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
             },
             {
-                "name": "masonry-view-filled-24",
+                "name": "masonry-view-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
@@ -2694,16 +2701,22 @@
                 "width": "20"
             },
             {
-                "name": "mastercard-18-colored",
-                "size": "18-colored",
-                "height": "18",
-                "width": "30"
-            },
-            {
                 "name": "masonry-view-filled-16",
                 "size": "16",
                 "height": "16",
                 "width": "16"
+            },
+            {
+                "name": "mastercard-24-colored",
+                "size": "24-colored",
+                "height": "24",
+                "width": "38"
+            },
+            {
+                "name": "mastercard-18-colored",
+                "size": "18-colored",
+                "height": "18",
+                "width": "30"
             },
             {
                 "name": "mastercard-32-colored",
@@ -2712,25 +2725,17 @@
                 "width": "50"
             },
             {
-                "name": "live-bag-thin-16",
+                "name": "medium-box-16",
                 "size": "16",
                 "height": "16",
                 "width": "16"
             },
-            { "name": "map-24", "size": "24", "height": "24", "width": "24" },
             {
                 "name": "medium-box-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
             },
-            {
-                "name": "mastercard-24-colored",
-                "size": "24-colored",
-                "height": "24",
-                "width": "38"
-            },
-            { "name": "menu-20", "size": "20", "height": "20", "width": "20" },
             {
                 "name": "megaphone-16",
                 "size": "16",
@@ -2744,6 +2749,7 @@
                 "width": "24"
             },
             { "name": "menu-16", "size": "16", "height": "16", "width": "16" },
+            { "name": "menu-20", "size": "20", "height": "20", "width": "20" },
             { "name": "menu-24", "size": "24", "height": "24", "width": "24" },
             {
                 "name": "mercado-pago-12-colored",
@@ -2758,16 +2764,10 @@
                 "width": "30"
             },
             {
-                "name": "microphone-16",
-                "size": "16",
-                "height": "16",
-                "width": "16"
-            },
-            {
-                "name": "medium-box-16",
-                "size": "16",
-                "height": "16",
-                "width": "16"
+                "name": "mercado-pago-32-colored",
+                "size": "32-colored",
+                "height": "32",
+                "width": "50"
             },
             {
                 "name": "mercado-pago-24-colored",
@@ -2776,10 +2776,10 @@
                 "width": "38"
             },
             {
-                "name": "mercado-pago-32-colored",
-                "size": "32-colored",
-                "height": "32",
-                "width": "50"
+                "name": "microphone-16",
+                "size": "16",
+                "height": "16",
+                "width": "16"
             },
             {
                 "name": "microphone-24",
@@ -2800,16 +2800,22 @@
                 "width": "24"
             },
             {
+                "name": "money-back-guarantee-24",
+                "size": "24",
+                "height": "24",
+                "width": "24"
+            },
+            {
                 "name": "money-back-guarantee-16",
                 "size": "16",
                 "height": "16",
                 "width": "16"
             },
             {
-                "name": "money-back-guarantee-24",
-                "size": "24",
-                "height": "24",
-                "width": "24"
+                "name": "money-back-guarantee-filled-16-colored",
+                "size": "16-colored",
+                "height": "16",
+                "width": "16"
             },
             {
                 "name": "money-back-guarantee-filled-24-colored",
@@ -2824,6 +2830,18 @@
                 "width": "16"
             },
             {
+                "name": "monthly-invoice-12-colored",
+                "size": "12-colored",
+                "height": "12",
+                "width": "20"
+            },
+            {
+                "name": "monthly-invoice-18-colored",
+                "size": "18-colored",
+                "height": "18",
+                "width": "30"
+            },
+            {
                 "name": "money-stack-24",
                 "size": "24",
                 "height": "24",
@@ -2836,39 +2854,32 @@
                 "width": "38"
             },
             {
-                "name": "monthly-invoice-12-colored",
-                "size": "12-colored",
-                "height": "12",
-                "width": "20"
-            },
-            {
                 "name": "monthly-invoice-32-colored",
                 "size": "32-colored",
                 "height": "32",
                 "width": "50"
             },
-            {
-                "name": "monthly-invoice-18-colored",
-                "size": "18-colored",
-                "height": "18",
-                "width": "30"
-            },
-            { "name": "moon-20", "size": "20", "height": "20", "width": "20" },
-            {
-                "name": "money-back-guarantee-filled-16-colored",
-                "size": "16-colored",
-                "height": "16",
-                "width": "16"
-            },
+            { "name": "moon-16", "size": "16", "height": "16", "width": "16" },
+            { "name": "moon-24", "size": "24", "height": "24", "width": "24" },
             {
                 "name": "motorcycle-16",
                 "size": "16",
                 "height": "16",
                 "width": "16"
             },
-            { "name": "moon-16", "size": "16", "height": "16", "width": "16" },
-            { "name": "moon-24", "size": "24", "height": "24", "width": "24" },
-            { "name": "move-16", "size": "16", "height": "16", "width": "16" },
+            { "name": "moon-20", "size": "20", "height": "20", "width": "20" },
+            {
+                "name": "motorcycle-24",
+                "size": "24",
+                "height": "24",
+                "width": "24"
+            },
+            {
+                "name": "mountain-16",
+                "size": "16",
+                "height": "16",
+                "width": "16"
+            },
             {
                 "name": "mountain-24",
                 "size": "24",
@@ -2882,12 +2893,7 @@
                 "height": "24",
                 "width": "29"
             },
-            {
-                "name": "neutral-16",
-                "size": "16",
-                "height": "16",
-                "width": "16"
-            },
+            { "name": "move-16", "size": "16", "height": "16", "width": "16" },
             {
                 "name": "negative-filled-16",
                 "size": "16",
@@ -2900,19 +2906,11 @@
                 "height": "24",
                 "width": "24"
             },
-            { "name": "nfc-16", "size": "16", "height": "16", "width": "16" },
-            { "name": "nfc-24", "size": "24", "height": "24", "width": "24" },
             {
-                "name": "nfc-card-18-colored",
-                "size": "18-colored",
-                "height": "18",
-                "width": "30"
-            },
-            {
-                "name": "motorcycle-24",
-                "size": "24",
-                "height": "24",
-                "width": "24"
+                "name": "neutral-16",
+                "size": "16",
+                "height": "16",
+                "width": "16"
             },
             {
                 "name": "neutral-24",
@@ -2920,11 +2918,31 @@
                 "height": "24",
                 "width": "24"
             },
+            { "name": "nfc-16", "size": "16", "height": "16", "width": "16" },
+            { "name": "nfc-24", "size": "24", "height": "24", "width": "24" },
+            {
+                "name": "nfc-card-12-colored",
+                "size": "12-colored",
+                "height": "12",
+                "width": "20"
+            },
+            {
+                "name": "nfc-card-18-colored",
+                "size": "18-colored",
+                "height": "18",
+                "width": "30"
+            },
             {
                 "name": "nfc-card-32-colored",
                 "size": "32-colored",
                 "height": "32",
                 "width": "50"
+            },
+            {
+                "name": "nfc-card-24-colored",
+                "size": "24-colored",
+                "height": "24",
+                "width": "38"
             },
             {
                 "name": "no-children-zero-three-48",
@@ -2939,6 +2957,18 @@
                 "width": "16"
             },
             {
+                "name": "notification-20",
+                "size": "20",
+                "height": "20",
+                "width": "20"
+            },
+            {
+                "name": "notification-24",
+                "size": "24",
+                "height": "24",
+                "width": "24"
+            },
+            {
                 "name": "notification-64",
                 "size": "64",
                 "height": "64",
@@ -2949,24 +2979,6 @@
                 "size": "24",
                 "height": "24",
                 "width": "24"
-            },
-            {
-                "name": "notification-24",
-                "size": "24",
-                "height": "24",
-                "width": "24"
-            },
-            {
-                "name": "notification-20",
-                "size": "20",
-                "height": "20",
-                "width": "20"
-            },
-            {
-                "name": "nfc-card-24-colored",
-                "size": "24-colored",
-                "height": "24",
-                "width": "38"
             },
             {
                 "name": "out-of-reach-48",
@@ -2981,16 +2993,28 @@
                 "width": "16"
             },
             {
-                "name": "overflow-vertical-16",
-                "size": "16",
-                "height": "16",
-                "width": "16"
+                "name": "overflow-horizontal-20",
+                "size": "20",
+                "height": "20",
+                "width": "20"
             },
             {
                 "name": "overflow-horizontal-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
+            },
+            {
+                "name": "overflow-vertical-16",
+                "size": "16",
+                "height": "16",
+                "width": "16"
+            },
+            {
+                "name": "overflow-vertical-20",
+                "size": "20",
+                "height": "20",
+                "width": "20"
             },
             {
                 "name": "overflow-vertical-24",
@@ -3005,23 +3029,10 @@
                 "width": "16"
             },
             {
-                "name": "overflow-vertical-20",
-                "size": "20",
-                "height": "20",
-                "width": "20"
-            },
-            {
                 "name": "package-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
-            },
-            { "name": "panel-16", "size": "16", "height": "16", "width": "16" },
-            {
-                "name": "package-64",
-                "size": "64",
-                "height": "64",
-                "width": "64"
             },
             {
                 "name": "package-error-24",
@@ -3029,26 +3040,15 @@
                 "height": "24",
                 "width": "24"
             },
-            { "name": "panel-24", "size": "24", "height": "24", "width": "24" },
+            {
+                "name": "package-64",
+                "size": "64",
+                "height": "64",
+                "width": "64"
+            },
             { "name": "panel-20", "size": "20", "height": "20", "width": "20" },
-            {
-                "name": "panel-close-20",
-                "size": "20",
-                "height": "20",
-                "width": "20"
-            },
-            {
-                "name": "nfc-card-12-colored",
-                "size": "12-colored",
-                "height": "12",
-                "width": "20"
-            },
-            {
-                "name": "mountain-16",
-                "size": "16",
-                "height": "16",
-                "width": "16"
-            },
+            { "name": "panel-16", "size": "16", "height": "16", "width": "16" },
+            { "name": "panel-24", "size": "24", "height": "24", "width": "24" },
             {
                 "name": "panel-close-16",
                 "size": "16",
@@ -3056,13 +3056,25 @@
                 "width": "16"
             },
             {
-                "name": "panel-open-16",
+                "name": "panel-close-20",
+                "size": "20",
+                "height": "20",
+                "width": "20"
+            },
+            {
+                "name": "panel-close-vertical-16",
                 "size": "16",
                 "height": "16",
                 "width": "16"
             },
             {
-                "name": "panel-open-24",
+                "name": "panel-close-vertical-20",
+                "size": "20",
+                "height": "20",
+                "width": "20"
+            },
+            {
+                "name": "panel-close-vertical-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
@@ -3080,10 +3092,22 @@
                 "width": "20"
             },
             {
-                "name": "panel-close-vertical-24",
+                "name": "panel-open-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
+            },
+            {
+                "name": "panel-open-16",
+                "size": "16",
+                "height": "16",
+                "width": "16"
+            },
+            {
+                "name": "panel-open-vertical-20",
+                "size": "20",
+                "height": "20",
+                "width": "20"
             },
             {
                 "name": "panel-open-vertical-16",
@@ -3098,61 +3122,24 @@
                 "width": "24"
             },
             {
-                "name": "panel-close-vertical-16",
-                "size": "16",
-                "height": "16",
-                "width": "16"
-            },
-            {
-                "name": "panel-close-vertical-20",
-                "size": "20",
-                "height": "20",
-                "width": "20"
-            },
-            {
-                "name": "panel-open-vertical-20",
-                "size": "20",
-                "height": "20",
-                "width": "20"
-            },
-            {
                 "name": "passkey-16",
                 "size": "16",
                 "height": "16",
                 "width": "16"
             },
-            { "name": "pause-16", "size": "16", "height": "16", "width": "16" },
             {
                 "name": "passkey-64",
                 "size": "64",
                 "height": "64",
                 "width": "64"
             },
+            { "name": "pause-16", "size": "16", "height": "16", "width": "16" },
+            { "name": "pause-20", "size": "20", "height": "20", "width": "20" },
             {
                 "name": "passkey-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
-            },
-            { "name": "pause-24", "size": "24", "height": "24", "width": "24" },
-            {
-                "name": "payoneer-18-colored",
-                "size": "18-colored",
-                "height": "18",
-                "width": "30"
-            },
-            { "name": "pause-20", "size": "20", "height": "20", "width": "20" },
-            {
-                "name": "payoneer-24-colored",
-                "size": "24-colored",
-                "height": "24",
-                "width": "38"
-            },
-            {
-                "name": "paypal-18-colored",
-                "size": "18-colored",
-                "height": "18",
-                "width": "30"
             },
             {
                 "name": "pause-filled-64-colored",
@@ -3160,12 +3147,7 @@
                 "height": "64",
                 "width": "64"
             },
-            {
-                "name": "overflow-horizontal-20",
-                "size": "20",
-                "height": "20",
-                "width": "20"
-            },
+            { "name": "pause-24", "size": "24", "height": "24", "width": "24" },
             {
                 "name": "payoneer-12-colored",
                 "size": "12-colored",
@@ -3173,10 +3155,10 @@
                 "width": "20"
             },
             {
-                "name": "paypal-32-colored",
-                "size": "32-colored",
-                "height": "32",
-                "width": "50"
+                "name": "payoneer-24-colored",
+                "size": "24-colored",
+                "height": "24",
+                "width": "38"
             },
             {
                 "name": "payoneer-32-colored",
@@ -3185,10 +3167,34 @@
                 "width": "50"
             },
             {
-                "name": "paypal-credit-24-colored",
+                "name": "payoneer-18-colored",
+                "size": "18-colored",
+                "height": "18",
+                "width": "30"
+            },
+            {
+                "name": "paypal-12-colored",
+                "size": "12-colored",
+                "height": "12",
+                "width": "20"
+            },
+            {
+                "name": "paypal-18-colored",
+                "size": "18-colored",
+                "height": "18",
+                "width": "30"
+            },
+            {
+                "name": "paypal-24-colored",
                 "size": "24-colored",
                 "height": "24",
                 "width": "38"
+            },
+            {
+                "name": "paypal-32-colored",
+                "size": "32-colored",
+                "height": "32",
+                "width": "50"
             },
             {
                 "name": "paypal-credit-12-colored",
@@ -3197,7 +3203,13 @@
                 "width": "20"
             },
             {
-                "name": "paypal-24-colored",
+                "name": "paypal-credit-18-colored",
+                "size": "18-colored",
+                "height": "18",
+                "width": "30"
+            },
+            {
+                "name": "paypal-credit-24-colored",
                 "size": "24-colored",
                 "height": "24",
                 "width": "38"
@@ -3207,6 +3219,12 @@
                 "size": "12-colored",
                 "height": "12",
                 "width": "20"
+            },
+            {
+                "name": "paypal-credit-32-colored",
+                "size": "32-colored",
+                "height": "32",
+                "width": "50"
             },
             {
                 "name": "paypal-disabled-18-colored",
@@ -3221,7 +3239,7 @@
                 "width": "37"
             },
             {
-                "name": "paypal-credit-32-colored",
+                "name": "paypal-disabled-32-colored",
                 "size": "32-colored",
                 "height": "32",
                 "width": "50"
@@ -3239,16 +3257,10 @@
                 "width": "30"
             },
             {
-                "name": "paypal-disabled-32-colored",
-                "size": "32-colored",
-                "height": "32",
-                "width": "50"
-            },
-            {
-                "name": "paypal-credit-18-colored",
-                "size": "18-colored",
-                "height": "18",
-                "width": "30"
+                "name": "paypay-24-colored",
+                "size": "24-colored",
+                "height": "24",
+                "width": "38"
             },
             {
                 "name": "paypay-32-colored",
@@ -3257,9 +3269,15 @@
                 "width": "50"
             },
             {
-                "name": "paypal-12-colored",
-                "size": "12-colored",
-                "height": "12",
+                "name": "pencil-16",
+                "size": "16",
+                "height": "16",
+                "width": "16"
+            },
+            {
+                "name": "pencil-20",
+                "size": "20",
+                "height": "20",
                 "width": "20"
             },
             {
@@ -3269,19 +3287,7 @@
                 "width": "24"
             },
             {
-                "name": "paypay-24-colored",
-                "size": "24-colored",
-                "height": "24",
-                "width": "38"
-            },
-            {
-                "name": "pencil-16",
-                "size": "16",
-                "height": "16",
-                "width": "16"
-            },
-            {
-                "name": "people-24",
+                "name": "pencil-signed-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
@@ -3293,22 +3299,17 @@
                 "width": "16"
             },
             {
-                "name": "pencil-20",
-                "size": "20",
-                "height": "20",
-                "width": "20"
-            },
-            { "name": "phone-24", "size": "24", "height": "24", "width": "24" },
-            { "name": "peso-16", "size": "16", "height": "16", "width": "16" },
-            { "name": "phone-16", "size": "16", "height": "16", "width": "16" },
-            {
-                "name": "pin-filled-24",
+                "name": "people-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
             },
+            { "name": "peso-16", "size": "16", "height": "16", "width": "16" },
+            { "name": "peso-24", "size": "24", "height": "24", "width": "24" },
+            { "name": "phone-16", "size": "16", "height": "16", "width": "16" },
+            { "name": "phone-24", "size": "24", "height": "24", "width": "24" },
             {
-                "name": "pencil-signed-24",
+                "name": "pin-filled-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
@@ -3321,17 +3322,17 @@
                 "width": "24"
             },
             { "name": "play-16", "size": "16", "height": "16", "width": "16" },
-            {
-                "name": "play-filled-16-colored",
-                "size": "16-colored",
-                "height": "16",
-                "width": "16"
-            },
             { "name": "play-20", "size": "20", "height": "20", "width": "20" },
             { "name": "play-24", "size": "24", "height": "24", "width": "24" },
             {
                 "name": "play-disabled-16",
                 "size": "16",
+                "height": "16",
+                "width": "16"
+            },
+            {
+                "name": "play-filled-16-colored",
+                "size": "16-colored",
                 "height": "16",
                 "width": "16"
             },
@@ -3342,12 +3343,11 @@
                 "width": "24"
             },
             {
-                "name": "postepay-18-colored",
-                "size": "18-colored",
-                "height": "18",
-                "width": "30"
+                "name": "play-filled-64-colored",
+                "size": "64-colored",
+                "height": "64",
+                "width": "64"
             },
-            { "name": "peso-24", "size": "24", "height": "24", "width": "24" },
             {
                 "name": "postepay-12-colored",
                 "size": "12-colored",
@@ -3355,10 +3355,22 @@
                 "width": "20"
             },
             {
-                "name": "play-filled-64-colored",
-                "size": "64-colored",
-                "height": "64",
-                "width": "64"
+                "name": "postepay-18-colored",
+                "size": "18-colored",
+                "height": "18",
+                "width": "30"
+            },
+            {
+                "name": "postepay-24-colored",
+                "size": "24-colored",
+                "height": "24",
+                "width": "38"
+            },
+            {
+                "name": "postepay-32-colored",
+                "size": "32-colored",
+                "height": "32",
+                "width": "50"
             },
             {
                 "name": "potted-plant-16",
@@ -3366,21 +3378,22 @@
                 "height": "16",
                 "width": "16"
             },
-            { "name": "pound-16", "size": "16", "height": "16", "width": "16" },
-            {
-                "name": "postepay-24-colored",
-                "size": "24-colored",
-                "height": "24",
-                "width": "38"
-            },
-            { "name": "pound-24", "size": "24", "height": "24", "width": "24" },
             {
                 "name": "potted-plant-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
             },
+            { "name": "pound-16", "size": "16", "height": "16", "width": "16" },
+            { "name": "pound-24", "size": "24", "height": "24", "width": "24" },
+            { "name": "print-16", "size": "16", "height": "16", "width": "16" },
             { "name": "print-24", "size": "24", "height": "24", "width": "24" },
+            {
+                "name": "profile-16",
+                "size": "16",
+                "height": "16",
+                "width": "16"
+            },
             {
                 "name": "profile-20",
                 "size": "20",
@@ -3395,25 +3408,6 @@
             },
             {
                 "name": "profile-filled-24",
-                "size": "24",
-                "height": "24",
-                "width": "24"
-            },
-            {
-                "name": "postepay-32-colored",
-                "size": "32-colored",
-                "height": "32",
-                "width": "50"
-            },
-            {
-                "name": "profile-16",
-                "size": "16",
-                "height": "16",
-                "width": "16"
-            },
-            { "name": "print-16", "size": "16", "height": "16", "width": "16" },
-            {
-                "name": "progress-upcoming-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
@@ -3443,11 +3437,12 @@
                 "width": "45"
             },
             {
-                "name": "psa-logo-color-16-colored",
-                "size": "16-colored",
-                "height": "16",
-                "width": "45"
+                "name": "progress-upcoming-24",
+                "size": "24",
+                "height": "24",
+                "width": "24"
             },
+            { "name": "psa-16", "size": "16", "height": "16", "width": "45" },
             {
                 "name": "psa-logo-16",
                 "size": "16",
@@ -3460,7 +3455,18 @@
                 "height": "16",
                 "width": "84"
             },
-            { "name": "psa-16", "size": "16", "height": "16", "width": "45" },
+            {
+                "name": "psa-logo-color-16-colored",
+                "size": "16-colored",
+                "height": "16",
+                "width": "45"
+            },
+            {
+                "name": "psa-vault-16",
+                "size": "16",
+                "height": "16",
+                "width": "16"
+            },
             {
                 "name": "psa-vault-24",
                 "size": "24",
@@ -3480,13 +3486,13 @@
                 "width": "84"
             },
             {
-                "name": "qr-code-24",
-                "size": "24",
-                "height": "24",
-                "width": "24"
+                "name": "qr-code-16",
+                "size": "16",
+                "height": "16",
+                "width": "16"
             },
             {
-                "name": "recovery-code-24",
+                "name": "qr-code-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
@@ -3496,6 +3502,12 @@
                 "size": "16",
                 "height": "16",
                 "width": "16"
+            },
+            {
+                "name": "recovery-code-24",
+                "size": "24",
+                "height": "24",
+                "width": "24"
             },
             {
                 "name": "reddit-24",
@@ -3510,25 +3522,25 @@
                 "width": "16"
             },
             {
-                "name": "refresh-24",
-                "size": "24",
-                "height": "24",
-                "width": "24"
-            },
-            {
-                "name": "qr-code-16",
-                "size": "16",
-                "height": "16",
-                "width": "16"
-            },
-            {
                 "name": "refresh-20",
                 "size": "20",
                 "height": "20",
                 "width": "20"
             },
             {
+                "name": "refresh-24",
+                "size": "24",
+                "height": "24",
+                "width": "24"
+            },
+            {
                 "name": "relaxed-grid-24",
+                "size": "24",
+                "height": "24",
+                "width": "24"
+            },
+            {
+                "name": "relaxed-grid-filled-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
@@ -3540,17 +3552,13 @@
                 "width": "12"
             },
             {
-                "name": "psa-vault-16",
-                "size": "16",
-                "height": "16",
-                "width": "16"
-            },
-            {
                 "name": "remove-16",
                 "size": "16",
                 "height": "16",
                 "width": "16"
             },
+            { "name": "reply-16", "size": "16", "height": "16", "width": "16" },
+            { "name": "reply-24", "size": "24", "height": "24", "width": "24" },
             {
                 "name": "remove-24",
                 "size": "24",
@@ -3558,34 +3566,13 @@
                 "width": "24"
             },
             {
-                "name": "relaxed-grid-filled-24",
-                "size": "24",
-                "height": "24",
-                "width": "24"
-            },
-            { "name": "reply-16", "size": "16", "height": "16", "width": "16" },
-            { "name": "reply-24", "size": "24", "height": "24", "width": "24" },
-            {
                 "name": "return-16",
                 "size": "16",
                 "height": "16",
                 "width": "16"
             },
             {
-                "name": "ribbon-24",
-                "size": "24",
-                "height": "24",
-                "width": "24"
-            },
-            {
-                "name": "ringgit-16",
-                "size": "16",
-                "height": "16",
-                "width": "16"
-            },
-            { "name": "rim-24", "size": "24", "height": "24", "width": "24" },
-            {
-                "name": "rotate-24",
+                "name": "return-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
@@ -3596,12 +3583,19 @@
                 "height": "16",
                 "width": "16"
             },
-            { "name": "rim-16", "size": "16", "height": "16", "width": "16" },
             {
-                "name": "rotate-landscape-left-24",
+                "name": "ribbon-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
+            },
+            { "name": "rim-16", "size": "16", "height": "16", "width": "16" },
+            { "name": "rim-24", "size": "24", "height": "24", "width": "24" },
+            {
+                "name": "ringgit-16",
+                "size": "16",
+                "height": "16",
+                "width": "16"
             },
             {
                 "name": "ringgit-24",
@@ -3610,52 +3604,59 @@
                 "width": "24"
             },
             {
-                "name": "return-24",
+                "name": "rotate-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
             },
-            { "name": "ruler-16", "size": "16", "height": "16", "width": "16" },
             {
-                "name": "rotate-portrait-right-24",
+                "name": "rotate-landscape-left-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
             },
-            { "name": "ruler-24", "size": "24", "height": "24", "width": "24" },
-            {
-                "name": "rotate-portrait-left-24",
-                "size": "24",
-                "height": "24",
-                "width": "24"
-            },
-            { "name": "rupee-16", "size": "16", "height": "16", "width": "16" },
             {
                 "name": "rotate-landscape-right-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
             },
-            { "name": "rupee-24", "size": "24", "height": "24", "width": "24" },
             {
-                "name": "satchel-24",
+                "name": "rotate-portrait-left-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
             },
             {
-                "name": "search-16",
-                "size": "16",
-                "height": "16",
-                "width": "16"
+                "name": "rotate-portrait-right-24",
+                "size": "24",
+                "height": "24",
+                "width": "24"
             },
+            { "name": "ruler-16", "size": "16", "height": "16", "width": "16" },
+            { "name": "ruler-24", "size": "24", "height": "24", "width": "24" },
+            { "name": "rupee-16", "size": "16", "height": "16", "width": "16" },
+            { "name": "rupee-24", "size": "24", "height": "24", "width": "24" },
             {
                 "name": "satchel-16",
                 "size": "16",
                 "height": "16",
                 "width": "16"
             },
+            {
+                "name": "satchel-24",
+                "size": "24",
+                "height": "24",
+                "width": "24"
+            },
             { "name": "scan-16", "size": "16", "height": "16", "width": "16" },
+            {
+                "name": "search-16",
+                "size": "16",
+                "height": "16",
+                "width": "16"
+            },
+            { "name": "scan-24", "size": "24", "height": "24", "width": "24" },
             {
                 "name": "search-20",
                 "size": "20",
@@ -3675,17 +3676,16 @@
                 "width": "64"
             },
             {
-                "name": "search-similar-16",
-                "size": "16",
-                "height": "16",
-                "width": "16"
-            },
-            { "name": "scan-24", "size": "24", "height": "24", "width": "24" },
-            {
                 "name": "search-filled-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
+            },
+            {
+                "name": "search-similar-16",
+                "size": "16",
+                "height": "16",
+                "width": "16"
             },
             {
                 "name": "search-similar-20",
@@ -3695,6 +3695,18 @@
             },
             {
                 "name": "search-similar-24",
+                "size": "24",
+                "height": "24",
+                "width": "24"
+            },
+            {
+                "name": "seasons-16",
+                "size": "16",
+                "height": "16",
+                "width": "16"
+            },
+            {
+                "name": "seasons-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
@@ -3718,24 +3730,11 @@
                 "width": "16"
             },
             {
-                "name": "selling-filled-24",
-                "size": "24",
-                "height": "24",
-                "width": "24"
+                "name": "selling-20",
+                "size": "20",
+                "height": "20",
+                "width": "20"
             },
-            {
-                "name": "seasons-16",
-                "size": "16",
-                "height": "16",
-                "width": "16"
-            },
-            {
-                "name": "seasons-24",
-                "size": "24",
-                "height": "24",
-                "width": "24"
-            },
-            { "name": "send-24", "size": "24", "height": "24", "width": "24" },
             {
                 "name": "selling-24",
                 "size": "24",
@@ -3743,10 +3742,23 @@
                 "width": "24"
             },
             {
-                "name": "selling-20",
-                "size": "20",
-                "height": "20",
-                "width": "20"
+                "name": "selling-filled-24",
+                "size": "24",
+                "height": "24",
+                "width": "24"
+            },
+            { "name": "send-24", "size": "24", "height": "24", "width": "24" },
+            {
+                "name": "settings-16",
+                "size": "16",
+                "height": "16",
+                "width": "16"
+            },
+            {
+                "name": "settings-24",
+                "size": "24",
+                "height": "24",
+                "width": "24"
             },
             {
                 "name": "share-android-16",
@@ -3756,6 +3768,12 @@
             },
             {
                 "name": "share-android-20",
+                "size": "20",
+                "height": "20",
+                "width": "20"
+            },
+            {
+                "name": "settings-20",
                 "size": "20",
                 "height": "20",
                 "width": "20"
@@ -3773,12 +3791,6 @@
                 "width": "16"
             },
             {
-                "name": "settings-20",
-                "size": "20",
-                "height": "20",
-                "width": "20"
-            },
-            {
                 "name": "share-ios-20",
                 "size": "20",
                 "height": "20",
@@ -3791,19 +3803,13 @@
                 "width": "24"
             },
             {
-                "name": "settings-16",
-                "size": "16",
-                "height": "16",
-                "width": "16"
-            },
-            {
-                "name": "share-ios-24",
+                "name": "ship-and-local-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
             },
             {
-                "name": "settings-24",
+                "name": "share-ios-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
@@ -3814,8 +3820,14 @@
                 "height": "16",
                 "width": "16"
             },
-            { "name": "shirt-24", "size": "24", "height": "24", "width": "24" },
             { "name": "shirt-16", "size": "16", "height": "16", "width": "16" },
+            { "name": "shirt-24", "size": "24", "height": "24", "width": "24" },
+            {
+                "name": "shoe-box-24",
+                "size": "24",
+                "height": "24",
+                "width": "24"
+            },
             {
                 "name": "shovel-16",
                 "size": "16",
@@ -3823,33 +3835,21 @@
                 "width": "16"
             },
             {
-                "name": "shoe-box-24",
+                "name": "shovel-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
             },
             { "name": "show-16", "size": "16", "height": "16", "width": "16" },
             {
-                "name": "ship-and-local-24",
-                "size": "24",
-                "height": "24",
-                "width": "24"
-            },
-            { "name": "show-24", "size": "24", "height": "24", "width": "24" },
-            {
-                "name": "shovel-24",
-                "size": "24",
-                "height": "24",
-                "width": "24"
-            },
-            {
                 "name": "small-box-16",
                 "size": "16",
                 "height": "16",
                 "width": "16"
             },
+            { "name": "show-24", "size": "24", "height": "24", "width": "24" },
             {
-                "name": "sneaker-24",
+                "name": "small-letter-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
@@ -3861,24 +3861,22 @@
                 "width": "16"
             },
             {
-                "name": "small-letter-24",
+                "name": "sneaker-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
             },
-            { "name": "sort-12", "size": "12", "height": "12", "width": "12" },
             {
                 "name": "snowflake-16",
                 "size": "16",
                 "height": "16",
                 "width": "16"
             },
-            { "name": "sort-16", "size": "16", "height": "16", "width": "16" },
             {
-                "name": "snowmobile-16",
-                "size": "16",
-                "height": "16",
-                "width": "16"
+                "name": "snowflake-24",
+                "size": "24",
+                "height": "24",
+                "width": "24"
             },
             {
                 "name": "snowmobile-24",
@@ -3887,17 +3885,25 @@
                 "width": "24"
             },
             {
+                "name": "snowmobile-16",
+                "size": "16",
+                "height": "16",
+                "width": "16"
+            },
+            {
                 "name": "small-box-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
             },
+            { "name": "sort-16", "size": "16", "height": "16", "width": "16" },
             { "name": "sort-24", "size": "24", "height": "24", "width": "24" },
+            { "name": "sort-12", "size": "12", "height": "12", "width": "12" },
             {
-                "name": "sort-down-12",
-                "size": "12",
-                "height": "12",
-                "width": "12"
+                "name": "sparkline-down-16",
+                "size": "16",
+                "height": "16",
+                "width": "16"
             },
             {
                 "name": "sort-up-12",
@@ -3906,16 +3912,16 @@
                 "width": "12"
             },
             {
-                "name": "sparkline-down-16",
-                "size": "16",
-                "height": "16",
-                "width": "16"
-            },
-            {
                 "name": "sparkline-down-20",
                 "size": "20",
                 "height": "20",
                 "width": "20"
+            },
+            {
+                "name": "sort-down-12",
+                "size": "12",
+                "height": "12",
+                "width": "12"
             },
             {
                 "name": "sparkline-down-24",
@@ -3936,10 +3942,10 @@
                 "width": "24"
             },
             {
-                "name": "snowflake-24",
-                "size": "24",
-                "height": "24",
-                "width": "24"
+                "name": "sparkline-up-16",
+                "size": "16",
+                "height": "16",
+                "width": "16"
             },
             {
                 "name": "sparkline-up-filled-24",
@@ -3960,57 +3966,7 @@
                 "width": "24"
             },
             {
-                "name": "sparkline-up-16",
-                "size": "16",
-                "height": "16",
-                "width": "16"
-            },
-            {
-                "name": "split-view-24",
-                "size": "24",
-                "height": "24",
-                "width": "24"
-            },
-            {
                 "name": "split-payment-16",
-                "size": "16",
-                "height": "16",
-                "width": "16"
-            },
-            {
-                "name": "spring-leaf-16",
-                "size": "16",
-                "height": "16",
-                "width": "16"
-            },
-            {
-                "name": "star-empty-16",
-                "size": "16",
-                "height": "16",
-                "width": "16"
-            },
-            {
-                "name": "spring-leaf-24",
-                "size": "24",
-                "height": "24",
-                "width": "24"
-            },
-            { "name": "star-empty-40", "height": "40", "width": "40" },
-            {
-                "name": "split-view-filled-24",
-                "size": "24",
-                "height": "24",
-                "width": "24"
-            },
-            {
-                "name": "star-filled-24",
-                "size": "24",
-                "height": "24",
-                "width": "24"
-            },
-            { "name": "star-filled-40", "height": "40", "width": "40" },
-            {
-                "name": "star-filled-16",
                 "size": "16",
                 "height": "16",
                 "width": "16"
@@ -4022,10 +3978,60 @@
                 "width": "24"
             },
             {
+                "name": "split-view-filled-24",
+                "size": "24",
+                "height": "24",
+                "width": "24"
+            },
+            {
+                "name": "spring-leaf-16",
+                "size": "16",
+                "height": "16",
+                "width": "16"
+            },
+            {
+                "name": "split-view-24",
+                "size": "24",
+                "height": "24",
+                "width": "24"
+            },
+            {
+                "name": "spring-leaf-24",
+                "size": "24",
+                "height": "24",
+                "width": "24"
+            },
+            {
+                "name": "star-empty-16",
+                "size": "16",
+                "height": "16",
+                "width": "16"
+            },
+            {
                 "name": "star-empty-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
+            },
+            { "name": "star-empty-40", "height": "40", "width": "40" },
+            {
+                "name": "star-filled-16",
+                "size": "16",
+                "height": "16",
+                "width": "16"
+            },
+            {
+                "name": "star-filled-24",
+                "size": "24",
+                "height": "24",
+                "width": "24"
+            },
+            { "name": "star-filled-40", "height": "40", "width": "40" },
+            {
+                "name": "star-half-16-colored",
+                "size": "16-colored",
+                "height": "16",
+                "width": "16"
             },
             {
                 "name": "star-half-24-colored",
@@ -4052,25 +4058,26 @@
                 "width": "24"
             },
             {
-                "name": "stepper-upcoming-24",
-                "size": "24",
-                "height": "25",
-                "width": "24"
-            },
-            { "name": "store-24", "size": "24", "height": "24", "width": "24" },
-            { "name": "store-16", "size": "16", "height": "16", "width": "16" },
-            {
                 "name": "stepper-confirmation-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
             },
             {
-                "name": "star-half-16-colored",
-                "size": "16-colored",
-                "height": "16",
-                "width": "16"
+                "name": "stepper-current-24",
+                "size": "24",
+                "height": "24",
+                "width": "24"
             },
+            {
+                "name": "stepper-upcoming-24",
+                "size": "24",
+                "height": "25",
+                "width": "24"
+            },
+            { "name": "store-16", "size": "16", "height": "16", "width": "16" },
+            { "name": "store-24", "size": "24", "height": "24", "width": "24" },
+            { "name": "store-64", "size": "64", "height": "64", "width": "64" },
             {
                 "name": "store-filled-24",
                 "size": "24",
@@ -4089,23 +4096,28 @@
                 "height": "24",
                 "width": "24"
             },
-            { "name": "swap-24", "size": "24", "height": "24", "width": "24" },
             { "name": "swap-16", "size": "16", "height": "16", "width": "16" },
-            { "name": "store-64", "size": "64", "height": "64", "width": "64" },
+            { "name": "swap-24", "size": "24", "height": "24", "width": "24" },
             {
-                "name": "text-messaging-16",
-                "size": "16",
-                "height": "16",
-                "width": "16"
-            },
-            {
-                "name": "stepper-current-24",
+                "name": "switch-camera-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
             },
             {
                 "name": "target-16",
+                "size": "16",
+                "height": "16",
+                "width": "16"
+            },
+            {
+                "name": "target-24",
+                "size": "24",
+                "height": "24",
+                "width": "24"
+            },
+            {
+                "name": "text-messaging-16",
                 "size": "16",
                 "height": "16",
                 "width": "16"
@@ -4129,16 +4141,10 @@
                 "width": "64"
             },
             {
-                "name": "target-24",
-                "size": "24",
-                "height": "24",
-                "width": "24"
-            },
-            {
-                "name": "the-ebay-vault-24",
-                "size": "24",
-                "height": "24",
-                "width": "24"
+                "name": "text-size-16",
+                "size": "16",
+                "height": "16",
+                "width": "16"
             },
             {
                 "name": "the-ebay-vault-16",
@@ -4147,25 +4153,13 @@
                 "width": "16"
             },
             {
-                "name": "text-size-16",
-                "size": "16",
-                "height": "16",
-                "width": "16"
-            },
-            {
-                "name": "text-size-24",
+                "name": "the-ebay-vault-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
             },
             {
-                "name": "thumb-down-filled-20",
-                "size": "20",
-                "height": "20",
-                "width": "20"
-            },
-            {
-                "name": "thumb-down-24",
+                "name": "text-size-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
@@ -4177,31 +4171,31 @@
                 "width": "16"
             },
             {
-                "name": "thumb-down-filled-16",
-                "size": "16",
-                "height": "16",
-                "width": "16"
-            },
-            {
-                "name": "thumb-down-filled-24",
-                "size": "24",
-                "height": "24",
-                "width": "24"
-            },
-            {
                 "name": "thumb-down-20",
                 "size": "20",
                 "height": "20",
                 "width": "20"
             },
             {
-                "name": "thumb-up-16",
+                "name": "thumb-down-24",
+                "size": "24",
+                "height": "24",
+                "width": "24"
+            },
+            {
+                "name": "thumb-down-filled-16",
                 "size": "16",
                 "height": "16",
                 "width": "16"
             },
             {
-                "name": "thumb-up-24",
+                "name": "thumb-down-filled-20",
+                "size": "20",
+                "height": "20",
+                "width": "20"
+            },
+            {
+                "name": "thumb-down-filled-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
@@ -4213,12 +4207,23 @@
                 "width": "20"
             },
             {
+                "name": "thumb-up-24",
+                "size": "24",
+                "height": "24",
+                "width": "24"
+            },
+            {
+                "name": "thumb-up-16",
+                "size": "16",
+                "height": "16",
+                "width": "16"
+            },
+            {
                 "name": "thumb-up-64",
                 "size": "64",
                 "height": "64",
                 "width": "64"
             },
-            { "name": "tick-16", "size": "16", "height": "16", "width": "16" },
             {
                 "name": "thumb-up-filled-16",
                 "size": "16",
@@ -4226,13 +4231,21 @@
                 "width": "16"
             },
             {
-                "name": "tiktok-24",
+                "name": "thumb-up-filled-20",
+                "size": "20",
+                "height": "20",
+                "width": "20"
+            },
+            {
+                "name": "thumb-up-filled-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
             },
+            { "name": "tick-16", "size": "16", "height": "16", "width": "16" },
+            { "name": "tick-24", "size": "24", "height": "24", "width": "24" },
             {
-                "name": "thumb-up-filled-24",
+                "name": "tiktok-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
@@ -4244,23 +4257,16 @@
                 "width": "24"
             },
             {
-                "name": "thumb-up-filled-20",
-                "size": "20",
-                "height": "20",
-                "width": "20"
-            },
-            { "name": "tick-24", "size": "24", "height": "24", "width": "24" },
-            {
                 "name": "toggle-mode-top-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
             },
             {
-                "name": "switch-camera-24",
-                "size": "24",
-                "height": "24",
-                "width": "24"
+                "name": "top-rated-plus-16",
+                "size": "16",
+                "height": "16",
+                "width": "16"
             },
             {
                 "name": "top-rated-plus-24",
@@ -4287,38 +4293,20 @@
                 "width": "16"
             },
             {
-                "name": "top-service-filled-16-colored",
-                "size": "16-colored",
-                "height": "16",
-                "width": "16"
-            },
-            {
                 "name": "top-service-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
             },
             {
-                "name": "top-service-filled-24-colored",
-                "size": "24-colored",
-                "height": "24",
-                "width": "24"
-            },
-            {
-                "name": "trading-card-24",
-                "size": "24",
-                "height": "24",
-                "width": "24"
-            },
-            {
-                "name": "top-rated-plus-16",
-                "size": "16",
+                "name": "top-service-filled-16-colored",
+                "size": "16-colored",
                 "height": "16",
                 "width": "16"
             },
             {
-                "name": "trading-card-edition-24",
-                "size": "24",
+                "name": "top-service-filled-24-colored",
+                "size": "24-colored",
                 "height": "24",
                 "width": "24"
             },
@@ -4329,7 +4317,19 @@
                 "width": "16"
             },
             {
-                "name": "translate-16",
+                "name": "trading-card-24",
+                "size": "24",
+                "height": "24",
+                "width": "24"
+            },
+            {
+                "name": "trading-card-edition-24",
+                "size": "24",
+                "height": "24",
+                "width": "24"
+            },
+            {
+                "name": "trading-card-grade-16",
                 "size": "16",
                 "height": "16",
                 "width": "16"
@@ -4339,6 +4339,24 @@
                 "size": "24",
                 "height": "24",
                 "width": "24"
+            },
+            {
+                "name": "transaction-24",
+                "size": "24",
+                "height": "24",
+                "width": "24"
+            },
+            {
+                "name": "translate-16",
+                "size": "16",
+                "height": "16",
+                "width": "16"
+            },
+            {
+                "name": "translate-20",
+                "size": "20",
+                "height": "20",
+                "width": "20"
             },
             {
                 "name": "translate-24",
@@ -4353,84 +4371,27 @@
                 "width": "13"
             },
             {
-                "name": "trend-up-16-fit",
-                "size": "16-fit",
-                "height": "16",
-                "width": "13"
-            },
-            {
                 "name": "trophy-16",
                 "size": "16",
                 "height": "16",
                 "width": "16"
             },
             {
+                "name": "trend-up-16-fit",
+                "size": "16-fit",
+                "height": "16",
+                "width": "13"
+            },
+            { "name": "truck-16", "size": "16", "height": "16", "width": "16" },
+            {
                 "name": "trophy-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
             },
-            {
-                "name": "trading-card-grade-16",
-                "size": "16",
-                "height": "16",
-                "width": "16"
-            },
-            { "name": "truck-16", "size": "16", "height": "16", "width": "16" },
-            { "name": "truck-64", "size": "64", "height": "64", "width": "64" },
-            {
-                "name": "translate-20",
-                "size": "20",
-                "height": "20",
-                "width": "20"
-            },
             { "name": "truck-24", "size": "24", "height": "24", "width": "24" },
             {
                 "name": "truck-shipped-16",
-                "size": "16",
-                "height": "16",
-                "width": "16"
-            },
-            {
-                "name": "twitter-24",
-                "size": "24",
-                "height": "24",
-                "width": "24"
-            },
-            { "name": "undo-16", "size": "16", "height": "16", "width": "16" },
-            { "name": "undo-24", "size": "24", "height": "24", "width": "24" },
-            {
-                "name": "unionpay-12-colored",
-                "size": "12-colored",
-                "height": "12",
-                "width": "20"
-            },
-            {
-                "name": "unionpay-18-colored",
-                "size": "18-colored",
-                "height": "18",
-                "width": "30"
-            },
-            {
-                "name": "unionpay-24-colored",
-                "size": "24-colored",
-                "height": "24",
-                "width": "38"
-            },
-            {
-                "name": "transaction-24",
-                "size": "24",
-                "height": "24",
-                "width": "24"
-            },
-            {
-                "name": "unlock-24",
-                "size": "24",
-                "height": "24",
-                "width": "24"
-            },
-            {
-                "name": "unlock-16",
                 "size": "16",
                 "height": "16",
                 "width": "16"
@@ -4441,11 +4402,32 @@
                 "height": "24",
                 "width": "24"
             },
+            { "name": "truck-64", "size": "64", "height": "64", "width": "64" },
             {
-                "name": "unselect-all-24",
+                "name": "twitter-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
+            },
+            { "name": "undo-16", "size": "16", "height": "16", "width": "16" },
+            { "name": "undo-24", "size": "24", "height": "24", "width": "24" },
+            {
+                "name": "unionpay-18-colored",
+                "size": "18-colored",
+                "height": "18",
+                "width": "30"
+            },
+            {
+                "name": "unionpay-12-colored",
+                "size": "12-colored",
+                "height": "12",
+                "width": "20"
+            },
+            {
+                "name": "unionpay-24-colored",
+                "size": "24-colored",
+                "height": "24",
+                "width": "38"
             },
             {
                 "name": "unionpay-32-colored",
@@ -4454,10 +4436,16 @@
                 "width": "50"
             },
             {
-                "name": "venmo-12-colored",
-                "size": "12-colored",
-                "height": "12",
-                "width": "20"
+                "name": "unlock-16",
+                "size": "16",
+                "height": "16",
+                "width": "16"
+            },
+            {
+                "name": "unselect-all-24",
+                "size": "24",
+                "height": "24",
+                "width": "24"
             },
             {
                 "name": "upload-16",
@@ -4466,10 +4454,16 @@
                 "width": "16"
             },
             {
-                "name": "upload-24",
+                "name": "unlock-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
+            },
+            {
+                "name": "venmo-12-colored",
+                "size": "12-colored",
+                "height": "12",
+                "width": "20"
             },
             {
                 "name": "venmo-24-colored",
@@ -4482,6 +4476,18 @@
                 "size": "18-colored",
                 "height": "18",
                 "width": "30"
+            },
+            {
+                "name": "upload-24",
+                "size": "24",
+                "height": "24",
+                "width": "24"
+            },
+            {
+                "name": "venmo-32-colored",
+                "size": "32-colored",
+                "height": "32",
+                "width": "50"
             },
             {
                 "name": "verified-condition-16",
@@ -4497,22 +4503,10 @@
                 "width": "20"
             },
             {
-                "name": "wallet-24",
-                "size": "24",
+                "name": "visa-24-colored",
+                "size": "24-colored",
                 "height": "24",
-                "width": "24"
-            },
-            {
-                "name": "venmo-32-colored",
-                "size": "32-colored",
-                "height": "32",
-                "width": "50"
-            },
-            {
-                "name": "visa-18-colored",
-                "size": "18-colored",
-                "height": "18",
-                "width": "30"
+                "width": "38"
             },
             {
                 "name": "verified-condition-24",
@@ -4521,10 +4515,10 @@
                 "width": "24"
             },
             {
-                "name": "visa-24-colored",
-                "size": "24-colored",
-                "height": "24",
-                "width": "38"
+                "name": "visa-18-colored",
+                "size": "18-colored",
+                "height": "18",
+                "width": "30"
             },
             {
                 "name": "visa-32-colored",
@@ -4533,16 +4527,34 @@
                 "width": "50"
             },
             {
-                "name": "wallet-64",
-                "size": "64",
-                "height": "64",
-                "width": "64"
+                "name": "wallet-24",
+                "size": "24",
+                "height": "24",
+                "width": "24"
+            },
+            {
+                "name": "wallet-balance-18-colored",
+                "size": "18-colored",
+                "height": "18",
+                "width": "30"
             },
             {
                 "name": "wallet-balance-12-colored",
                 "size": "12-colored",
                 "height": "12",
                 "width": "20"
+            },
+            {
+                "name": "wallet-64",
+                "size": "64",
+                "height": "64",
+                "width": "64"
+            },
+            {
+                "name": "wallet-balance-24-colored",
+                "size": "24-colored",
+                "height": "24",
+                "width": "38"
             },
             {
                 "name": "wallet-balance-32-colored",
@@ -4552,18 +4564,14 @@
             },
             { "name": "watch-16", "size": "16", "height": "16", "width": "16" },
             {
-                "name": "wallet-balance-24-colored",
-                "size": "24-colored",
-                "height": "24",
-                "width": "38"
-            },
-            { "name": "watch-24", "size": "24", "height": "24", "width": "24" },
-            {
                 "name": "whatsapp-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
             },
+            { "name": "won-16", "size": "16", "height": "16", "width": "16" },
+            { "name": "watch-24", "size": "24", "height": "24", "width": "24" },
+            { "name": "won-24", "size": "24", "height": "24", "width": "24" },
             {
                 "name": "wrench-16",
                 "size": "16",
@@ -4571,21 +4579,7 @@
                 "width": "16"
             },
             {
-                "name": "wallet-balance-18-colored",
-                "size": "18-colored",
-                "height": "18",
-                "width": "30"
-            },
-            { "name": "won-16", "size": "16", "height": "16", "width": "16" },
-            { "name": "won-24", "size": "24", "height": "24", "width": "24" },
-            {
                 "name": "wrench-24",
-                "size": "24",
-                "height": "24",
-                "width": "24"
-            },
-            {
-                "name": "youtube-24",
                 "size": "24",
                 "height": "24",
                 "width": "24"
@@ -4593,15 +4587,15 @@
             { "name": "yuan-16", "size": "16", "height": "16", "width": "16" },
             { "name": "yuan-24", "size": "24", "height": "24", "width": "24" },
             { "name": "zloty-16", "size": "16", "height": "16", "width": "16" },
+            {
+                "name": "youtube-24",
+                "size": "24",
+                "height": "24",
+                "width": "24"
+            },
             { "name": "zloty-24", "size": "24", "height": "24", "width": "24" },
             {
                 "name": "zoom-in-16",
-                "size": "16",
-                "height": "16",
-                "width": "16"
-            },
-            {
-                "name": "zoom-out-16",
                 "size": "16",
                 "height": "16",
                 "width": "16"
@@ -4617,6 +4611,12 @@
                 "size": "24",
                 "height": "24",
                 "width": "24"
+            },
+            {
+                "name": "zoom-out-16",
+                "size": "16",
+                "height": "16",
+                "width": "16"
             }
         ],
         "skipDocs": [

--- a/packages/skin/src/components/master-icons.marko
+++ b/packages/skin/src/components/master-icons.marko
@@ -3081,6 +3081,7 @@
       rx="1.5"
       fill="#fff"
       stroke="#191919"
+      stroke-width="1"
     />
     <path
       fill-rule="evenodd"
@@ -3116,6 +3117,7 @@
       rx="1.5"
       fill="#fff"
       stroke="#191919"
+      stroke-width="1"
     />
     <path
       fill-rule="evenodd"
@@ -3151,6 +3153,7 @@
       rx="1.5"
       fill="#fff"
       stroke="#191919"
+      stroke-width="1"
     />
     <path
       fill-rule="evenodd"
@@ -3186,6 +3189,7 @@
       rx="1.5"
       fill="#fff"
       stroke="#191919"
+      stroke-width="1"
     />
     <path
       fill-rule="evenodd"

--- a/packages/skin/src/routes/static/icon/icon-ebay-balance-12-colored.svg
+++ b/packages/skin/src/routes/static/icon/icon-ebay-balance-12-colored.svg
@@ -7,6 +7,7 @@
     rx="1.5"
     fill="#fff"
     stroke="#191919"
+    stroke-width="1"
   />
   <path
     fill-rule="evenodd"

--- a/packages/skin/src/routes/static/icon/icon-ebay-balance-18-colored.svg
+++ b/packages/skin/src/routes/static/icon/icon-ebay-balance-18-colored.svg
@@ -7,6 +7,7 @@
     rx="1.5"
     fill="#fff"
     stroke="#191919"
+    stroke-width="1"
   />
   <path
     fill-rule="evenodd"

--- a/packages/skin/src/routes/static/icon/icon-ebay-balance-24-colored.svg
+++ b/packages/skin/src/routes/static/icon/icon-ebay-balance-24-colored.svg
@@ -7,6 +7,7 @@
     rx="1.5"
     fill="#fff"
     stroke="#191919"
+    stroke-width="1"
   />
   <path
     fill-rule="evenodd"

--- a/packages/skin/src/routes/static/icon/icon-ebay-balance-32-colored.svg
+++ b/packages/skin/src/routes/static/icon/icon-ebay-balance-32-colored.svg
@@ -7,6 +7,7 @@
     rx="1.5"
     fill="#fff"
     stroke="#191919"
+    stroke-width="1"
   />
   <path
     fill-rule="evenodd"

--- a/packages/skin/src/routes/static/icons.svg
+++ b/packages/skin/src/routes/static/icons.svg
@@ -3081,6 +3081,7 @@
       rx="1.5"
       fill="#fff"
       stroke="#191919"
+      stroke-width="1"
     />
     <path
       fill-rule="evenodd"
@@ -3116,6 +3117,7 @@
       rx="1.5"
       fill="#fff"
       stroke="#191919"
+      stroke-width="1"
     />
     <path
       fill-rule="evenodd"
@@ -3151,6 +3153,7 @@
       rx="1.5"
       fill="#fff"
       stroke="#191919"
+      stroke-width="1"
     />
     <path
       fill-rule="evenodd"
@@ -3186,6 +3189,7 @@
       rx="1.5"
       fill="#fff"
       stroke="#191919"
+      stroke-width="1"
     />
     <path
       fill-rule="evenodd"

--- a/packages/skin/src/svg/icon/icon-ebay-balance-12-colored.svg
+++ b/packages/skin/src/svg/icon/icon-ebay-balance-12-colored.svg
@@ -7,6 +7,7 @@
     rx="1.5"
     fill="#fff"
     stroke="#191919"
+    stroke-width="1"
   />
   <path
     fill-rule="evenodd"

--- a/packages/skin/src/svg/icon/icon-ebay-balance-18-colored.svg
+++ b/packages/skin/src/svg/icon/icon-ebay-balance-18-colored.svg
@@ -7,6 +7,7 @@
     rx="1.5"
     fill="#fff"
     stroke="#191919"
+    stroke-width="1"
   />
   <path
     fill-rule="evenodd"

--- a/packages/skin/src/svg/icon/icon-ebay-balance-24-colored.svg
+++ b/packages/skin/src/svg/icon/icon-ebay-balance-24-colored.svg
@@ -7,6 +7,7 @@
     rx="1.5"
     fill="#fff"
     stroke="#191919"
+    stroke-width="1"
   />
   <path
     fill-rule="evenodd"

--- a/packages/skin/src/svg/icon/icon-ebay-balance-32-colored.svg
+++ b/packages/skin/src/svg/icon/icon-ebay-balance-32-colored.svg
@@ -7,6 +7,7 @@
     rx="1.5"
     fill="#fff"
     stroke="#191919"
+    stroke-width="1"
   />
   <path
     fill-rule="evenodd"

--- a/packages/skin/src/svg/icons.svg
+++ b/packages/skin/src/svg/icons.svg
@@ -3081,6 +3081,7 @@
       rx="1.5"
       fill="#fff"
       stroke="#191919"
+      stroke-width="1"
     />
     <path
       fill-rule="evenodd"
@@ -3116,6 +3117,7 @@
       rx="1.5"
       fill="#fff"
       stroke="#191919"
+      stroke-width="1"
     />
     <path
       fill-rule="evenodd"
@@ -3151,6 +3153,7 @@
       rx="1.5"
       fill="#fff"
       stroke="#191919"
+      stroke-width="1"
     />
     <path
       fill-rule="evenodd"
@@ -3186,6 +3189,7 @@
       rx="1.5"
       fill="#fff"
       stroke="#191919"
+      stroke-width="1"
     />
     <path
       fill-rule="evenodd"


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #214 

<!-- Select which type of PR this is -->
- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
I manually added the missing stroke to the ebay balance icons.

## Screenshots

**Before**

<kbd><img width="107" height="104" alt="image" src="https://github.com/user-attachments/assets/251a8d90-d25f-41a5-8e45-43986ee115de" /></kbd>

**After**

<kbd><img width="105" height="105" alt="image" src="https://github.com/user-attachments/assets/8c830561-e351-4819-a1f4-caf2e060aa73" /></kbd>


## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue

<!-- For Markup Changes -->
- [ ] I verify the markup will not be a breaking change (if not a major release)
- [ ] I verify the MIND pattern for the component has been created/revised

<!-- For CSS changes -->
- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [ ] I tested the UI in dark mode and RTL mode
- [ ] I added/updated/removed Storybook coverage as appropriate
