### PR TITLE
chore: updated pr and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/NEW-FEATURE-REQUEST.yml
+++ b/.github/ISSUE_TEMPLATE/NEW-FEATURE-REQUEST.yml
@@ -37,5 +37,5 @@ body:
       - label: Supports dark mode.
       - label: Supports responsive design.
       - label: Tokens have been provided (or already exist).
-      - label: Successful accessibility review with Core A11Y Team.
+      - label: Successful accessibility review with Core A11Y Team and MIND pattern is created.
       - label: Successful frontend review with eBayUI Team.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 <!-- Insert GitHub issue number below. An issue is required for all PRs -->
 
-Fixes #
+- Fixes #
 
 ## Description
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,33 +1,30 @@
-<!-- Insert GitHub issue number below -->
+<!-- Insert GitHub issue number below. An issue is required for all PRs -->
+
 Fixes #
 
-<!-- Select which type of PR this is -->
-- [ ] This PR contains CSS changes
-- [ ] This PR does not contain CSS changes
-
 ## Description
+
 <!-- Briefly describe the proposed changes -->
 
 ## Notes
+
 <!-- Be sure to mention anything unusual, out-of-scope or new technical debt, etc -->
 
 ## Screenshots
+
 <!-- Upload screenshots of UI before & after these changes -->
 
 ## Checklist
+
 <!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->
 
 <!-- For all PR types -->
-- [ ] I verify the build is in a non-broken state
-- [ ] I verify all changes are within scope of the linked issue
 
-<!-- For Markup Changes -->
-- [ ] I verify the markup will not be a breaking change (if not a major release)
-- [ ] I verify the MIND pattern for the component has been created/revised
+- [ ] I verify all changes are within scope of the linked issue
+- [ ] I added/updated/removed testing (Storybook in Skin) coverage as appropriate
 
 <!-- For CSS changes -->
-- [ ] I regenerated all CSS files under dist folder
+
 - [ ] I tested the UI in all supported browsers
 - [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
 - [ ] I tested the UI in dark mode and RTL mode
-- [ ] I added/updated/removed Storybook coverage as appropriate

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -35,6 +35,15 @@ jobs:
             - uses: codecov/codecov-action@v5
               with:
                 token: ${{ secrets.CODECOV_TOKEN }}
+            - name: Check for uncommitted changes
+              run: |
+                if output=$(git status --porcelain) && [ -z "$output" ]; then
+                  echo "Working directory is clean. No uncommitted changes."
+                else
+                  echo "Working directory has uncommitted changes or untracked files. Please run the build and check these files in as part of your PR:"
+                  echo "$output"
+                  exit 1 # Fail the CI run if there are uncommitted changes
+                fi
     # Deployment job
     deploy:
         if: github.ref == 'refs/heads/main'

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ yarn-debug.log*
 yarn-error.log*
 lerna-debug.log*
 .pnpm-debug.log*
+codecov*
 /dist/
 
 # Coverage directory used by tools like istanbul


### PR DESCRIPTION
## Description
Updated the PR template
PLEASE READ before reviewing for explanations. 

* Added a blurb that issue is required. 
* Removed mind patterns checkboxes, those are now part of the create issue template checklist
* I removed the has CSS changes or not. That can be seen in the PR. Also we should be using labels to determine if this is a skin/ebayui/react PR
* I removed the is build in a broken state. This should be determined by the PR CI which should pass before merging a PR
* I moved `I added/updated/removed testing (Storybook in Skin) coverage as appropriate` into all PR types (should have tests updated for ebayui and react too)
* I removed the `I regenerated all CSS files under dist folder`. What I did is update the CI job to fail if there are any uncommited files after running the build. This way the CI will be the source of truth. We can leave this in if needed as a reminder, but I felt the CI should be sufficient in showing there are files generated in the build

Im happy to add any other checkboxes. For coreui the all PR types checkboxes should be sufficient. We can probably add I made sure they are matching skin but it seems redundant. 

Also if we feel this needs a larger discussion, lets setup time to chat on this. 