### PR TITLE
fix(EbayTooltip): close tooltip on Esc key

### DIFF
--- a/.changeset/tiny-files-kneel.md
+++ b/.changeset/tiny-files-kneel.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ui-core-react": patch
+---
+
+fix(EbayTooltip): close tooltip on Esc keydown

--- a/packages/ebayui-core-react/src/ebay-tooltip/__tests__/index.spec.tsx
+++ b/packages/ebayui-core-react/src/ebay-tooltip/__tests__/index.spec.tsx
@@ -94,6 +94,14 @@ describe("<EbayTooltip>", () => {
             fireEvent.focus(wrapper.getByText("Info"));
             checkIsExpanded(wrapper);
         });
+
+        it("should collapse the tooltip on pressing 'Esc'", () => {
+            const wrapper = renderComponent();
+            fireEvent.focus(wrapper.getByText("Info"));
+            checkIsExpanded(wrapper);
+            fireEvent.keyDown(document, { key: "Esc" });
+            checkIsCollapsed(wrapper);
+        });
     });
 
     describe("on tooltip blur", () => {

--- a/packages/ebayui-core-react/src/ebay-tooltip/ebay-tooltip.tsx
+++ b/packages/ebayui-core-react/src/ebay-tooltip/ebay-tooltip.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties, FC, useRef } from "react";
+import React, { CSSProperties, FC, useEffect, useRef } from "react";
 import { findComponent } from "../common/component-utils";
 import {
     Tooltip,
@@ -10,6 +10,7 @@ import {
 } from "../common/tooltip-utils";
 import EbayTooltipContent from "./ebay-tooltip-content";
 import EbayTooltipHost from "./ebay-tooltip-host";
+import { handleEscapeKeydown } from "../events";
 
 // @todo: this type is weird, we should improve it
 type Props = Omit<TooltipProps, "ref"> & {
@@ -36,6 +37,20 @@ const EbayTooltip: FC<Props> = ({
 }) => {
     const { isExpanded, expandTooltip, collapseTooltip } = useTooltip({ onCollapse, onExpand });
     const timeoutRef = useRef<ReturnType<typeof setTimeout>>(null);
+
+    useEffect(() => {
+        const handleKeydown = function (event: KeyboardEvent) {
+            handleEscapeKeydown(event as unknown as React.KeyboardEvent, collapseTooltip);
+        };
+
+        if (isExpanded) {
+            document.addEventListener("keydown", handleKeydown);
+        }
+
+        return () => {
+            document.removeEventListener("keydown", handleKeydown);
+        };
+    }, [isExpanded]);
 
     const handleOnMouseEnter = (event) => {
         onMouseEnter(event);


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #235 

<!-- Select which type of PR this is -->
- [ ] This PR contains CSS changes
- [x] This PR does not contain CSS changes

## Description
<!-- Briefly describe the proposed changes -->
- Add `Esc` key press handler on tooltip

## Notes
<!-- Be sure to mention anything unusual, out-of-scope or new technical debt, etc -->

## Screenshots
<!-- Upload screenshots of UI before & after these changes -->

## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [ ] I verify the build is in a non-broken state
- [ ] I verify all changes are within scope of the linked issue

<!-- For Markup Changes -->
- [ ] I verify the markup will not be a breaking change (if not a major release)
- [ ] I verify the MIND pattern for the component has been created/revised

<!-- For CSS changes -->
- [ ] I regenerated all CSS files under dist folder
- [ ] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [ ] I tested the UI in dark mode and RTL mode
- [ ] I added/updated/removed Storybook coverage as appropriate
