### PR TITLE
fix(EbayListboxButton): Handle split attribute undefined

### DIFF
--- a/packages/ebayui-core-react/src/ebay-listbox-button/__tests__/render.spec.tsx
+++ b/packages/ebayui-core-react/src/ebay-listbox-button/__tests__/render.spec.tsx
@@ -22,6 +22,7 @@ describe("ebay-listbox-button rendering", () => {
         const listboxButton: HTMLElement = container.querySelector(".listbox-button");
         const button = within(listboxButton).getByRole("button", { name: "Option 2" });
         expect(button).toHaveClass("btn btn--form");
+        expect(button).not.toHaveClass("btn--split-undefined");
         expect(button).toHaveAttribute("aria-expanded", "false");
         expect(button).toHaveAttribute("aria-haspopup", "listbox");
         expect(button).toHaveAttribute("type", "button");

--- a/packages/ebayui-core-react/src/ebay-listbox-button/listbox-button.tsx
+++ b/packages/ebayui-core-react/src/ebay-listbox-button/listbox-button.tsx
@@ -262,7 +262,7 @@ const ListboxButton: FC<EbayListboxButtonProps> = ({
         "btn--form": !borderless,
         "btn--borderless": borderless,
         "btn--floating-label": floatingLabel && selectedOption,
-        [`btn--split-${split}`]: split !== "none",
+        [`btn--split-${split}`]: split && split !== "none",
     });
     const expandBtnTextId = prefixId && "expand-btn-text";
 


### PR DESCRIPTION
<!-- Insert GitHub issue number below. An issue is required for all PRs -->

- Fixes #280

## Description

Handle that split can be undefined.

## Notes

<!-- Be sure to mention anything unusual, out-of-scope or new technical debt, etc -->

## Screenshots

<!-- Upload screenshots of UI before & after these changes -->

## Checklist

<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->

- [x] I verify all changes are within scope of the linked issue
- [x] I added/updated/removed testing (Storybook in Skin) coverage as appropriate

<!-- For CSS changes -->

- [ ] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [ ] I tested the UI in dark mode and RTL mode
