### PR TITLE
feat(menu): added support for footer element

### DIFF
--- a/.changeset/tidy-sites-poke.md
+++ b/.changeset/tidy-sites-poke.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ebayui-core": minor
+---
+
+feat(menu/menu-button): added support for footer

--- a/packages/ebayui-core/src/components/ebay-menu-button/component.ts
+++ b/packages/ebayui-core/src/components/ebay-menu-button/component.ts
@@ -41,6 +41,7 @@ interface MenuButtonInput
     }>;
     "prefix-label"?: AttrString;
     icon?: Marko.AttrTag<{ renderBody?: Marko.Body }>;
+    footer?: Marko.AttrTag<{ renderBody?: Marko.Body }>;
     status?: Marko.AttrTag<{ renderBody?: Marko.Body<[number, Boolean[]]> }>;
     text?: AttrString;
     reverse?: boolean;

--- a/packages/ebayui-core/src/components/ebay-menu-button/component.ts
+++ b/packages/ebayui-core/src/components/ebay-menu-button/component.ts
@@ -7,7 +7,7 @@ import setupMenu, {
     type MenuState,
 } from "../../common/menu-utils";
 import type { MenuEvent } from "../ebay-menu/component";
-import type { Input as EbayButtonInput } from "../ebay-button/index.marko";
+import type { Input as EbayButtonInput, ButtonEvent } from "../ebay-button/index.marko";
 import { WithNormalizedProps } from "../../global";
 import type { AttrString } from "marko/tags-html";
 
@@ -41,7 +41,8 @@ interface MenuButtonInput
     }>;
     "prefix-label"?: AttrString;
     icon?: Marko.AttrTag<{ renderBody?: Marko.Body }>;
-    footer?: Marko.AttrTag<{ renderBody?: Marko.Body }>;
+    "footer-button"?: Marko.AttrTag<EbayButtonInput>;
+    "on-footer-button-click"?: (event: ButtonEvent<MouseEvent>) => void;
     status?: Marko.AttrTag<{ renderBody?: Marko.Body<[number, Boolean[]]> }>;
     text?: AttrString;
     reverse?: boolean;

--- a/packages/ebayui-core/src/components/ebay-menu-button/examples/footer.marko
+++ b/packages/ebayui-core/src/components/ebay-menu-button/examples/footer.marko
@@ -7,6 +7,7 @@ export interface Input {
     on-expand("emit", "expand")
     on-change("emit", "change")
     on-select("emit", "select")
+    on-footer-button-click("emit", "footer-button-click")
     text="Filter Items"
     variant="filter"
     ...input>
@@ -24,9 +25,7 @@ export interface Input {
     <@item value="item 3">
         item 3
     </@item>
-    <@footer>
-        <ebay-button priority="tertiary">
+    <@footer-button priority="tertiary">
             Apply
-        </ebay-button>
-    </@footer>
+    </@footer-button>
 </ebay-menu-button>

--- a/packages/ebayui-core/src/components/ebay-menu-button/examples/footer.marko
+++ b/packages/ebayui-core/src/components/ebay-menu-button/examples/footer.marko
@@ -1,0 +1,32 @@
+export interface Input {
+    renderBody: Marko.Body;
+}
+
+<ebay-menu-button
+    on-collapse("emit", "collapse")
+    on-expand("emit", "expand")
+    on-change("emit", "change")
+    on-select("emit", "select")
+    text="Filter Items"
+    variant="filter"
+    ...input>
+    <@status|count, checkedItems|>
+        <if(count > 0)>
+            (+${count})
+        </if>
+    </@status>
+    <@item value="item 1">
+        item 1
+    </@item>
+    <@item value="item 2">
+        item 2
+    </@item>
+    <@item value="item 3">
+        item 3
+    </@item>
+    <@footer>
+        <ebay-button priority="tertiary">
+            Apply
+        </ebay-button>
+    </@footer>
+</ebay-menu-button>

--- a/packages/ebayui-core/src/components/ebay-menu-button/index.marko
+++ b/packages/ebayui-core/src/components/ebay-menu-button/index.marko
@@ -16,6 +16,7 @@ $ const {
     borderless,
     size,
     partiallyDisabled,
+    footer,
     priority: inputPriority,
     disabled,
     variant: inputVariant,
@@ -128,6 +129,7 @@ $ var separatorCount = 0;
         type=type
         fixWidth=fixWidth
         tabindex=-1
+        footer=footer
         on-keydown("handleMenuKeydown")
         on-change("handleMenuChange")
         on-select("handleMenuSelect")

--- a/packages/ebayui-core/src/components/ebay-menu-button/index.marko
+++ b/packages/ebayui-core/src/components/ebay-menu-button/index.marko
@@ -16,7 +16,7 @@ $ const {
     borderless,
     size,
     partiallyDisabled,
-    footer,
+    footerButton,
     priority: inputPriority,
     disabled,
     variant: inputVariant,
@@ -129,7 +129,8 @@ $ var separatorCount = 0;
         type=type
         fixWidth=fixWidth
         tabindex=-1
-        footer=footer
+        footerButton=footerButton
+        on-footer-button-click("emit", "footer-button-click")
         on-keydown("handleMenuKeydown")
         on-change("handleMenuChange")
         on-select("handleMenuSelect")

--- a/packages/ebayui-core/src/components/ebay-menu-button/marko-tag.json
+++ b/packages/ebayui-core/src/components/ebay-menu-button/marko-tag.json
@@ -31,6 +31,14 @@
         },
         "@html-attributes": "expression"
     },
+    "@footer <footer>": {
+        "@*": {
+            "targetProperty": null,
+            "type": "expression"
+        },
+        "@html-attributes": "expression"
+    },
+
     "@disabled": "boolean",
     "@collapseOnSelect": "boolean",
     "@variant": "string",

--- a/packages/ebayui-core/src/components/ebay-menu-button/marko-tag.json
+++ b/packages/ebayui-core/src/components/ebay-menu-button/marko-tag.json
@@ -31,7 +31,7 @@
         },
         "@html-attributes": "expression"
     },
-    "@footer <footer>": {
+    "@footer-button <footer-button>": {
         "@*": {
             "targetProperty": null,
             "type": "expression"

--- a/packages/ebayui-core/src/components/ebay-menu-button/menu-button.stories.ts
+++ b/packages/ebayui-core/src/components/ebay-menu-button/menu-button.stories.ts
@@ -164,12 +164,13 @@ export default {
                 category: "@attribute tags",
             },
         },
-        footer: {
-            name: "@footer",
+        footerButton: {
+            name: "@footerButton",
             table: {
                 category: "@attribute tags",
             },
-            description: "The footer content. Generally renders a button. Used for filter type generally."
+            description:
+                "The footer content. Renders an ebay-button component. Used for filter type generally.",
         },
         item: {
             name: "@item",
@@ -206,6 +207,16 @@ export default {
                 category: "Events",
                 defaultValue: {
                     summary: "",
+                },
+            },
+        },
+        "onFooter-button-click": {
+            action: "on-footer-button-click",
+            description: "Triggered on click of footer button",
+            table: {
+                category: "Events",
+                defaultValue: {
+                    summary: "{ originalEvent }",
                 },
             },
         },

--- a/packages/ebayui-core/src/components/ebay-menu-button/menu-button.stories.ts
+++ b/packages/ebayui-core/src/components/ebay-menu-button/menu-button.stories.ts
@@ -16,7 +16,8 @@ import PrefixLabelTemplate from "./examples/prefix-label.marko";
 import PrefixLabelTemplateCode from "./examples/prefix-label.marko?raw";
 import FilterTemplate from "./examples/filter.marko";
 import FilterTemplateCode from "./examples/filter.marko?raw";
-
+import FooterTemplate from "./examples/footer.marko";
+import FooterTemplateCode from "./examples/footer.marko?raw";
 import Component from "./index.marko";
 import { Story } from "@storybook/marko";
 import type { Input } from "./component";
@@ -163,6 +164,13 @@ export default {
                 category: "@attribute tags",
             },
         },
+        footer: {
+            name: "@footer",
+            table: {
+                category: "@attribute tags",
+            },
+            description: "The footer content. Generally renders a button. Used for filter type generally."
+        },
         item: {
             name: "@item",
             table: {
@@ -277,6 +285,11 @@ export const Badged = buildExtensionTemplate(
 export const Filter = buildExtensionTemplate(
     FilterTemplate,
     FilterTemplateCode,
+);
+
+export const Footer = buildExtensionTemplate(
+    FooterTemplate,
+    FooterTemplateCode,
 );
 
 export const PrefixLabel = buildExtensionTemplate(

--- a/packages/ebayui-core/src/components/ebay-menu-button/test/__snapshots__/test.server.js.snap
+++ b/packages/ebayui-core/src/components/ebay-menu-button/test/__snapshots__/test.server.js.snap
@@ -1299,6 +1299,174 @@ exports[`menu-button > renders with fixed strategy 1`] = `
 [36m</DocumentFragment>[39m"
 `;
 
+exports[`menu-button > renders with footer 1`] = `
+"[36m<DocumentFragment>[39m
+  [36m<span[39m
+    [33mclass[39m=[32m"menu-button"[39m
+  [36m>[39m
+    [36m<button[39m
+      [33maria-expanded[39m=[32m"false"[39m
+      [33maria-haspopup[39m=[32m"true"[39m
+      [33maria-pressed[39m=[32m"false"[39m
+      [33mclass[39m=[32m"filter-chip menu-button__button"[39m
+      [33mtype[39m=[32m"button"[39m
+    [36m>[39m
+      [36m<span[39m
+        [33mclass[39m=[32m"filter-chip__text"[39m
+      [36m>[39m
+        [36m<span>[39m
+          [0mFilter Items[0m
+        [36m</span>[39m
+      [36m</span>[39m
+      [36m<svg[39m
+        [33maria-hidden[39m=[32m"true"[39m
+        [33mclass[39m=[32m"filter-chip__trailing icon icon--12"[39m
+        [33mfocusable[39m=[32m"false"[39m
+      [36m>[39m
+        [36m<defs>[39m
+          [36m<symbol[39m
+            [33mid[39m=[32m"icon-chevron-down-12"[39m
+            [33mviewBox[39m=[32m"0 0 12 12"[39m
+          [36m>[39m
+            [36m<path[39m
+              [33mclip-rule[39m=[32m"evenodd"[39m
+              [33md[39m=[32m"M1.808 4.188a.625.625 0 0 1 .884 0L6 7.495l3.308-3.307a.625.625 0 1 1 .884.885l-3.75 3.749a.625.625 0 0 1-.884 0l-3.75-3.749a.626.626 0 0 1 0-.885Z"[39m
+              [33mfill-rule[39m=[32m"evenodd"[39m
+            [36m/>[39m
+          [36m</symbol>[39m
+        [36m</defs>[39m
+        [36m<use[39m
+          [33mhref[39m=[32m"#icon-chevron-down-12"[39m
+        [36m/>[39m
+      [36m</svg>[39m
+    [36m</button>[39m
+    [36m<span[39m
+      [33mclass[39m=[32m"menu-button__menu menu-button--filter"[39m
+      [33mtabindex[39m=[32m"-1"[39m
+    [36m>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"menu-button__items"[39m
+        [33mid[39m=[32m"s0-0-@content-menu"[39m
+        [33mrole[39m=[32m"menu"[39m
+      [36m>[39m
+        [36m<div[39m
+          [33maria-checked[39m=[32m"false"[39m
+          [33mclass[39m=[32m"menu-button__item"[39m
+          [33mrole[39m=[32m"menuitemcheckbox"[39m
+        [36m>[39m
+          [36m<svg[39m
+            [33maria-hidden[39m=[32m"true"[39m
+            [33mclass[39m=[32m"icon--unchecked icon icon--18"[39m
+            [33mfocusable[39m=[32m"false"[39m
+          [36m>[39m
+            [36m<defs>[39m
+              [36m<symbol[39m
+                [33mid[39m=[32m"icon-checkbox-unchecked-18"[39m
+                [33mviewBox[39m=[32m"0 0 18 18"[39m
+              [36m>[39m
+                [36m<path[39m
+                  [33md[39m=[32m"M6.4 17h5.2c1.137 0 1.929 0 2.546-.051.605-.05.953-.142 1.216-.276a3 3 0 0 0 1.311-1.311c.134-.263.226-.611.276-1.216.05-.617.051-1.41.051-2.546V6.4c0-1.137 0-1.929-.051-2.546-.05-.605-.142-.953-.276-1.216a3 3 0 0 0-1.311-1.311c-.263-.134-.611-.226-1.216-.276C13.529 1.001 12.736 1 11.6 1H6.4c-1.137 0-1.929 0-2.546.051-.605.05-.953.142-1.216.276a3 3 0 0 0-1.311 1.311c-.134.263-.226.611-.276 1.216C1.001 4.471 1 5.264 1 6.4v5.2c0 1.137 0 1.929.051 2.546.05.605.142.953.276 1.216a3 3 0 0 0 1.311 1.311c.263.134.611.226 1.216.276.617.05 1.41.051 2.546.051ZM.436 15.816C0 14.96 0 13.84 0 11.6V6.4c0-2.24 0-3.36.436-4.216A4 4 0 0 1 2.184.436C3.04 0 4.16 0 6.4 0h5.2c2.24 0 3.36 0 4.216.436a4 4 0 0 1 1.748 1.748C18 3.04 18 4.16 18 6.4v5.2c0 2.24 0 3.36-.436 4.216a4 4 0 0 1-1.748 1.748C14.96 18 13.84 18 11.6 18H6.4c-2.24 0-3.36 0-4.216-.436a4 4 0 0 1-1.748-1.748Z"[39m
+                [36m/>[39m
+              [36m</symbol>[39m
+            [36m</defs>[39m
+            [36m<use[39m
+              [33mhref[39m=[32m"#icon-checkbox-unchecked-18"[39m
+            [36m/>[39m
+          [36m</svg>[39m
+          [36m<svg[39m
+            [33maria-hidden[39m=[32m"true"[39m
+            [33mclass[39m=[32m"icon--checked icon icon--18"[39m
+            [33mfocusable[39m=[32m"false"[39m
+          [36m>[39m
+            [36m<defs>[39m
+              [36m<symbol[39m
+                [33mid[39m=[32m"icon-checkbox-checked-18"[39m
+                [33mviewBox[39m=[32m"0 0 18 18"[39m
+              [36m>[39m
+                [36m<path[39m
+                  [33md[39m=[32m"M0 6.4c0-2.24 0-3.36.436-4.216A4 4 0 0 1 2.184.436C3.04 0 4.16 0 6.4 0h5.2c2.24 0 3.36 0 4.216.436a4 4 0 0 1 1.748 1.748C18 3.04 18 4.16 18 6.4v5.2c0 2.24 0 3.36-.436 4.216a4 4 0 0 1-1.748 1.748C14.96 18 13.84 18 11.6 18H6.4c-2.24 0-3.36 0-4.216-.436a4 4 0 0 1-1.748-1.748C0 14.96 0 13.84 0 11.6V6.4Zm14.71-2.11a1 1 0 0 0-1.41 0L7 10.59l-2.29-2.3a1.004 1.004 0 0 0-1.42 1.42l3 3a1 1 0 0 0 1.41 0l7-7a1 1 0 0 0 .01-1.42Z"[39m
+                [36m/>[39m
+              [36m</symbol>[39m
+            [36m</defs>[39m
+            [36m<use[39m
+              [33mhref[39m=[32m"#icon-checkbox-checked-18"[39m
+            [36m/>[39m
+          [36m</svg>[39m
+          [36m<span>[39m
+            [0mitem 1[0m
+          [36m</span>[39m
+        [36m</div>[39m
+        [36m<div[39m
+          [33maria-checked[39m=[32m"false"[39m
+          [33mclass[39m=[32m"menu-button__item"[39m
+          [33mrole[39m=[32m"menuitemcheckbox"[39m
+        [36m>[39m
+          [36m<svg[39m
+            [33maria-hidden[39m=[32m"true"[39m
+            [33mclass[39m=[32m"icon--unchecked icon icon--18"[39m
+            [33mfocusable[39m=[32m"false"[39m
+          [36m>[39m
+            [36m<use[39m
+              [33mhref[39m=[32m"#icon-checkbox-unchecked-18"[39m
+            [36m/>[39m
+          [36m</svg>[39m
+          [36m<svg[39m
+            [33maria-hidden[39m=[32m"true"[39m
+            [33mclass[39m=[32m"icon--checked icon icon--18"[39m
+            [33mfocusable[39m=[32m"false"[39m
+          [36m>[39m
+            [36m<use[39m
+              [33mhref[39m=[32m"#icon-checkbox-checked-18"[39m
+            [36m/>[39m
+          [36m</svg>[39m
+          [36m<span>[39m
+            [0mitem 2[0m
+          [36m</span>[39m
+        [36m</div>[39m
+        [36m<div[39m
+          [33maria-checked[39m=[32m"false"[39m
+          [33mclass[39m=[32m"menu-button__item"[39m
+          [33mrole[39m=[32m"menuitemcheckbox"[39m
+        [36m>[39m
+          [36m<svg[39m
+            [33maria-hidden[39m=[32m"true"[39m
+            [33mclass[39m=[32m"icon--unchecked icon icon--18"[39m
+            [33mfocusable[39m=[32m"false"[39m
+          [36m>[39m
+            [36m<use[39m
+              [33mhref[39m=[32m"#icon-checkbox-unchecked-18"[39m
+            [36m/>[39m
+          [36m</svg>[39m
+          [36m<svg[39m
+            [33maria-hidden[39m=[32m"true"[39m
+            [33mclass[39m=[32m"icon--checked icon icon--18"[39m
+            [33mfocusable[39m=[32m"false"[39m
+          [36m>[39m
+            [36m<use[39m
+              [33mhref[39m=[32m"#icon-checkbox-checked-18"[39m
+            [36m/>[39m
+          [36m</svg>[39m
+          [36m<span>[39m
+            [0mitem 3[0m
+          [36m</span>[39m
+        [36m</div>[39m
+      [36m</div>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"menu-button__footer"[39m
+      [36m>[39m
+        [36m<button[39m
+          [33mclass[39m=[32m"btn btn--tertiary"[39m
+          [33mdata-ebayui[39m=[32m""[39m
+          [33mtype[39m=[32m"button"[39m
+        [36m>[39m
+          [0mApply[0m
+        [36m</button>[39m
+      [36m</div>[39m
+    [36m</span>[39m
+  [36m</span>[39m
+[36m</DocumentFragment>[39m"
+`;
+
 exports[`menu-button > renders with icon 1`] = `
 "[36m<DocumentFragment>[39m
   [36m<span[39m

--- a/packages/ebayui-core/src/components/ebay-menu-button/test/test.server.js
+++ b/packages/ebayui-core/src/components/ebay-menu-button/test/test.server.js
@@ -4,8 +4,16 @@ import * as testUtils from "../../../common/test-utils/server";
 import { snapshotHTML } from "../../../common/test-utils/snapshots";
 import * as stories from "../menu-button.stories"; // import all stories from the stories file
 
-const { Default, Typeahead, Badged, Separator, IconText, PrefixLabel, Filter } =
-    composeStories(stories);
+const {
+    Default,
+    Typeahead,
+    Badged,
+    Separator,
+    IconText,
+    PrefixLabel,
+    Filter,
+    Footer,
+} = composeStories(stories);
 const htmlSnap = snapshotHTML(__dirname);
 
 describe("menu-button", () => {
@@ -71,6 +79,10 @@ describe("menu-button", () => {
 
     it("renders with filter", async () => {
         await htmlSnap(Filter);
+    });
+
+    it("renders with footer", async () => {
+        await htmlSnap(Footer);
     });
 
     ["radio", "checkbox"].forEach((type) => {

--- a/packages/ebayui-core/src/components/ebay-menu/component.ts
+++ b/packages/ebayui-core/src/components/ebay-menu/component.ts
@@ -2,6 +2,7 @@ import * as scrollKeyPreventer from "makeup-prevent-scroll-keys";
 import { createLinear } from "makeup-roving-tabindex";
 import typeahead from "makeup-typeahead";
 import * as eventUtils from "../../common/event-utils";
+import type { Input as EbayButtonInput, ButtonEvent } from "../ebay-button/index.marko";
 import setupMenu, {
     type MenuItem,
     type BaseMenuInput,
@@ -36,8 +37,9 @@ interface MenuInput
     fixed?: boolean;
     "fix-width"?: boolean;
     renderBody?: Marko.Body;
-    footer?: Marko.AttrTag<{ renderBody?: Marko.Body }>;
+    "footer-button"?: Marko.AttrTag<EbayButtonInput>;
     "on-keydown"?: (event: MenuEvent) => void;
+    "on-footer-button-click"?: (event: ButtonEvent<MouseEvent>) => void;
     "on-change"?: (event: MenuEvent) => void;
     "on-select"?: (event: MenuEvent) => void;
 }

--- a/packages/ebayui-core/src/components/ebay-menu/component.ts
+++ b/packages/ebayui-core/src/components/ebay-menu/component.ts
@@ -36,6 +36,7 @@ interface MenuInput
     fixed?: boolean;
     "fix-width"?: boolean;
     renderBody?: Marko.Body;
+    footer?: Marko.AttrTag<{ renderBody?: Marko.Body }>;
     "on-keydown"?: (event: MenuEvent) => void;
     "on-change"?: (event: MenuEvent) => void;
     "on-select"?: (event: MenuEvent) => void;

--- a/packages/ebayui-core/src/components/ebay-menu/examples/footer.marko
+++ b/packages/ebayui-core/src/components/ebay-menu/examples/footer.marko
@@ -1,0 +1,21 @@
+<ebay-menu
+    variant="filter"
+    ...input
+    on-keydown("emit", "keydown")
+    on-change("emit", "change")
+    on-select("emit", "select")>
+    <@item value="item 1">
+        item 1
+    </@item>
+    <@item value="item 2">
+        item 2
+    </@item>
+    <@item value="item 3">
+        item 3
+    </@item>
+    <@footer>
+        <ebay-button priority="tertiary">
+            Apply
+        </ebay-button>
+    </@footer>
+</ebay-menu>

--- a/packages/ebayui-core/src/components/ebay-menu/examples/footer.marko
+++ b/packages/ebayui-core/src/components/ebay-menu/examples/footer.marko
@@ -3,7 +3,8 @@
     ...input
     on-keydown("emit", "keydown")
     on-change("emit", "change")
-    on-select("emit", "select")>
+    on-select("emit", "select")
+    on-footer-button-click("emit", "footer-button-click")>
     <@item value="item 1">
         item 1
     </@item>
@@ -13,9 +14,7 @@
     <@item value="item 3">
         item 3
     </@item>
-    <@footer>
-        <ebay-button priority="tertiary">
-            Apply
-        </ebay-button>
-    </@footer>
+    <@footer-button priority="tertiary">
+        Apply
+    </@footer-button>
 </ebay-menu>

--- a/packages/ebayui-core/src/components/ebay-menu/index.marko
+++ b/packages/ebayui-core/src/components/ebay-menu/index.marko
@@ -7,6 +7,7 @@ $ const {
     reverse,
     fixed,
     fixWidth,
+    footer,
     item: items = [],
     variant,
     ariaLabel,
@@ -96,4 +97,9 @@ $ var separatorMap = component.getSeparatorMap(input);
             </div>
         </for>
     </div>
+    <if(footer)>
+        <div class=`${baseClass}__footer` ...processHtmlAttributes(footer)>
+            <${footer}/>
+        </div>
+    </if>
 </span>

--- a/packages/ebayui-core/src/components/ebay-menu/index.marko
+++ b/packages/ebayui-core/src/components/ebay-menu/index.marko
@@ -99,7 +99,7 @@ $ var separatorMap = component.getSeparatorMap(input);
     </div>
     <if(footerButton)>
         <div class=`${baseClass}__footer` >
-            <ebay-button on-click("emit", "footer-button-click") ...processHtmlAttributes(footerButton)>
+            <ebay-button on-click("emit", "footer-button-click") ...footerButton>
                 <${footerButton}/>
             </>
         </div>

--- a/packages/ebayui-core/src/components/ebay-menu/index.marko
+++ b/packages/ebayui-core/src/components/ebay-menu/index.marko
@@ -7,7 +7,7 @@ $ const {
     reverse,
     fixed,
     fixWidth,
-    footer,
+    footerButton,
     item: items = [],
     variant,
     ariaLabel,
@@ -97,9 +97,11 @@ $ var separatorMap = component.getSeparatorMap(input);
             </div>
         </for>
     </div>
-    <if(footer)>
-        <div class=`${baseClass}__footer` ...processHtmlAttributes(footer)>
-            <${footer}/>
+    <if(footerButton)>
+        <div class=`${baseClass}__footer` >
+            <ebay-button on-click("emit", "footer-button-click") ...processHtmlAttributes(footerButton)>
+                <${footerButton}/>
+            </>
         </div>
     </if>
 </span>

--- a/packages/ebayui-core/src/components/ebay-menu/marko-tag.json
+++ b/packages/ebayui-core/src/components/ebay-menu/marko-tag.json
@@ -11,7 +11,7 @@
     "@type": "string",
     "@reverse": "boolean",
     "@fix-width": "boolean",
-    "@footer <footer>": {
+    "@footer-button <footer-button>": {
         "@*": {
             "targetProperty": null,
             "type": "expression"

--- a/packages/ebayui-core/src/components/ebay-menu/marko-tag.json
+++ b/packages/ebayui-core/src/components/ebay-menu/marko-tag.json
@@ -11,6 +11,13 @@
     "@type": "string",
     "@reverse": "boolean",
     "@fix-width": "boolean",
+    "@footer <footer>": {
+        "@*": {
+            "targetProperty": null,
+            "type": "expression"
+        },
+        "@html-attributes": "expression"
+    },
     "@item <item>[]": {
         "@*": {
             "targetProperty": null,

--- a/packages/ebayui-core/src/components/ebay-menu/menu.stories.ts
+++ b/packages/ebayui-core/src/components/ebay-menu/menu.stories.ts
@@ -87,13 +87,23 @@ export default {
             description:
                 "Passed as the `aria-label` directly to the badge. Required only if badge number is provided",
         },
-        footer: {
-            name: "@footer",
+        footerButton: {
+            name: "@footer-button",
             table: {
                 category: "@attribute tags",
             },
             description:
-                "The footer content. Generally renders a button. Used for filter type generally.",
+                "The footer content. Renders an ebay-button. Used for filter type generally.",
+        },
+        "onFooter-button-click": {
+            action: "on-footer-button-click",
+            description: "Triggered on click of footer button",
+            table: {
+                category: "Events",
+                defaultValue: {
+                    summary: "{ }",
+                },
+            },
         },
         onKeydown: {
             action: "on-keydown",

--- a/packages/ebayui-core/src/components/ebay-menu/menu.stories.ts
+++ b/packages/ebayui-core/src/components/ebay-menu/menu.stories.ts
@@ -15,6 +15,8 @@ import TypeaheadTemplate from "./examples/typeahead.marko";
 import TypeaheadTemplateCode from "./examples/typeahead.marko?raw";
 import SeparatorTemplate from "./examples/separator.marko";
 import SeparatorTemplateCode from "./examples/separator.marko?raw";
+import FooterTemplate from "./examples/footer.marko";
+import FooterTemplateCode from "./examples/footer.marko?raw";
 import { Story } from "@storybook/marko";
 import type { Input } from "./component";
 
@@ -84,6 +86,14 @@ export default {
             },
             description:
                 "Passed as the `aria-label` directly to the badge. Required only if badge number is provided",
+        },
+        footer: {
+            name: "@footer",
+            table: {
+                category: "@attribute tags",
+            },
+            description:
+                "The footer content. Generally renders a button. Used for filter type generally.",
         },
         onKeydown: {
             action: "on-keydown",
@@ -162,4 +172,8 @@ export const Sprites = buildExtensionTemplate(
 export const Separator = buildExtensionTemplate(
     SeparatorTemplate,
     SeparatorTemplateCode,
+);
+export const Footer = buildExtensionTemplate(
+    FooterTemplate,
+    FooterTemplateCode,
 );

--- a/packages/ebayui-core/src/components/ebay-menu/test/__snapshots__/test.server.js.snap
+++ b/packages/ebayui-core/src/components/ebay-menu/test/__snapshots__/test.server.js.snap
@@ -766,6 +766,134 @@ exports[`menu > renders with fix-width=true 1`] = `
 [36m</DocumentFragment>[39m"
 `;
 
+exports[`menu > renders with footer version 1`] = `
+"[36m<DocumentFragment>[39m
+  [36m<span[39m
+    [33mclass[39m=[32m"menu menu--filter"[39m
+  [36m>[39m
+    [36m<div[39m
+      [33mclass[39m=[32m"menu__items"[39m
+      [33mid[39m=[32m"s0-0-menu"[39m
+      [33mrole[39m=[32m"menu"[39m
+    [36m>[39m
+      [36m<div[39m
+        [33maria-checked[39m=[32m"false"[39m
+        [33mclass[39m=[32m"menu__item"[39m
+        [33mrole[39m=[32m"menuitemcheckbox"[39m
+      [36m>[39m
+        [36m<svg[39m
+          [33maria-hidden[39m=[32m"true"[39m
+          [33mclass[39m=[32m"icon--unchecked icon icon--18"[39m
+          [33mfocusable[39m=[32m"false"[39m
+        [36m>[39m
+          [36m<defs>[39m
+            [36m<symbol[39m
+              [33mid[39m=[32m"icon-checkbox-unchecked-18"[39m
+              [33mviewBox[39m=[32m"0 0 18 18"[39m
+            [36m>[39m
+              [36m<path[39m
+                [33md[39m=[32m"M6.4 17h5.2c1.137 0 1.929 0 2.546-.051.605-.05.953-.142 1.216-.276a3 3 0 0 0 1.311-1.311c.134-.263.226-.611.276-1.216.05-.617.051-1.41.051-2.546V6.4c0-1.137 0-1.929-.051-2.546-.05-.605-.142-.953-.276-1.216a3 3 0 0 0-1.311-1.311c-.263-.134-.611-.226-1.216-.276C13.529 1.001 12.736 1 11.6 1H6.4c-1.137 0-1.929 0-2.546.051-.605.05-.953.142-1.216.276a3 3 0 0 0-1.311 1.311c-.134.263-.226.611-.276 1.216C1.001 4.471 1 5.264 1 6.4v5.2c0 1.137 0 1.929.051 2.546.05.605.142.953.276 1.216a3 3 0 0 0 1.311 1.311c.263.134.611.226 1.216.276.617.05 1.41.051 2.546.051ZM.436 15.816C0 14.96 0 13.84 0 11.6V6.4c0-2.24 0-3.36.436-4.216A4 4 0 0 1 2.184.436C3.04 0 4.16 0 6.4 0h5.2c2.24 0 3.36 0 4.216.436a4 4 0 0 1 1.748 1.748C18 3.04 18 4.16 18 6.4v5.2c0 2.24 0 3.36-.436 4.216a4 4 0 0 1-1.748 1.748C14.96 18 13.84 18 11.6 18H6.4c-2.24 0-3.36 0-4.216-.436a4 4 0 0 1-1.748-1.748Z"[39m
+              [36m/>[39m
+            [36m</symbol>[39m
+          [36m</defs>[39m
+          [36m<use[39m
+            [33mhref[39m=[32m"#icon-checkbox-unchecked-18"[39m
+          [36m/>[39m
+        [36m</svg>[39m
+        [36m<svg[39m
+          [33maria-hidden[39m=[32m"true"[39m
+          [33mclass[39m=[32m"icon--checked icon icon--18"[39m
+          [33mfocusable[39m=[32m"false"[39m
+        [36m>[39m
+          [36m<defs>[39m
+            [36m<symbol[39m
+              [33mid[39m=[32m"icon-checkbox-checked-18"[39m
+              [33mviewBox[39m=[32m"0 0 18 18"[39m
+            [36m>[39m
+              [36m<path[39m
+                [33md[39m=[32m"M0 6.4c0-2.24 0-3.36.436-4.216A4 4 0 0 1 2.184.436C3.04 0 4.16 0 6.4 0h5.2c2.24 0 3.36 0 4.216.436a4 4 0 0 1 1.748 1.748C18 3.04 18 4.16 18 6.4v5.2c0 2.24 0 3.36-.436 4.216a4 4 0 0 1-1.748 1.748C14.96 18 13.84 18 11.6 18H6.4c-2.24 0-3.36 0-4.216-.436a4 4 0 0 1-1.748-1.748C0 14.96 0 13.84 0 11.6V6.4Zm14.71-2.11a1 1 0 0 0-1.41 0L7 10.59l-2.29-2.3a1.004 1.004 0 0 0-1.42 1.42l3 3a1 1 0 0 0 1.41 0l7-7a1 1 0 0 0 .01-1.42Z"[39m
+              [36m/>[39m
+            [36m</symbol>[39m
+          [36m</defs>[39m
+          [36m<use[39m
+            [33mhref[39m=[32m"#icon-checkbox-checked-18"[39m
+          [36m/>[39m
+        [36m</svg>[39m
+        [36m<span>[39m
+          [0mitem 1[0m
+        [36m</span>[39m
+      [36m</div>[39m
+      [36m<div[39m
+        [33maria-checked[39m=[32m"false"[39m
+        [33mclass[39m=[32m"menu__item"[39m
+        [33mrole[39m=[32m"menuitemcheckbox"[39m
+      [36m>[39m
+        [36m<svg[39m
+          [33maria-hidden[39m=[32m"true"[39m
+          [33mclass[39m=[32m"icon--unchecked icon icon--18"[39m
+          [33mfocusable[39m=[32m"false"[39m
+        [36m>[39m
+          [36m<use[39m
+            [33mhref[39m=[32m"#icon-checkbox-unchecked-18"[39m
+          [36m/>[39m
+        [36m</svg>[39m
+        [36m<svg[39m
+          [33maria-hidden[39m=[32m"true"[39m
+          [33mclass[39m=[32m"icon--checked icon icon--18"[39m
+          [33mfocusable[39m=[32m"false"[39m
+        [36m>[39m
+          [36m<use[39m
+            [33mhref[39m=[32m"#icon-checkbox-checked-18"[39m
+          [36m/>[39m
+        [36m</svg>[39m
+        [36m<span>[39m
+          [0mitem 2[0m
+        [36m</span>[39m
+      [36m</div>[39m
+      [36m<div[39m
+        [33maria-checked[39m=[32m"false"[39m
+        [33mclass[39m=[32m"menu__item"[39m
+        [33mrole[39m=[32m"menuitemcheckbox"[39m
+      [36m>[39m
+        [36m<svg[39m
+          [33maria-hidden[39m=[32m"true"[39m
+          [33mclass[39m=[32m"icon--unchecked icon icon--18"[39m
+          [33mfocusable[39m=[32m"false"[39m
+        [36m>[39m
+          [36m<use[39m
+            [33mhref[39m=[32m"#icon-checkbox-unchecked-18"[39m
+          [36m/>[39m
+        [36m</svg>[39m
+        [36m<svg[39m
+          [33maria-hidden[39m=[32m"true"[39m
+          [33mclass[39m=[32m"icon--checked icon icon--18"[39m
+          [33mfocusable[39m=[32m"false"[39m
+        [36m>[39m
+          [36m<use[39m
+            [33mhref[39m=[32m"#icon-checkbox-checked-18"[39m
+          [36m/>[39m
+        [36m</svg>[39m
+        [36m<span>[39m
+          [0mitem 3[0m
+        [36m</span>[39m
+      [36m</div>[39m
+    [36m</div>[39m
+    [36m<div[39m
+      [33mclass[39m=[32m"menu__footer"[39m
+    [36m>[39m
+      [36m<button[39m
+        [33mclass[39m=[32m"btn btn--tertiary"[39m
+        [33mdata-ebayui[39m=[32m""[39m
+        [33mdata-marko[39m=[32m"{\\"onclick\\":\\"handleClick s0-0-11-1 false\\",\\"onkeydown\\":\\"handleKeydown s0-0-11-1 false\\",\\"onfocus\\":\\"handleFocus s0-0-11-1 false\\",\\"onblur\\":\\"handleBlur s0-0-11-1 false\\"}"[39m
+        [33mtype[39m=[32m"button"[39m
+      [36m>[39m
+        [0mApply[0m
+      [36m</button>[39m
+    [36m</div>[39m
+  [36m</span>[39m
+[36m</DocumentFragment>[39m"
+`;
+
 exports[`menu > renders with reverse=true 1`] = `
 "[36m<DocumentFragment>[39m
   [36m<span[39m

--- a/packages/ebayui-core/src/components/ebay-menu/test/__snapshots__/test.server.js.snap
+++ b/packages/ebayui-core/src/components/ebay-menu/test/__snapshots__/test.server.js.snap
@@ -884,7 +884,6 @@ exports[`menu > renders with footer version 1`] = `
       [36m<button[39m
         [33mclass[39m=[32m"btn btn--tertiary"[39m
         [33mdata-ebayui[39m=[32m""[39m
-        [33mdata-marko[39m=[32m"{\\"onclick\\":\\"handleClick s0-0-11-1 false\\",\\"onkeydown\\":\\"handleKeydown s0-0-11-1 false\\",\\"onfocus\\":\\"handleFocus s0-0-11-1 false\\",\\"onblur\\":\\"handleBlur s0-0-11-1 false\\"}"[39m
         [33mtype[39m=[32m"button"[39m
       [36m>[39m
         [0mApply[0m

--- a/packages/ebayui-core/src/components/ebay-menu/test/test.server.js
+++ b/packages/ebayui-core/src/components/ebay-menu/test/test.server.js
@@ -4,7 +4,7 @@ import * as testUtils from "../../../common/test-utils/server";
 import { snapshotHTML } from "../../../common/test-utils/snapshots";
 import * as stories from "../menu.stories"; // import all stories from the stories file
 
-const { Default, Typeahead, Badged, Sprites, Separator, Filter } =
+const { Default, Typeahead, Badged, Sprites, Separator, Filter, Footer } =
     composeStories(stories);
 const htmlSnap = snapshotHTML(__dirname);
 
@@ -46,7 +46,9 @@ describe("menu", () => {
     it("renders with filter version", async () => {
         await htmlSnap(Filter);
     });
-
+    it("renders with footer version", async () => {
+        await htmlSnap(Footer);
+    });
     ["radio", "checkbox"].forEach((type) => {
         [true, false].forEach((checked) => {
             it(`renders with type=${type} and checked=${checked}`, async () => {


### PR DESCRIPTION

Fixes #224
## Description
* Added support for footer in menu and menu button. This was in skin already but did not get into coreui. 
 
## Screenshots
<img width="169" height="294" alt="Screenshot 2025-08-21 at 8 20 24 AM" src="https://github.com/user-attachments/assets/84403239-ecc4-48a8-bbc7-92354c093f01" />


## Checklist
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue
