### PR TITLE
fix(EbayLightboxDialog): observe child nodes changes to refresh keyboard trap

### DIFF
--- a/.changeset/plain-tigers-stay.md
+++ b/.changeset/plain-tigers-stay.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ui-core-react": patch
+---
+
+fix(EbayLightboxDialog): observe child nodes changes to refresh keyboard trap

--- a/packages/ebayui-core-react/src/ebay-dialog-base/components/dialogBase.tsx
+++ b/packages/ebayui-core-react/src/ebay-dialog-base/components/dialogBase.tsx
@@ -108,9 +108,25 @@ export const DialogBase: FC<DialogBaseProps<HTMLElement>> = ({
     };
 
     useEffect(() => {
+        let observer: MutationObserver;
+
         if (open && isModal) {
+            observer = new MutationObserver((records) => {
+                for (const record of records) {
+                    if (record.type === "childList") {
+                        keyboardTrap.refresh();
+                        break;
+                    }
+                }
+            });
             screenreaderTrap.trap(drawerBaseEl.current);
             keyboardTrap.trap(drawerBaseEl.current);
+            observer.observe(drawerBaseEl.current, {
+                childList: true,
+                subtree: true,
+                attributes: false,
+                characterData: false,
+            });
         } else {
             screenreaderTrap.untrap();
             keyboardTrap.untrap();
@@ -118,8 +134,9 @@ export const DialogBase: FC<DialogBaseProps<HTMLElement>> = ({
         return () => {
             screenreaderTrap.untrap();
             keyboardTrap.untrap();
+            observer?.disconnect();
         };
-    });
+    }, [open, isModal]);
 
     useDialogAnimation({
         open,

--- a/packages/ebayui-core-react/src/ebay-lightbox-dialog/__tests__/index.stories.tsx
+++ b/packages/ebayui-core-react/src/ebay-lightbox-dialog/__tests__/index.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Meta, StoryFn } from "@storybook/react-vite";
 import { action } from "storybook/actions";
 import { EbayDialogFooter, EbayDialogHeader, EbayDialogPreviousButton } from "../../ebay-dialog-base";
@@ -356,12 +356,42 @@ export const Expressive: StoryFn<typeof EbayLightboxDialog> = (args) => {
     );
 };
 
+function LoadContent({ open }) {
+    const [isPending, setIsPending] = useState(true);
+
+    useEffect(() => {
+        let timeout: ReturnType<typeof setTimeout>;
+        if (open) {
+            timeout = setTimeout(() => {
+                setIsPending(false);
+            }, 1000);
+        } else {
+            setIsPending(true);
+        }
+
+        return () => {
+            clearTimeout(timeout);
+        };
+    }, [open]);
+
+    return isPending ? (
+        <div style={{ display: "flex", justifyContent: "center" }}>
+            <EbayProgressSpinner />
+        </div>
+    ) : (
+        <>
+            {textParagraph}
+            <p>
+                <a href="http://www.ebay.com">www.ebay.com</a>
+            </p>
+        </>
+    );
+}
+
 export const LazyContent: StoryFn<typeof EbayLightboxDialog> = (args) => {
     const [open, setOpen] = useState(false);
-    const [isPending, setIsPending] = useState(false);
     const close = () => {
         setOpen(false);
-        setIsPending(false);
     };
     return (
         <div>
@@ -369,8 +399,6 @@ export const LazyContent: StoryFn<typeof EbayLightboxDialog> = (args) => {
                 className="btn btn--secondary"
                 onClick={() => {
                     setOpen(!open);
-                    setIsPending(true);
-                    setTimeout(() => setIsPending(false), 1000);
                 }}
             >
                 Open Dialog
@@ -387,27 +415,7 @@ export const LazyContent: StoryFn<typeof EbayLightboxDialog> = (args) => {
                 a11yCloseText="Close"
             >
                 <EbayDialogHeader>Heading</EbayDialogHeader>
-                {isPending ? (
-                    <div style={{ display: "flex", justifyContent: "center" }}>
-                        <EbayProgressSpinner />
-                    </div>
-                ) : (
-                    <>
-                        {textParagraph}
-                        <p>
-                            <a href="http://www.ebay.com">www.ebay.com</a>
-                        </p>
-                    </>
-                )}
-
-                {isPending ? null : (
-                    <EbayDialogFooter>
-                        <EbayButton priority="primary" onClick={close}>
-                            OK
-                        </EbayButton>
-                        <EbayButton onClick={close}>Cancel</EbayButton>
-                    </EbayDialogFooter>
-                )}
+                <LoadContent open={open} />
             </EbayLightboxDialog>
         </div>
     );


### PR DESCRIPTION
<!-- Select which type of PR this is -->
- [ ] This PR contains CSS changes
- [x] This PR does not contain CSS changes

## Description
Add an observer on the dialog element that checks for nodes removal/addition and refresh the keyboard trap so it make sure the first and last focusable element are always up to date. This issue is visible when data fetching is executed inside the child component and the dialog component doesn't re-render.

## Notes
<!-- Be sure to mention anything unusual, out-of-scope or new technical debt, etc -->
The same issue is possible to happen in Marko, although data fetching on component level might not be common. @agliga let me know if you want me to implement the same on marko

## Screenshots
<!-- Upload screenshots of UI before & after these changes -->

## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [ ] I verify the build is in a non-broken state
- [ ] I verify all changes are within scope of the linked issue

<!-- For Markup Changes -->
- [ ] I verify the markup will not be a breaking change (if not a major release)
- [ ] I verify the MIND pattern for the component has been created/revised

<!-- For CSS changes -->
- [ ] I regenerated all CSS files under dist folder
- [ ] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [ ] I tested the UI in dark mode and RTL mode
- [ ] I added/updated/removed Storybook coverage as appropriate
