### PR TITLE
chore(EbayAvatar): remove usage of React.Children and cloneElement

### DIFF
--- a/.changeset/petite-swans-drum.md
+++ b/.changeset/petite-swans-drum.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ui-core-react": patch
+---
+
+chore(EbayAvatar): remove usage of React.Children and cloneElement

--- a/packages/ebayui-core-react/src/ebay-avatar/__tests__/__snapshots__/render.spec.tsx.snap
+++ b/packages/ebayui-core-react/src/ebay-avatar/__tests__/__snapshots__/render.spec.tsx.snap
@@ -86,7 +86,7 @@ exports[`<EbayAvatar /> rendering renders with custom body story correctly 1`] =
 <div>
   <div
     aria-label="Signed in as Elizabeth"
-    class="avatar avatar--teal"
+    class="avatar"
     role="img"
   >
     <div

--- a/packages/ebayui-core-react/src/ebay-avatar/avatar-image.tsx
+++ b/packages/ebayui-core-react/src/ebay-avatar/avatar-image.tsx
@@ -1,8 +1,23 @@
 /* eslint-disable jsx-a11y/alt-text */
-import React, { ComponentProps, FC } from "react";
+import React, { ComponentProps, FC, useContext } from "react";
+import { AvatarContext } from "./context";
+import { isFit } from "./utils";
+import { invariant } from "../utils/invariant";
 
 export type EbayAvatarImageProps = ComponentProps<"img">;
 
-const AvatarImage: FC<EbayAvatarImageProps> = (props) => <img {...props} />;
+const AvatarImage: FC<EbayAvatarImageProps> = ({ onLoad, ...props }) => {
+    const context = useContext(AvatarContext);
+    invariant(context, "EbayAvatarImage needs to be used with EbayAvatar component");
+
+    const handleImageLoad: ComponentProps<"img">["onLoad"] = (event) => {
+        const element = event.target as HTMLImageElement;
+        const aspectRatio = element.naturalWidth / element.naturalHeight;
+
+        context.setImagePlacement(isFit(aspectRatio) ? "fit" : "cover");
+        onLoad?.(event);
+    };
+    return <img onLoad={handleImageLoad} {...props} />;
+};
 
 export default AvatarImage;

--- a/packages/ebayui-core-react/src/ebay-avatar/avatar.tsx
+++ b/packages/ebayui-core-react/src/ebay-avatar/avatar.tsx
@@ -1,10 +1,9 @@
 import React, { ComponentProps, FC, useState } from "react";
 import cx from "classnames";
 import { EbayIcon } from "../ebay-icon";
-import { getColorForText } from "./utils";
+import { getColorForText, isFit } from "./utils";
 import { Size, Color } from "./types";
-import { findComponent } from "../utils";
-import EbayAvatarImage from "./avatar-image";
+import { AvatarContext } from "./context";
 
 export type EbayAvatarProps = ComponentProps<"div"> & {
     size?: Size | `${Size}`;
@@ -12,10 +11,6 @@ export type EbayAvatarProps = ComponentProps<"div"> & {
     username?: string;
     knownAspectRatio?: number;
 };
-
-function isFit(aspectRation?: number): boolean {
-    return aspectRation && (aspectRation < 3 / 4 || aspectRation < 4 / 3);
-}
 
 const EbayAvatar: FC<EbayAvatarProps> = ({
     size,
@@ -27,38 +22,23 @@ const EbayAvatar: FC<EbayAvatarProps> = ({
     ...rest
 }: EbayAvatarProps) => {
     const [imagePlacement, setImagePlacement] = useState<"fit" | "cover">(isFit(knownAspectRatio) ? "fit" : "cover");
-    const img = findComponent(children, EbayAvatarImage);
-
-    const handleImageLoad: ComponentProps<"img">["onLoad"] = (event) => {
-        const element = event.target as HTMLImageElement;
-        const aspectRatio = element.naturalWidth / element.naturalHeight;
-
-        setImagePlacement(isFit(aspectRatio) ? "fit" : "cover");
-    };
 
     return (
-        <div
-            {...rest}
-            role="img"
-            className={cx(
-                "avatar",
-                className,
-                size && `avatar--${size}`,
-                imagePlacement === "fit" && "avatar--fit",
-                username && !img && `avatar--${getColorForText(username, color)}`,
-            )}
-        >
-            {React.Children.count(children) > 0
-                ? (img &&
-                      React.cloneElement<ComponentProps<"img">>(img, {
-                          onLoad(event) {
-                              img.props.onLoad?.(event);
-                              handleImageLoad(event);
-                          },
-                      })) ||
-                  children
-                : username?.charAt(0).toUpperCase() || <EbayIcon name="avatarSignedOut" />}
-        </div>
+        <AvatarContext.Provider value={{ setImagePlacement }}>
+            <div
+                {...rest}
+                role="img"
+                className={cx(
+                    "avatar",
+                    className,
+                    size && `avatar--${size}`,
+                    imagePlacement === "fit" && "avatar--fit",
+                    username && !children && `avatar--${getColorForText(username, color)}`,
+                )}
+            >
+                {children || username?.charAt(0).toUpperCase() || <EbayIcon name="avatarSignedOut" />}
+            </div>
+        </AvatarContext.Provider>
     );
 };
 

--- a/packages/ebayui-core-react/src/ebay-avatar/context.ts
+++ b/packages/ebayui-core-react/src/ebay-avatar/context.ts
@@ -1,0 +1,5 @@
+import { createContext } from "react";
+
+export const AvatarContext = createContext<{
+    setImagePlacement: (value: "fit" | "cover") => void;
+} | null>(null);

--- a/packages/ebayui-core-react/src/ebay-avatar/utils.ts
+++ b/packages/ebayui-core-react/src/ebay-avatar/utils.ts
@@ -21,3 +21,7 @@ export function getColorForText(username?: string, color?: Color): Color {
     const index = Math.abs(hash) % colorCount;
     return backgroundColors[index];
 }
+
+export function isFit(aspectRatio?: number): boolean {
+    return aspectRatio && (aspectRatio < 3 / 4 || aspectRatio < 4 / 3);
+}

--- a/packages/ebayui-core-react/src/utils/invariant.ts
+++ b/packages/ebayui-core-react/src/utils/invariant.ts
@@ -1,0 +1,7 @@
+export function invariant(condition: unknown, message?: string): asserts condition {
+    if (condition) {
+        return;
+    }
+
+    throw new Error(message || "Invariant failed");
+}


### PR DESCRIPTION
<!-- Insert GitHub issue number below. An issue is required for all PRs -->

Part of #112 

## Description

<!-- Briefly describe the proposed changes -->
- Remove `findComponents` usage from `EbayAvatar`
- Introduce a context so state update function can be used on the `EbayAvatarImage`
- Move onLoad logic to `EbayAvatarImage` component

## Notes

This doesn't change any behavior nor API of the component.