### PR TITLE
feat(EbayIconButton): add support for 'priority' property

### DIFF
--- a/.changeset/common-pears-move.md
+++ b/.changeset/common-pears-move.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ui-core-react": minor
+---
+
+feat(EbayIconButton): add support for 'priority' property

--- a/packages/ebayui-core-react/src/ebay-icon-button/README.md
+++ b/packages/ebayui-core-react/src/ebay-icon-button/README.md
@@ -50,6 +50,7 @@ with badge:
 | `bageAriaLabel` | String  | No       | No       | aria label of the badge                                  |
 | `transparent`   | Boolean | No       | No       | for transparent background                               |
 | `size`          | String  | No       | No       | alternative size for the icon button, 'large' or 'small' |
+| `priority`      | String  | No       | No       | `primary`, `secondary`, `tertiary`, `none` (default)     |
 
 ## Callbacks
 

--- a/packages/ebayui-core-react/src/ebay-icon-button/__tests__/index.stories.tsx
+++ b/packages/ebayui-core-react/src/ebay-icon-button/__tests__/index.stories.tsx
@@ -57,3 +57,12 @@ export const Transparent = () => (
         </p>
     </>
 );
+
+export const WithPriority = () => (
+    <div style={{ display: "flex", flexDirection: "column", gap: "16px" }}>
+        <EbayIconButton onClick={action("clicked")} icon="menu20" aria-label="Menu" />
+        <EbayIconButton onClick={action("clicked")} priority="primary" icon="menu20" aria-label="Menu" />
+        <EbayIconButton onClick={action("clicked")} priority="secondary" icon="menu20" aria-label="Menu" />
+        <EbayIconButton onClick={action("clicked")} priority="tertiary" icon="menu20" aria-label="Menu" />
+    </div>
+);

--- a/packages/ebayui-core-react/src/ebay-icon-button/__tests__/render.spec.tsx
+++ b/packages/ebayui-core-react/src/ebay-icon-button/__tests__/render.spec.tsx
@@ -1,11 +1,12 @@
 import React from "react";
 import { render, getAllByRole } from "@testing-library/react";
 import { composeStory } from "@storybook/react-vite";
-import Meta, { Default, WithBadges, Transparent } from "./index.stories";
+import Meta, { Default, WithBadges, Transparent, WithPriority } from "./index.stories";
 
 const DefaultStory = composeStory(Default, Meta);
 const WithBadgesStory = composeStory(WithBadges, Meta);
 const TransparentStory = composeStory(Transparent, Meta);
+const WithPriorityStory = composeStory(WithPriority, Meta);
 
 describe("EbayIconButton rendering", () => {
     describe("Default", () => {
@@ -56,6 +57,18 @@ describe("EbayIconButton rendering", () => {
             expect(svg).toHaveClass("icon icon--20");
             expect(svg).toHaveAttribute("aria-hidden", "true");
             expect(svg).toHaveAttribute("focusable", "false");
+        });
+    });
+
+    describe("With Priority", () => {
+        it("should render correctly", () => {
+            const { container } = render(<WithPriorityStory />);
+            const buttons = getAllByRole(container, "button");
+
+            expect(buttons[0]).toHaveClass("icon-btn");
+            expect(buttons[1]).toHaveClass("icon-btn icon-btn--primary");
+            expect(buttons[2]).toHaveClass("icon-btn icon-btn--secondary");
+            expect(buttons[3]).toHaveClass("icon-btn icon-btn--tertiary");
         });
     });
 });

--- a/packages/ebayui-core-react/src/ebay-icon-button/icon-button.tsx
+++ b/packages/ebayui-core-react/src/ebay-icon-button/icon-button.tsx
@@ -4,7 +4,7 @@ import { EbayIcon, Icon } from "../ebay-icon";
 import { EbayBadge } from "../ebay-badge";
 import { withForwardRef } from "../common/component-utils";
 import { EbayKeyboardEventHandler } from "../common/event-utils/types";
-import { Size } from "../ebay-button";
+import { Priority, Size } from "../ebay-button";
 
 export type EbayIconButtonProps = ComponentProps<"button"> &
     ComponentProps<"a"> & {
@@ -13,6 +13,7 @@ export type EbayIconButtonProps = ComponentProps<"button"> &
         badgeNumber?: number;
         badgeAriaLabel?: string;
         transparent?: boolean;
+        priority?: Priority;
         size?: Size;
         forwardedRef?: RefObject<HTMLAnchorElement & HTMLButtonElement>;
         onEscape?: EbayKeyboardEventHandler;
@@ -26,16 +27,29 @@ const EbayIconButton: FC<EbayIconButtonProps> = ({
     transparent,
     className: extraClasses,
     forwardedRef,
+    priority = "none",
     size,
     onEscape = () => {},
     onKeyDown = () => {},
     ...rest
 }) => {
     const classPrefix = href ? "icon-link" : "icon-btn";
-    const className = classNames(extraClasses, classPrefix, size && `${classPrefix}--${size}`, {
-        [`${classPrefix}--badged`]: badgeNumber,
-        [`${classPrefix}--transparent`]: transparent,
-    });
+    const priorityStyles: { [key in Priority]: string } = {
+        primary: `${classPrefix}--primary`,
+        secondary: `${classPrefix}--secondary`,
+        tertiary: `${classPrefix}--tertiary`,
+        none: "",
+    };
+    const className = classNames(
+        extraClasses,
+        classPrefix,
+        size && `${classPrefix}--${size}`,
+        {
+            [`${classPrefix}--badged`]: badgeNumber,
+            [`${classPrefix}--transparent`]: transparent,
+        },
+        priorityStyles[priority],
+    );
     const children = (
         <>
             <EbayIcon name={icon} />


### PR DESCRIPTION
<!-- Insert GitHub issue number below. An issue is required for all PRs -->

- Fixes #309 

## Description

- Add support for `priority` on `EbayIconButton`

## Screenshots
<img width="75" height="221" alt="Screenshot 2025-10-03 at 2 01 23 PM" src="https://github.com/user-attachments/assets/fdb6ba7f-59db-45fa-b36a-3a5f7d1b0668" />

<!-- Upload screenshots of UI before & after these changes -->

## Checklist

<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->

- [x] I verify all changes are within scope of the linked issue
- [x] I added/updated/removed testing (Storybook in Skin) coverage as appropriate

<!-- For CSS changes -->

- [ ] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [ ] I tested the UI in dark mode and RTL mode
