### PR TITLE
fix(combobox): initialize makeup-expander only when there are visible options

### DIFF
--- a/.changeset/funny-beans-yell.md
+++ b/.changeset/funny-beans-yell.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ui-core-react": patch
+---
+
+fix(combobox): initialize makeup-expander only when there are visible options

--- a/packages/ebayui-core-react/src/common/dropdown.ts
+++ b/packages/ebayui-core-react/src/common/dropdown.ts
@@ -44,7 +44,7 @@ export function useFloatingDropdown({ open, options }: FloatingDropdownHookArgs)
 
 type ElementId = string;
 export type ExpanderHookArgs<T extends HTMLElement> = {
-    ref: React.MutableRefObject<T>;
+    ref: React.MutableRefObject<T> | null;
     expanded?: boolean;
     options: {
         contentSelector: string;
@@ -90,12 +90,12 @@ export function useExpander<T extends HTMLElement>(
                 onCollapse?.();
             }
 
-            ref.current?.addEventListener("expander-expand", handleExpand);
-            ref.current?.addEventListener("expander-collapse", handleCollapse);
+            ref?.current?.addEventListener("expander-expand", handleExpand);
+            ref?.current?.addEventListener("expander-collapse", handleCollapse);
 
             return () => {
-                ref.current?.removeEventListener("expander-expand", handleExpand);
-                ref.current?.removeEventListener("expander-collapse", handleCollapse);
+                ref?.current?.removeEventListener("expander-expand", handleExpand);
+                ref?.current?.removeEventListener("expander-collapse", handleCollapse);
             };
         },
         () => expander.current?.expanded,
@@ -103,7 +103,7 @@ export function useExpander<T extends HTMLElement>(
     );
 
     useEffect(() => {
-        if (ref.current) {
+        if (ref?.current) {
             expander.current = new Expander(ref.current, options);
         }
 

--- a/packages/ebayui-core-react/src/ebay-chips-combobox/__tests__/index.spec.tsx
+++ b/packages/ebayui-core-react/src/ebay-chips-combobox/__tests__/index.spec.tsx
@@ -196,4 +196,21 @@ describe("EbayChipsCombobox", () => {
         expect(options.length).toBe(1);
         expect(options[0]).toHaveTextContent("Option 3");
     });
+
+    it("should properly render when all options are selected", async () => {
+        render(
+            <EbayChipsCombobox defaultSelected={["Option 1", "Option 2", "Option 3"]} placeholder="Select options">
+                <EbayComboboxOption text="Option 1" />
+                <EbayComboboxOption text="Option 2" />
+                <EbayComboboxOption text="Option 3" />
+            </EbayChipsCombobox>,
+        );
+
+        const optionToRemove = screen.getByLabelText("Remove Option 2");
+        await userEvent.click(optionToRemove);
+
+        const options = screen.getAllByRole("option");
+        expect(options.length).toBe(1);
+        expect(options[0]).toBeVisible();
+    });
 });


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #

<!-- Select which type of PR this is -->
- [ ] This PR contains CSS changes
- [x] This PR does not contain CSS changes

## Description
<!-- Briefly describe the proposed changes -->
- Initialize makeup-expander only when visibleOptions are available

## Notes
<!-- Be sure to mention anything unusual, out-of-scope or new technical debt, etc -->

## Screenshots
<!-- Upload screenshots of UI before & after these changes -->

## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [ ] I verify the build is in a non-broken state
- [ ] I verify all changes are within scope of the linked issue

<!-- For Markup Changes -->
- [ ] I verify the markup will not be a breaking change (if not a major release)
- [ ] I verify the MIND pattern for the component has been created/revised

<!-- For CSS changes -->
- [ ] I regenerated all CSS files under dist folder
- [ ] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [ ] I tested the UI in dark mode and RTL mode
- [ ] I added/updated/removed Storybook coverage as appropriate
