### PR TITLE
fix(selection-chip): moved animated logic to onCreate

### DIFF
--- a/.changeset/stale-years-walk.md
+++ b/.changeset/stale-years-walk.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ebayui-core": patch
+---
+
+fix(selection-chip): moved animated logic to onCreate

--- a/packages/ebayui-core/src/components/ebay-selection-chip/component.ts
+++ b/packages/ebayui-core/src/components/ebay-selection-chip/component.ts
@@ -13,6 +13,12 @@ export interface State {
 }
 
 class SelectionChip extends Marko.Component<Input, State> {
+    onCreate(input: Input) {
+        this.state = {
+            mounted: false,
+            selected: input.selected || false,
+        };
+    }
     onMount() {
         this.state.mounted = true;
     }
@@ -28,10 +34,9 @@ class SelectionChip extends Marko.Component<Input, State> {
     }
 
     onInput(input: Input) {
-        this.state = {
-            selected: input.selected || false,
-            mounted: false,
-        };
+        if (input.selected !== undefined) {
+            this.state.selected = input.selected;
+        }
     }
 }
 


### PR DESCRIPTION

Fixes #270 
## Description
* Added state to onCreate and removed mounted changes from onInput

## Checklist
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue
