### PR TITLE
fix(video,tourtip): bugs on components

### DIFF
--- a/.changeset/clear-news-search.md
+++ b/.changeset/clear-news-search.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ebayui-core": patch
+---
+
+fix(video): fixed several bugs on resize and undefined variables

--- a/.changeset/thin-snakes-talk.md
+++ b/.changeset/thin-snakes-talk.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ebayui-core": patch
+---
+
+fix(tourtip): added host container override

--- a/packages/ebayui-core/src/components/ebay-tourtip/component.ts
+++ b/packages/ebayui-core/src/components/ebay-tourtip/component.ts
@@ -6,7 +6,10 @@ interface TourtipInput
     extends Omit<Marko.HTML.Span, `on${string}` | "content"> {
     open?: boolean;
     "no-hover"?: TooltipBaseInput["noHover"];
-    host?: Marko.AttrTag<Marko.HTML.Span>;
+    host?: Marko.AttrTag<Marko.HTML.Span & {
+        as?: string;
+        renderBody?: Marko.Body;
+    }>;
     offset?: TooltipBaseInput["offset"];
     pointer?: TooltipBaseInput["pointer"];
     placement?: TooltipBaseInput["placement"];

--- a/packages/ebayui-core/src/components/ebay-tourtip/index.marko
+++ b/packages/ebayui-core/src/components/ebay-tourtip/index.marko
@@ -23,19 +23,21 @@ $ const {
         pointer=input.pointer
         placement=input.placement
         offset=input.offset
-        overlay-id:scoped="overlay"
-    >
+        overlay-id:scoped="overlay">
         <span
             ...processHtmlAttributes(htmlInput)
-            class=["tourtip", state.expanded && "tourtip--expanded"]
-        >
+            class=["tourtip", state.expanded && "tourtip--expanded"]>
             <if(host)>
-                <span
-                    class=[host.class, "tourtip__host"]
-                    ...processHtmlAttributes(host)
-                >
+                $ const {
+                    as: hostAs = "span",
+                    class: hostClass,
+                    ...hostInput
+                } = host;
+                <${hostAs}
+                    class=[hostClass, "tourtip__host"]
+                    ...processHtmlAttributes(hostInput)>
                     <${host.renderBody}/>
-                </span>
+                </>
             </if>
             <ebay-tooltip-overlay
                 type="tourtip"
@@ -43,8 +45,7 @@ $ const {
                 heading=heading
                 content=content
                 a11yCloseText=a11yCloseText
-                onOverlay-close("handleCollapse")
-            >
+                onOverlay-close("handleCollapse")>
                 <if(footer)>
                     <@footer class=[footer.class]>
                         <if(footer.index)>

--- a/packages/ebayui-core/src/components/ebay-tourtip/marko-tag.json
+++ b/packages/ebayui-core/src/components/ebay-tourtip/marko-tag.json
@@ -47,7 +47,8 @@
             "targetProperty": null,
             "type": "expression"
         },
-        "@html-attributes": "expression"
+        "@html-attributes": "expression",
+        "@as": "string"
     },
     "@heading <heading>": {
         "attribute-groups": ["html-attributes"],

--- a/packages/ebayui-core/src/components/ebay-tourtip/tourtip.stories.ts
+++ b/packages/ebayui-core/src/components/ebay-tourtip/tourtip.stories.ts
@@ -51,7 +51,7 @@ export default {
 
         host: {
             name: "@host",
-            description: "The body which will be wrapped as the tourtip's host",
+            description: "The body which will be wrapped as the tourtip's host. Defaults as span. Use \"as\" attribute on @host to override.",
             table: {
                 category: "@attribute tags",
             },

--- a/packages/ebayui-core/src/components/ebay-video/component.ts
+++ b/packages/ebayui-core/src/components/ebay-video/component.ts
@@ -30,7 +30,6 @@ const eventList = [
 ];
 
 const videoConfig = {
-    addBigPlayButton: false,
     addSeekBar: true,
     controlPanelElements: [
         "play_pause",
@@ -98,6 +97,7 @@ class Video extends Marko.Component<Input, State> {
     declare video: HTMLVideoElement;
     declare root: HTMLElement;
     declare containerEl: HTMLElement;
+    declare playButtonContainer: HTMLElement;
     declare player: any;
     declare ui: any;
     declare shaka: any;
@@ -117,7 +117,7 @@ class Video extends Marko.Component<Input, State> {
     }
 
     handleResize() {
-        if (!this.input.width && this.video) {
+        if (!this.input.width && this.video && this.root) {
             const { width: containerWidth } = this.root.getBoundingClientRect();
             this.containerEl.setAttribute("width", containerWidth.toString());
             this.alignSeekbar();
@@ -133,11 +133,13 @@ class Video extends Marko.Component<Input, State> {
             const rangeContainer = this.el.querySelector<HTMLElement>(
                 ".shaka-range-container",
             )!;
-            const buttonPanelRect = buttonPanel.getBoundingClientRect();
-            const spacerRect = spacer.getBoundingClientRect();
+            if (buttonPanel && spacer) {
+                const buttonPanelRect = buttonPanel.getBoundingClientRect();
+                const spacerRect = spacer.getBoundingClientRect();
 
-            rangeContainer.style.marginRight = `${buttonPanelRect.right - spacerRect.right}px`;
-            rangeContainer.style.marginLeft = `${spacerRect.left - buttonPanelRect.left}px`;
+                rangeContainer.style.marginRight = `${buttonPanelRect.right - spacerRect.right}px`;
+                rangeContainer.style.marginLeft = `${spacerRect.left - buttonPanelRect.left}px`;
+            }
         }
     }
 
@@ -172,12 +174,8 @@ class Video extends Marko.Component<Input, State> {
     handleError(err: Error) {
         this.state.failed = true;
         this.state.isLoaded = true;
+        this.playButtonContainer.remove();
 
-        if (this.ui) {
-            this.ui.configure({
-                addBigPlayButton: false,
-            });
-        }
         this.emit("load-error", err);
     }
 
@@ -335,7 +333,6 @@ class Video extends Marko.Component<Input, State> {
         );
 
         this.ui.configure({
-            addBigPlayButton: true,
             controlPanelElements: [],
             addSeekBar: false,
         });
@@ -344,10 +341,13 @@ class Video extends Marko.Component<Input, State> {
         if (this.el) {
             const playIcon =
                 this.getComponent("play-icon")!.el!.cloneNode(true);
-            const playButton =
-                this.el.querySelector<HTMLElement>(".shaka-play-button")!;
-            playButton.removeAttribute("icon");
-            playButton.appendChild(playIcon);
+            const container =
+                this.el.querySelector<HTMLElement>(".shaka-controls-container")!;
+            this.playButtonContainer = document.createElement("div");
+            this.playButtonContainer.classList.add("shaka-play-button-container");
+
+            this.playButtonContainer.appendChild(playIcon);
+            container.appendChild(this.playButtonContainer);
 
             const shakaSpinner =
                 this.el.querySelector<HTMLElement>(".shaka-spinner");

--- a/packages/ebayui-core/src/components/ebay-video/index.marko
+++ b/packages/ebayui-core/src/components/ebay-video/index.marko
@@ -22,8 +22,8 @@ $ const {
     ...htmlInput
 } = input;
 $ const styleSize = {
-    width: `${width}px`,
-    height: `${height}px`,
+    width: width ? `${width}px` : "",
+    height: height ? `${height}px` : "",
 };
 
 <div


### PR DESCRIPTION
## Description
* Video: fixed an issue where the video was being loaded but not shown. This was causing some issues with showing an error in the console because some dom elements werent instantiated by shaka yet
* Video: fixed an issue with the big play button which was bugged and showing weird symbols. I basically just inject a play button container now.
* Video: Fixed an issue where styles were coming in the page as `width: undefinedpx, height: undefinedpx`
* Tourtip: added an override to allow custom containers so that span wasn't the only option. This helps to position of the element correctly if the container needs to be a div

## Checklist
- [X] I verify all changes are within scope of the linked issue
- [X] I added/updated/removed testing (Storybook in Skin) coverage as appropriate
