### PR TITLE
fix(toast): swapped margin to padding and added a stronger selector for toast close

### DIFF
--- a/.changeset/wide-carrots-invite.md
+++ b/.changeset/wide-carrots-invite.md
@@ -1,0 +1,5 @@
+---
+"@ebay/skin": patch
+---
+
+fix(toast): swapped margin to padding and added a stronger selector for toast close button

--- a/packages/skin/dist/toast-dialog/toast-dialog.css
+++ b/packages/skin/dist/toast-dialog/toast-dialog.css
@@ -61,7 +61,7 @@
 }
 
 .toast-dialog__window {
-    margin: var(--spacing-100) var(--spacing-200) var(--spacing-200);
+    padding: var(--spacing-100) var(--spacing-200) var(--spacing-200);
 }
 
 .toast-dialog__header {
@@ -72,7 +72,7 @@
 .toast-dialog__title {
     margin: 0;
 }
-button.toast-dialog__close {
+button.icon-btn.toast-dialog__close {
     align-self: flex-start;
     border: 0;
     color: var(
@@ -83,15 +83,15 @@ button.toast-dialog__close {
     margin-inline-start: auto;
     padding: 0;
 }
-button.toast-dialog__close:focus {
+button.icon-btn.toast-dialog__close:focus {
     outline: 2px solid var(--color-foreground-on-information);
 }
-button.toast-dialog__close:focus,
-button.toast-dialog__close:hover {
+button.icon-btn.toast-dialog__close:focus,
+button.icon-btn.toast-dialog__close:hover {
     color: var(--color-state-primary-hover);
 }
 
-button.toast-dialog__close > svg {
+button.icon-btn.toast-dialog__close > svg {
     fill: currentColor;
 }
 
@@ -175,6 +175,6 @@ button.toast-dialog__close > svg {
         width: auto;
     }
     .toast-dialog__window {
-        margin: var(--spacing-200) var(--spacing-300) var(--spacing-300);
+        padding: var(--spacing-200) var(--spacing-300) var(--spacing-300);
     }
 }

--- a/packages/skin/src/sass/toast-dialog/toast-dialog.scss
+++ b/packages/skin/src/sass/toast-dialog/toast-dialog.scss
@@ -65,7 +65,7 @@
 }
 
 .toast-dialog__window {
-    margin: var(--spacing-100) var(--spacing-200) var(--spacing-200);
+    padding: var(--spacing-100) var(--spacing-200) var(--spacing-200);
 }
 
 .toast-dialog__header {
@@ -80,7 +80,7 @@
 }
 
 /* inherits from .icon-btn */
-button.toast-dialog__close {
+button.icon-btn.toast-dialog__close {
     align-self: flex-start;
     border: 0;
     flex-shrink: 0;
@@ -101,7 +101,7 @@ button.toast-dialog__close {
     }
 }
 
-button.toast-dialog__close > svg {
+button.icon-btn.toast-dialog__close > svg {
     fill: currentColor;
 }
 
@@ -199,6 +199,6 @@ button.toast-dialog__close > svg {
     }
 
     .toast-dialog__window {
-        margin: var(--spacing-200) var(--spacing-300) var(--spacing-300);
+        padding: var(--spacing-200) var(--spacing-300) var(--spacing-300);
     }
 }


### PR DESCRIPTION
Fixes #239


- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
* Swapped margin to padding
* Depending on the order of the css files loaded there was a potential issue for styles on icon-btn overring the toast close button, so added a stronger selector


## Checklist
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue
- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [ ] I tested the UI in dark mode and RTL mode
- [ ] I added/updated/removed Storybook coverage as appropriate
