### PR TITLE
fix(section-notice): remove spacing on the right for CTA without dismiss button

### DIFF
--- a/packages/skin/dist/section-notice/section-notice.css
+++ b/packages/skin/dist/section-notice/section-notice.css
@@ -33,6 +33,10 @@ span[role="region"].section-notice {
 .section-notice__cta a {
     white-space: nowrap;
 }
+.section-notice:not(:has(.section-notice__dismiss)) .section-notice__cta {
+    margin-right: 0;
+    padding-right: 0;
+}
 .section-notice__title:not(:only-child) {
     font-weight: 700;
 }
@@ -126,6 +130,9 @@ p.section-notice__cta {
     }
     .section-notice__footer {
         padding-left: var(--spacing-200);
+    }
+    .section-notice__dismiss {
+        text-decoration: none;
     }
 }
 [dir="rtl"] .section-notice__footer {

--- a/packages/skin/src/sass/section-notice/section-notice.scss
+++ b/packages/skin/src/sass/section-notice/section-notice.scss
@@ -46,6 +46,12 @@ span[role="region"].section-notice {
     white-space: nowrap;
 }
 
+/* remove padding and margin from CTA when there's no dismiss button */
+.section-notice:not(:has(.section-notice__dismiss)) .section-notice__cta {
+    margin-right: 0;
+    padding-right: 0;
+}
+
 /* legacy version with separate bold heading */
 .section-notice__title:not(:only-child) {
     font-weight: bold;
@@ -156,6 +162,10 @@ p.section-notice__cta {
 
     .section-notice__footer {
         padding-left: var(--spacing-200);
+    }
+
+    .section-notice__dismiss {
+        text-decoration: none;
     }
 }
 

--- a/packages/skin/src/sass/section-notice/stories/icon-16.stories.js
+++ b/packages/skin/src/sass/section-notice/stories/icon-16.stories.js
@@ -46,6 +46,24 @@ export const linkCTA = () => `
 `;
 
 // known issue: https://github.com/eBay/skin/issues/2146
+export const linkCTAInsideCTASection = () => `
+<div class="section-notice section-notice--confirmation" role="region">
+    <div class="section-notice__header" role="region" aria-roledescription="Notice">
+        <svg aria-hidden="true" class="icon icon--16">
+            <use href="#icon-confirmation-filled-16"></use>
+        </svg>
+    </div>
+    <div class="section-notice__main">
+        <h3 class="section-notice__title">Notification Title</h3>
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+    </div>
+    <p class="section-notice__cta">
+        <a href="https://www.ebay.com">Action</a>
+    </p>
+</div>
+`;
+
+// known issue: https://github.com/eBay/skin/issues/2146
 export const fakeLinkCTA = () => `
 <div class="section-notice section-notice--confirmation" role="region">
     <div class="section-notice__header" role="region" aria-roledescription="Notice">


### PR DESCRIPTION

<!-- Insert GitHub issue number below -->
Partially fixes #18 spacing on the desktop issue.

<!-- Select which type of PR this is -->
- [x] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
The current implementation of section-notice with CTA has padding to the right which is not needed on desktop. We removed the padding and created a new Section Notice story called Link CTA inside CTA Section for this.

## Notes
This is only applied to CTA without dismiss button.

## Screenshots
dWeb
<img width="1198" height="490" alt="image" src="https://github.com/user-attachments/assets/107cf0c0-caeb-43b8-b5cd-27e3994c47da" />

mWeb
<img width="1198" height="432" alt="image" src="https://github.com/user-attachments/assets/faf9cebb-6aa9-450d-ac7a-4f9a1bc2b167" />


## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [x] I verify the build is in a non-broken state
- [x] I verify all changes are within scope of the linked issue

<!-- For Markup Changes -->
- [ ] I verify the markup will not be a breaking change (if not a major release)
- [ ] I verify the MIND pattern for the component has been created/revised

<!-- For CSS changes -->
- [x] I regenerated all CSS files under dist folder
- [x] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [ ] I tested the UI in dark mode and RTL mode
- [x] I added/updated/removed Storybook coverage as appropriate