### PR TITLE
fix(listbox, listbox-button): explicit announce selected state

### DIFF
--- a/.changeset/purple-sheep-say.md
+++ b/.changeset/purple-sheep-say.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ebayui-core": patch
+---
+
+fix(listbox, listbox-button): explicit announce selected state

--- a/packages/ebayui-core/src/components/ebay-listbox-button/component.ts
+++ b/packages/ebayui-core/src/components/ebay-listbox-button/component.ts
@@ -25,6 +25,7 @@ interface ListboxButtonInput extends Omit<Marko.HTML.Div, `on${string}`> {
     invalid?: boolean;
     hasError?: boolean;
     "a11y-icon-prefix-text"?: Marko.HTMLAttributes["aria-label"];
+    "a11y-selected-text"?: string;
     "prefix-label"?: string;
     "postfix-label"?: string;
     "collapse-on-select"?: boolean;

--- a/packages/ebayui-core/src/components/ebay-listbox-button/index.marko
+++ b/packages/ebayui-core/src/components/ebay-listbox-button/index.marko
@@ -21,6 +21,7 @@ $ const {
     strategy,
     split = "none",
     a11yIconPrefixText,
+    a11ySelectedText = "selected",
     ariaDescribedby: describedby,
     ...htmlInput
 } = input;
@@ -118,6 +119,7 @@ $ var isForm = variant === "form";
         name=name
         tabindex=-1
         listSelection=listSelection
+        a11ySelectedText=a11ySelectedText
         onChange("handleListboxChange")
         onEscape("handleListboxEscape")
     >

--- a/packages/ebayui-core/src/components/ebay-listbox-button/listbox-button.stories.ts
+++ b/packages/ebayui-core/src/components/ebay-listbox-button/listbox-button.stories.ts
@@ -118,6 +118,17 @@ export default {
                 category: "@option attributes",
             },
         },
+        a11ySelectedText: {
+            type: "text",
+            control: { type: "text" },
+            description:
+                "Localized text to be read by screen readers when an option is selected",
+            table: {
+                defaultValue: {
+                    summary: "selected",
+                },
+            },
+        },
         value: {
             table: {
                 control: { type: "value" },

--- a/packages/ebayui-core/src/components/ebay-listbox-button/marko-tag.json
+++ b/packages/ebayui-core/src/components/ebay-listbox-button/marko-tag.json
@@ -15,6 +15,7 @@
     "@prefix-id": "string",
     "@prefix-label": "string",
     "@a11y-icon-prefix-text": "string",
+    "@a11y-selected-text": "string",
     "@floating-label": "string",
     "@unselected-text": "string",
     "@postfix-label": "string",

--- a/packages/ebayui-core/src/components/ebay-listbox-button/test/__snapshots__/test.server.js.snap
+++ b/packages/ebayui-core/src/components/ebay-listbox-button/test/__snapshots__/test.server.js.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`listbox > renders basic version 1`] = `
+exports[`listbox button > renders basic version 1`] = `
 "[36m<DocumentFragment>[39m
   [36m<span[39m
     [33mclass[39m=[32m"listbox-button"[39m
@@ -137,7 +137,7 @@ exports[`listbox > renders basic version 1`] = `
 [36m</DocumentFragment>[39m"
 `;
 
-exports[`listbox > renders fluid layout 1`] = `
+exports[`listbox button > renders fluid layout 1`] = `
 "[36m<DocumentFragment>[39m
   [36m<span[39m
     [33mclass[39m=[32m"listbox-button listbox-button--fluid"[39m
@@ -274,7 +274,7 @@ exports[`listbox > renders fluid layout 1`] = `
 [36m</DocumentFragment>[39m"
 `;
 
-exports[`listbox > renders truncated layout 1`] = `
+exports[`listbox button > renders truncated layout 1`] = `
 "[36m<DocumentFragment>[39m
   [36m<div[39m
     [33mclass[39m=[32m"listbox-button"[39m
@@ -411,7 +411,7 @@ exports[`listbox > renders truncated layout 1`] = `
 [36m</DocumentFragment>[39m"
 `;
 
-exports[`listbox > renders with description 1`] = `
+exports[`listbox button > renders with description 1`] = `
 "[36m<DocumentFragment>[39m
   [36m<span[39m
     [33mclass[39m=[32m"listbox-button"[39m
@@ -470,6 +470,11 @@ exports[`listbox > renders with description 1`] = `
           [33mclass[39m=[32m"listbox__value"[39m
         [36m>[39m
           [0mOption 1[0m
+          [36m<span[39m
+            [33mclass[39m=[32m"clipped"[39m
+          [36m>[39m
+            [0mselected[0m
+          [36m</span>[39m
         [36m</span>[39m
         [36m<span[39m
           [33mclass[39m=[32m"listbox__description"[39m
@@ -567,7 +572,7 @@ exports[`listbox > renders with description 1`] = `
 [36m</DocumentFragment>[39m"
 `;
 
-exports[`listbox > renders with error 1`] = `
+exports[`listbox button > renders with error 1`] = `
 "[36m<DocumentFragment>[39m
   [36m<span[39m
     [33mclass[39m=[32m"field"[39m
@@ -625,6 +630,11 @@ exports[`listbox > renders with error 1`] = `
             [33mclass[39m=[32m"listbox__value"[39m
           [36m>[39m
             [0mOption 1[0m
+            [36m<span[39m
+              [33mclass[39m=[32m"clipped"[39m
+            [36m>[39m
+              [0mselected[0m
+            [36m</span>[39m
           [36m</span>[39m
           [36m<svg[39m
             [33maria-hidden[39m=[32m"true"[39m
@@ -738,7 +748,7 @@ exports[`listbox > renders with error 1`] = `
 [36m</DocumentFragment>[39m"
 `;
 
-exports[`listbox > renders with floating label 1`] = `
+exports[`listbox button > renders with floating label 1`] = `
 "[36m<DocumentFragment>[39m
   [36m<span[39m
     [33mclass[39m=[32m"listbox-button"[39m
@@ -870,7 +880,7 @@ exports[`listbox > renders with floating label 1`] = `
 [36m</DocumentFragment>[39m"
 `;
 
-exports[`listbox > renders with form 1`] = `
+exports[`listbox button > renders with form 1`] = `
 "[36m<DocumentFragment>[39m
   [36m<span[39m
     [33mclass[39m=[32m"listbox-button listbox-button--form"[39m
@@ -1007,7 +1017,7 @@ exports[`listbox > renders with form 1`] = `
 [36m</DocumentFragment>[39m"
 `;
 
-exports[`listbox > renders with prefix id 1`] = `
+exports[`listbox button > renders with prefix id 1`] = `
 "[36m<DocumentFragment>[39m
   [36m<span[39m
     [33mclass[39m=[32m"listbox-button"[39m
@@ -1146,7 +1156,7 @@ exports[`listbox > renders with prefix id 1`] = `
 [36m</DocumentFragment>[39m"
 `;
 
-exports[`listbox > renders with prefix label 1`] = `
+exports[`listbox button > renders with prefix label 1`] = `
 "[36m<DocumentFragment>[39m
   [36m<span[39m
     [33mclass[39m=[32m"listbox-button"[39m
@@ -1283,7 +1293,7 @@ exports[`listbox > renders with prefix label 1`] = `
 [36m</DocumentFragment>[39m"
 `;
 
-exports[`listbox > renders with second item selected 1`] = `
+exports[`listbox button > renders with second item selected 1`] = `
 "[36m<DocumentFragment>[39m
   [36m<span[39m
     [33mclass[39m=[32m"listbox-button"[39m
@@ -1421,7 +1431,7 @@ exports[`listbox > renders with second item selected 1`] = `
 [36m</DocumentFragment>[39m"
 `;
 
-exports[`listbox > renders with strategy=fixed 1`] = `
+exports[`listbox button > renders with strategy=fixed 1`] = `
 "[36m<DocumentFragment>[39m
   [36m<span[39m
     [33mclass[39m=[32m"listbox-button"[39m

--- a/packages/ebayui-core/src/components/ebay-listbox-button/test/test.server.js
+++ b/packages/ebayui-core/src/components/ebay-listbox-button/test/test.server.js
@@ -7,7 +7,7 @@ const { Default, withDescription, withError } = composeStories(stories);
 
 const htmlSnap = snapshotHTML(__dirname);
 
-describe("listbox", () => {
+describe("listbox button", () => {
     it("renders basic version", async () => {
         await htmlSnap(Default);
     });

--- a/packages/ebayui-core/src/components/ebay-listbox/component.ts
+++ b/packages/ebayui-core/src/components/ebay-listbox/component.ts
@@ -22,6 +22,7 @@ export interface Option extends Omit<Marko.HTML.Option, `on${string}`> {
 interface ListboxInput extends Omit<Marko.HTML.Div, `on${string}`> {
     "list-selection"?: "auto" | "manual";
     "typeahead-timeout-length"?: number;
+    "a11y-selected-text"?: string;
     option?: Marko.AttrTag<Option>;
     name?: string;
     disabled?: boolean;

--- a/packages/ebayui-core/src/components/ebay-listbox/index.marko
+++ b/packages/ebayui-core/src/components/ebay-listbox/index.marko
@@ -6,6 +6,7 @@ $ const {
     option: options = [],
     tabindex = 0,
     typeaheadTimeoutLength,
+    a11ySelectedText = "selected",
     ...htmlInput
 } = input;
 
@@ -18,8 +19,7 @@ $ const {
     on-activeDescendantChange(
         component.isAutoSelection ? "handleListboxChange" : undefined,
     )
-    onKeydown(!component.isAutoSelection && "handleKeyDown")
->
+    onKeydown(!component.isAutoSelection && "handleKeyDown")>
     <for|option, index| of=options || []>
         $ const {
             value,
@@ -32,6 +32,7 @@ $ const {
             description,
             ...htmlOption
         } = option;
+        $ var isSelected = (index === state.selectedIndex);
         <div
             ...processHtmlAttributes(htmlOption)
             key="option[]"
@@ -39,15 +40,19 @@ $ const {
             role="option"
             tabindex=(disabled ? -1 : tabindex)
             aria-disabled=disabled && "true"
-            aria-selected=index === state.selectedIndex && "true"
+            aria-selected=isSelected && "true"
             onClick(!component.isAutoSelection && "handleClick", index)
-            onMousedown(component.isAutoSelection && "handleMouseDown")
-        >
+            onMousedown(component.isAutoSelection && "handleMouseDown")>
             <if(icon)>
                 <span class="listbox__value">
                     <${icon}/>
                     <if(text)>
                         <span>${text}</span>
+                        <if(isSelected)>
+                            <span class="clipped">
+                                ${a11ySelectedText}
+                            </span>
+                        </if>
                     </if>
                     <if(description)>
                         <span>
@@ -59,6 +64,11 @@ $ const {
             <else>
                 <span class="listbox__value">
                     ${text}
+                    <if(isSelected)>
+                        <span class="clipped">
+                            ${a11ySelectedText}
+                        </span>
+                    </if>
                 </span>
                 <if(description)>
                     <span class="listbox__description">
@@ -75,7 +85,6 @@ $ const {
         <option
             value=option.value
             selected=i === state.selectedIndex
-            class=option.class
-        />
+            class=option.class/>
     </for>
 </select>

--- a/packages/ebayui-core/src/components/ebay-listbox/listbox.stories.ts
+++ b/packages/ebayui-core/src/components/ebay-listbox/listbox.stories.ts
@@ -46,6 +46,17 @@ export default {
             description:
                 "allows you to set the selected index option to `selected`",
         },
+        a11ySelectedText: {
+            type: "text",
+            control: { type: "text" },
+            description:
+                "Localized text to be read by screen readers when an option is selected",
+            table: {
+                defaultValue: {
+                    summary: "selected",
+                },
+            },
+        },
         option: {
             name: "@option",
             table: {

--- a/packages/ebayui-core/src/components/ebay-listbox/marko-tag.json
+++ b/packages/ebayui-core/src/components/ebay-listbox/marko-tag.json
@@ -16,6 +16,7 @@
     },
     "@button-name": "#html-name",
     "@disabled": "#html-disabled",
+    "@a11y-selected-text": "string",
     "@option <option>[]": {
         "attribute-groups": ["html-attributes"],
         "@*": {

--- a/packages/ebayui-core/src/components/ebay-listbox/test/__snapshots__/test.server.js.snap
+++ b/packages/ebayui-core/src/components/ebay-listbox/test/__snapshots__/test.server.js.snap
@@ -503,6 +503,11 @@ exports[`listbox > renders with second item disabled 1`] = `
         [33mclass[39m=[32m"listbox__value"[39m
       [36m>[39m
         [0mOption 2[0m
+        [36m<span[39m
+          [33mclass[39m=[32m"clipped"[39m
+        [36m>[39m
+          [0mselected[0m
+        [36m</span>[39m
       [36m</span>[39m
       [36m<svg[39m
         [33maria-hidden[39m=[32m"true"[39m
@@ -599,6 +604,11 @@ exports[`listbox > renders with second item selected 1`] = `
         [33mclass[39m=[32m"listbox__value"[39m
       [36m>[39m
         [0mOption 2[0m
+        [36m<span[39m
+          [33mclass[39m=[32m"clipped"[39m
+        [36m>[39m
+          [0mselected[0m
+        [36m</span>[39m
       [36m</span>[39m
       [36m<svg[39m
         [33maria-hidden[39m=[32m"true"[39m


### PR DESCRIPTION
<!-- Insert GitHub issue number below. An issue is required for all PRs -->

- Fixes #276

## Description

- Added a new `a11ySelectedText` attribute (defaults to "selected") to both `ebay-listbox` and `ebay-listbox-button` components
- This allows localization of the text announced by screen readers when an option is selected
- Updated test snapshots to reflect the new accessibility markup

## Notes

- Added a hidden <span class="clipped"> element that contains the selected text for AT. This span is only rendered when an option is selected

## Checklist

<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->

- [x] I verify all changes are within scope of the linked issue
- [x] I added/updated/removed testing (Storybook in Skin) coverage as appropriate