### PR TITLE
fix(EbayMenuButton): update checked items when children "checked" changes

### DIFF
--- a/.changeset/slimy-hats-sleep.md
+++ b/.changeset/slimy-hats-sleep.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ui-core-react": patch
+---
+
+fix(EbayMenuButton): update checked items when children checked changes

--- a/packages/ebayui-core-react/src/ebay-menu-button/menu-button.tsx
+++ b/packages/ebayui-core-react/src/ebay-menu-button/menu-button.tsx
@@ -51,6 +51,11 @@ const EbayMenuButton: FC<MenuButtonProps> = ({
     const menuItems = filterByType<typeof EbayMenuButtonItem>(children, [EbayMenuButtonItem, EbayMenuButtonSeparator]);
     const defaultIndexes = menuItems.map((item) => Boolean(item.props.checked));
     const [checkedIndexes, setCheckedIndexes] = useState<boolean[]>(defaultIndexes);
+    useEffect(() => {
+        if (defaultIndexes.join("|") !== checkedIndexes.join("|")) {
+            setCheckedIndexes(defaultIndexes);
+        }
+    }, [defaultIndexes.join("|")]);
 
     const menuButtonLabel = findComponent(children, EbayMenuButtonLabel);
     const icon = findComponent(children, EbayIcon);


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #

<!-- Select which type of PR this is -->
- [ ] This PR contains CSS changes
- [x] This PR does not contain CSS changes

## Description
<!-- Briefly describe the proposed changes -->
- Make sure to update internal `checkedIndexes` state when the checked items changes.

## Screenshots
<!-- Upload screenshots of UI before & after these changes -->

## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [ ] I verify the build is in a non-broken state
- [ ] I verify all changes are within scope of the linked issue

<!-- For Markup Changes -->
- [ ] I verify the markup will not be a breaking change (if not a major release)
- [ ] I verify the MIND pattern for the component has been created/revised

<!-- For CSS changes -->
- [ ] I regenerated all CSS files under dist folder
- [ ] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [ ] I tested the UI in dark mode and RTL mode
- [ ] I added/updated/removed Storybook coverage as appropriate
