### PR TITLE
fix(chip): added type for event

### DIFF
--- a/.changeset/short-frogs-post.md
+++ b/.changeset/short-frogs-post.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ebayui-core": patch
+---
+
+fix(chip): added type for event

--- a/packages/ebayui-core/src/components/ebay-filter-chip/component.ts
+++ b/packages/ebayui-core/src/components/ebay-filter-chip/component.ts
@@ -4,6 +4,11 @@ interface Image extends Marko.HTML.Img {
     as?: string;
 }
 
+export interface FilterChipEvent {
+    originalEvent: MouseEvent;
+    expanded: boolean;
+    selected: boolean;
+}
 interface FilterChipInput
     extends Omit<Marko.HTML.Button, `on${string}` | "type">,
         Omit<Marko.HTML.A, `on${string}`> {
@@ -14,11 +19,7 @@ interface FilterChipInput
     image?: Marko.AttrTag<Image>;
     "a11y-selected-text"?: Marko.HTMLAttributes["aria-label"];
     expanded?: boolean;
-    "on-click"?: (event: {
-        originalEvent: MouseEvent;
-        expanded: boolean;
-        selected: boolean;
-    }) => void;
+    "on-click"?: (event: FilterChipEvent) => void;
 }
 export interface Input extends WithNormalizedProps<FilterChipInput> {}
 

--- a/packages/ebayui-core/src/components/ebay-selection-chip/component.ts
+++ b/packages/ebayui-core/src/components/ebay-selection-chip/component.ts
@@ -2,7 +2,7 @@ import type { WithNormalizedProps } from "../../global";
 
 export interface SelectionChipEvent {
    selected: boolean;
-   originalEvent: Event
+   originalEvent: Event;
 }
 
 interface SelectionChipInput extends Omit<Marko.HTML.Button, `on${string}`> {

--- a/packages/ebayui-core/src/components/ebay-selection-chip/component.ts
+++ b/packages/ebayui-core/src/components/ebay-selection-chip/component.ts
@@ -1,9 +1,14 @@
 import type { WithNormalizedProps } from "../../global";
 
+export interface SelectionChipEvent {
+   selected: boolean;
+   originalEvent: Event
+}
+
 interface SelectionChipInput extends Omit<Marko.HTML.Button, `on${string}`> {
     renderBody?: Marko.Body;
     selected?: boolean;
-    "on-click"?: () => void;
+    "on-click"?: (event: SelectionChipEvent) => void;
 }
 export interface Input extends WithNormalizedProps<SelectionChipInput> {}
 


### PR DESCRIPTION
- Fixes #269

## Description

Added types for filter chip and selection chip

## Checklist

- [X] I verify all changes are within scope of the linked issue
- [X] I added/updated/removed testing (Storybook in Skin) coverage as appropriate
