### PR TITLE
fix(carousel): fixed aria-roledescription defaulting behavior

### DIFF
--- a/.changeset/silly-cycles-jam.md
+++ b/.changeset/silly-cycles-jam.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ebayui-core": patch
+---
+
+fix(carousel): fixed aria-roledescription defaulting behavior

--- a/packages/ebayui-core/src/components/ebay-carousel/component.ts
+++ b/packages/ebayui-core/src/components/ebay-carousel/component.ts
@@ -77,6 +77,7 @@ interface State {
     a11yNextText: string;
     a11yPauseText: string;
     a11yPlayText: string;
+    ariaRoledescription: string;
 }
 
 class Carousel extends Marko.Component<Input, State> {
@@ -441,6 +442,7 @@ class Carousel extends Marko.Component<Input, State> {
             a11yNextText: input.a11yNextText || "Next Slide",
             a11yPauseText: input.a11yPauseText || "Pause",
             a11yPlayText: input.a11yPlayText || "Play",
+            ariaRoledescription: input.ariaRoledescription || "Carousel",
             items: [] as State["items"],
             slideWidth: 0,
             autoplayInterval: 0,

--- a/packages/ebayui-core/src/components/ebay-carousel/index.marko
+++ b/packages/ebayui-core/src/components/ebay-carousel/index.marko
@@ -2,10 +2,10 @@ $ var data = component.getTemplateData(state);
 $ var config = data.config;
 
 <div
-    aria-roledescription="Carousel",
     ...data.htmlAttributes
     class=data.classes
     style=data.style
+    aria-roledescription=data.ariaRoledescription
     role="group"
 >
     <div


### PR DESCRIPTION
- Issue # TBD

Reverts https://github.com/eBay/evo-web/commit/fc4bf34020f78c95956dbf0213d96036088b894b#diff-95e37f2be92482d274ecdff521de17d05a4532d93681dc2b824be75b15ca4c89
and changes spelling
```diff
- input.ariaRoleDescription
+ input.ariaRoledescription
```

## Description

✅ Validated behavior across all use cases:

1. `aria-roledescription` is unset:
  Renders default value: `aria-roledescription="Carousel"`
```
<ebay-carousel
  ...
/>
```
2. `aria-roledescription` is `undefined` - 🚧 **this is what is currently broken on main**:
  Renders default value: `aria-roledescription="Carousel"`
```
<ebay-carousel
  ...
  aria-roledescription=undefined
/>
```


3. `aria-roledescription` is `"Custom value"`:
  Renders custom value: `aria-roledescription="Custom value"`
```
<ebay-carousel
  ...
  aria-roledescription="Custom value"
/>
```

4. camelCase spelling: `ariaRoledescription` is `"Custom value"`:
  Renders custom value: `aria-roledescription="Custom value"`
```
<ebay-carousel
  ...
  ariaRoledescription="Custom value"
/>
```
