### PR TITLE
feat(EbayMenu): add support for 'fixed' strategy on menus

### DIFF
--- a/.changeset/tasty-apes-ring.md
+++ b/.changeset/tasty-apes-ring.md
@@ -1,0 +1,7 @@
+---
+"@ebay/ui-core-react": minor
+---
+
+feat(MenuButton): add support for 'fixed' layout strategy
+feat(ListboxButton): add support for 'fixed' layout strategy
+feat(Menu): add support for 'fixed' layout strategy

--- a/packages/ebayui-core-react/src/common/dropdown.ts
+++ b/packages/ebayui-core-react/src/common/dropdown.ts
@@ -21,11 +21,13 @@ export type FloatingDropdownHookArgs = {
 export type FloatingDropdownHookOptions = {
     offset?: number;
     reverse?: boolean;
+    strategy?: "fixed" | "absolute";
 };
 
 export function useFloatingDropdown({ open, options }: FloatingDropdownHookArgs): FloatingDropdownHookReturn {
     const { floatingStyles, refs } = useFloating({
         placement: options?.reverse ? "bottom-end" : "bottom-start",
+        strategy: options?.strategy,
         open,
         middleware: [offset(options?.offset ?? 4), flip(), shift()],
         whileElementsMounted: autoUpdate,

--- a/packages/ebayui-core-react/src/ebay-fake-menu-button/menu-button.tsx
+++ b/packages/ebayui-core-react/src/ebay-fake-menu-button/menu-button.tsx
@@ -21,6 +21,7 @@ export type EbayFakeMenuButtonProps = {
     expanded?: boolean;
     fixWidth?: boolean;
     reverse?: boolean;
+    strategy?: "absolute" | "fixed";
     variant?: EbayFakeMenuButtonVariant;
     className?: string;
     onCollapse?: () => void;
@@ -42,6 +43,7 @@ const EbayMenuButton: FC<Props> = ({
     fixWidth,
     reverse,
     variant,
+    strategy,
     expanded: defaultExpanded = false,
     className,
     onCollapse = () => {},
@@ -61,7 +63,7 @@ const EbayMenuButton: FC<Props> = ({
 
     const { overlayStyles, refs } = useFloatingDropdown({
         open: expanded,
-        options: { reverse },
+        options: { reverse, strategy },
     });
 
     const buttonRef = refs.host as React.MutableRefObject<HTMLButtonElement>;

--- a/packages/ebayui-core-react/src/ebay-listbox-button/README.md
+++ b/packages/ebayui-core-react/src/ebay-listbox-button/README.md
@@ -44,19 +44,20 @@ yarn add @ebay/ui-core-react
 
 ## Attributes
 
-| Name             | Type    | Required | Description                                                                                             |
-| ---------------- | ------- | -------- | ------------------------------------------------------------------------------------------------------- |
-| `value`          | string  | No       | Allows you to set the selected option to the one with `value`                                           |
-| `selected`       | number  | No       | Allows you to set the selected index option to `selected`                                               |
-| `aria-disabled`  | boolean | No       | Set to true if the field is disabled                                                                    |
-| `aria-invalid`   | boolean | No       | Set to true if the field is invalid                                                                     |
-| `fluid`          | boolean | No       | To make the listbox fluid                                                                               |
-| `borderless`     | boolean | No       | To make the listbox borderless                                                                          |
-| `maxHeight`      | string  | No       | example: 100px, 200px, 10rem                                                                            |
-| `prefixId`       | string  | No       | The id of an external element to use as the a11y prefix label for the listbox button.                   |
-| `prefixLabel`    | string  | No       | The label to add before selected option on the button. Cannot be used with `prefixId`                   |
-| `floatingLabel`  | string  | No       | Indicates that the listbox is a floating label type and renders it with a label                         |
-| `unselectedText` | string  | No       | The text to be shown when no options are selected. Default is '-'. Cannot be used with `floating-label` |
+| Name             | Type    | Required | Description                                                                                                                                                          |
+| ---------------- | ------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `value`          | string  | No       | Allows you to set the selected option to the one with `value`                                                                                                        |
+| `selected`       | number  | No       | Allows you to set the selected index option to `selected`                                                                                                            |
+| `aria-disabled`  | boolean | No       | Set to true if the field is disabled                                                                                                                                 |
+| `aria-invalid`   | boolean | No       | Set to true if the field is invalid                                                                                                                                  |
+| `fluid`          | boolean | No       | To make the listbox fluid                                                                                                                                            |
+| `borderless`     | boolean | No       | To make the listbox borderless                                                                                                                                       |
+| `maxHeight`      | string  | No       | example: 100px, 200px, 10rem                                                                                                                                         |
+| `prefixId`       | string  | No       | The id of an external element to use as the a11y prefix label for the listbox button.                                                                                |
+| `prefixLabel`    | string  | No       | The label to add before selected option on the button. Cannot be used with `prefixId`                                                                                |
+| `floatingLabel`  | string  | No       | Indicates that the listbox is a floating label type and renders it with a label                                                                                      |
+| `unselectedText` | string  | No       | The text to be shown when no options are selected. Default is '-'. Cannot be used with `floating-label`                                                              |
+| `strategy`       | string  | No       | Swap between `fixed` and `absolute` positioning strategy. Use `fixed` when dropdown is in contained in an overflow and needs to be visible as you scroll the screen. |
 
 ## Callbacks
 

--- a/packages/ebayui-core-react/src/ebay-listbox-button/__tests__/index.stories.tsx
+++ b/packages/ebayui-core-react/src/ebay-listbox-button/__tests__/index.stories.tsx
@@ -182,3 +182,11 @@ export const FloatingLabel = () => (
         </EbayListboxButton>
     </>
 );
+
+export const WithFixedStrategy = () => (
+    <EbayListboxButton floatingLabel="Select" value="BB" strategy="fixed">
+        <EbayListboxButtonOption value="AA">Option 1</EbayListboxButtonOption>
+        <EbayListboxButtonOption value="BB">Option 2</EbayListboxButtonOption>
+        <EbayListboxButtonOption value="CC">Option 3</EbayListboxButtonOption>
+    </EbayListboxButton>
+);

--- a/packages/ebayui-core-react/src/ebay-listbox-button/__tests__/render.spec.tsx
+++ b/packages/ebayui-core-react/src/ebay-listbox-button/__tests__/render.spec.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { render, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { composeStories } from "@storybook/react-vite";
 import * as stories from "./index.stories";
 
@@ -13,6 +14,7 @@ const {
     InvalidState,
     PrefixLabel,
     FloatingLabel,
+    WithFixedStrategy,
 } = composeStories(stories);
 
 describe("ebay-listbox-button rendering", () => {
@@ -137,5 +139,13 @@ describe("ebay-listbox-button rendering", () => {
         expect(button.querySelector(".btn__floating-label")).toHaveTextContent("Select");
         expect(button.querySelector(".btn__text")).toHaveTextContent("Option 2");
         expect(button.querySelector("svg")).toMatchSnapshot();
+    });
+
+    it("renders with fixed strategy correctly", async () => {
+        const { container } = render(<WithFixedStrategy />);
+
+        const listboxButton: HTMLElement = container.querySelector(".listbox-button button");
+        await userEvent.click(listboxButton);
+        expect(container.querySelector(".listbox-button__listbox")).toHaveClass("listbox-button__listbox--fixed");
     });
 });

--- a/packages/ebayui-core-react/src/ebay-listbox-button/listbox-button.tsx
+++ b/packages/ebayui-core-react/src/ebay-listbox-button/listbox-button.tsx
@@ -33,6 +33,7 @@ export type EbayListboxButtonProps = Omit<ComponentProps<"button">, "onChange"> 
     prefixLabel?: string;
     floatingLabel?: string;
     split?: "none" | "start" | "end";
+    strategy?: "absolute" | "fixed";
     unselectedText?: string;
     onChange?: EbayChangeEventHandler<HTMLButtonElement, ChangeEventProps>;
     onCollapse?: () => void;
@@ -51,6 +52,7 @@ const ListboxButton: FC<EbayListboxButtonProps> = ({
     prefixId,
     prefixLabel,
     floatingLabel,
+    strategy,
     split,
     unselectedText = "-",
     onChange = () => {},
@@ -93,6 +95,9 @@ const ListboxButton: FC<EbayListboxButtonProps> = ({
 
     const { overlayStyles, refs } = useFloatingDropdown({
         open: expanded,
+        options: {
+            strategy,
+        },
     });
 
     const buttonRef = refs.host as React.MutableRefObject<HTMLButtonElement>;
@@ -299,7 +304,9 @@ const ListboxButton: FC<EbayListboxButtonProps> = ({
             </button>
             {(expanded || optionsOpened) && (
                 <div
-                    className="listbox-button__listbox"
+                    className={classNames("listbox-button__listbox", {
+                        "listbox-button__listbox--fixed": strategy === "fixed",
+                    })}
                     ref={refs.setOverlay}
                     style={{ ...overlayStyles, maxHeight: maxHeight }}
                 >

--- a/packages/ebayui-core-react/src/ebay-menu-button/README.md
+++ b/packages/ebayui-core-react/src/ebay-menu-button/README.md
@@ -37,28 +37,29 @@ import '@ebay/skin/menu-button';
 
 ## EbayMenuButton Attributes
 
-| Name               | Type     | Required                  | Description                                                                                                                                              |
-| ------------------ | -------- | ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `text`             | String   | No                        | button label text                                                                                                                                        |
-| `a11yText`         | String   | Only without a text label | a11y text for the button                                                                                                                                 |
-| `noToggleIcon`     | Boolean  | No                        | whether to hide the chevron toggle icon                                                                                                                  |
-| `expanded`         | Boolean  | No                        | whether content is expanded                                                                                                                              |
-| `type`             | String   | No                        | can be `radio` or `checkbox`                                                                                                                             |
-| `reverse`          | Boolean  | No                        | expand menu flyout to the left                                                                                                                           |
-| `fixWidth`         | Boolean  | No                        | Constrain items container width to button width                                                                                                          |
-| `borderless`       | Boolean  | No                        | Whether button has borders                                                                                                                               |
-| `size`             | String   | No                        | button size: `small` or `large`                                                                                                                          |
-| `priority`         | String   | No                        | button size: `primary`, `secondary` (default), `tertiary`, `none`                                                                                        |
-| `checked`          | Number   | No                        | will set the corresponding index item to checked state and use the `aria-checked` attribute in markup                                                    |
-| `disabled`         | Boolean  | No                        | will disable the entire dropdown (disables the ebay-button label) if set to true                                                                         |
-| `variant`          | String   | No                        | will change the button style: `overflow`, `form` or `button`                                                                                             |
-| `collapseOnSelect` | Boolean  | No                        | Will collapse whole menu when an item is selected in menu. Typically used in type=`radio`                                                                |
-| `prefixId`         | String   | No                        | The id of an external element to use as the prefix label for the menu button. Cannot be used with `prefix-label`                                         |
-| `prefixLabel`      | String   | No                        | The label to add before each selected item on the button. Cannot be used with `prefix-id` (NOT YET IMPLEMENTED)                                          |
-| `onExpand`         | Function | No                        | Called when content is expanded                                                                                                                          |
-| `onCollapse`       | Function | No                        | Called when content is collapsed                                                                                                                         |
-| `onSelect`         | Function | No                        | props: (e: event, { index: number }), triggered on item clicked (not for type `radio`/`checkbox`)                                                        |
-| `onChange`         | Function | No                        | props: (e: event, { index: number, checked: number[], checkedValues: string[] }), triggered on item `checked` change, (for type `radio`/`checkbox` only) |
+| Name               | Type     | Required                  | Description                                                                                                                                                          |
+| ------------------ | -------- | ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `text`             | String   | No                        | button label text                                                                                                                                                    |
+| `a11yText`         | String   | Only without a text label | a11y text for the button                                                                                                                                             |
+| `noToggleIcon`     | Boolean  | No                        | whether to hide the chevron toggle icon                                                                                                                              |
+| `expanded`         | Boolean  | No                        | whether content is expanded                                                                                                                                          |
+| `type`             | String   | No                        | can be `radio` or `checkbox`                                                                                                                                         |
+| `reverse`          | Boolean  | No                        | expand menu flyout to the left                                                                                                                                       |
+| `fixWidth`         | Boolean  | No                        | Constrain items container width to button width                                                                                                                      |
+| `borderless`       | Boolean  | No                        | Whether button has borders                                                                                                                                           |
+| `size`             | String   | No                        | button size: `small` or `large`                                                                                                                                      |
+| `priority`         | String   | No                        | button size: `primary`, `secondary` (default), `tertiary`, `none`                                                                                                    |
+| `checked`          | Number   | No                        | will set the corresponding index item to checked state and use the `aria-checked` attribute in markup                                                                |
+| `disabled`         | Boolean  | No                        | will disable the entire dropdown (disables the ebay-button label) if set to true                                                                                     |
+| `variant`          | String   | No                        | will change the button style: `overflow`, `form` or `button`                                                                                                         |
+| `collapseOnSelect` | Boolean  | No                        | Will collapse whole menu when an item is selected in menu. Typically used in type=`radio`                                                                            |
+| `prefixId`         | String   | No                        | The id of an external element to use as the prefix label for the menu button. Cannot be used with `prefix-label`                                                     |
+| `prefixLabel`      | String   | No                        | The label to add before each selected item on the button. Cannot be used with `prefix-id` (NOT YET IMPLEMENTED)                                                      |
+| `onExpand`         | Function | No                        | Called when content is expanded                                                                                                                                      |
+| `onCollapse`       | Function | No                        | Called when content is collapsed                                                                                                                                     |
+| `onSelect`         | Function | No                        | props: (e: event, { index: number }), triggered on item clicked (not for type `radio`/`checkbox`)                                                                    |
+| `onChange`         | Function | No                        | props: (e: event, { index: number, checked: number[], checkedValues: string[] }), triggered on item `checked` change, (for type `radio`/`checkbox` only)             |
+| `strategy`         | string   | No                        | Swap between `fixed` and `absolute` positioning strategy. Use `fixed` when dropdown is in contained in an overflow and needs to be visible as you scroll the screen. |
 
 ## EbayMenuButtonItem Attributes
 

--- a/packages/ebayui-core-react/src/ebay-menu-button/__tests__/index.stories.tsx
+++ b/packages/ebayui-core-react/src/ebay-menu-button/__tests__/index.stories.tsx
@@ -323,3 +323,11 @@ export const ReverseMenuGrowsToTheLeft = {
 
     name: "Reverse (Menu grows to the left)",
 };
+
+export const WithFixedStrategy = (args) => (
+    <EbayMenuButton {...args} strategy="fixed" text="Menu has a button width">
+        <Item>item 1 that has very long text</Item>
+        <Item>item 2</Item>
+        <Item>item 3</Item>
+    </EbayMenuButton>
+);

--- a/packages/ebayui-core-react/src/ebay-menu-button/__tests__/render.spec.tsx
+++ b/packages/ebayui-core-react/src/ebay-menu-button/__tests__/render.spec.tsx
@@ -19,6 +19,7 @@ const {
     MultiSelectMenuButton,
     FixedWidth,
     ReverseMenuGrowsToTheLeft,
+    WithFixedStrategy,
 } = composeStories(stories);
 
 describe("EbayMenuButton rendering", () => {
@@ -185,7 +186,7 @@ describe("EbayMenuButton rendering", () => {
         it("should render correctly", () => {
             render(<FixedWidth expanded />);
             const menu = screen.getByRole("menu");
-            expect(menu.parentElement).toHaveClass("menu-button__menu menu-button__menu--fix-width menu");
+            expect(menu.parentElement).toHaveClass("menu-button__menu menu-button__menu--fix-width");
         });
     });
 
@@ -194,6 +195,14 @@ describe("EbayMenuButton rendering", () => {
             render(<ReverseMenuGrowsToTheLeft expanded />);
             const menu = screen.getByRole("menu");
             expect(menu.parentElement).toHaveClass("menu-button__menu menu-button__menu--reverse");
+        });
+    });
+
+    describe("WithFixedStrategy", () => {
+        it("should render correctly", () => {
+            render(<WithFixedStrategy expanded />);
+            const menu = screen.getByRole("menu");
+            expect(menu.parentElement).toHaveClass("menu-button__menu menu-button__menu--fixed");
         });
     });
 });

--- a/packages/ebayui-core-react/src/ebay-menu-button/menu-button.tsx
+++ b/packages/ebayui-core-react/src/ebay-menu-button/menu-button.tsx
@@ -22,6 +22,7 @@ const EbayMenuButton: FC<MenuButtonProps> = ({
     text = "",
     fixWidth,
     reverse,
+    strategy,
     expanded: defaultExpanded,
     noToggleIcon,
     checked,
@@ -42,7 +43,7 @@ const EbayMenuButton: FC<MenuButtonProps> = ({
 
     const { overlayStyles, refs } = useFloatingDropdown({
         open: expanded,
-        options: { reverse },
+        options: { reverse, strategy },
     });
 
     const buttonRef = refs.host as React.MutableRefObject<HTMLButtonElement>;
@@ -61,11 +62,6 @@ const EbayMenuButton: FC<MenuButtonProps> = ({
     const icon = findComponent(children, EbayIcon);
     const label = labelWithPrefixAndIcon({ text, prefixId, prefixLabel, menuButtonLabel, icon });
     const wrapperClasses = classnames("menu-button", className);
-
-    const menuClasses = classnames("menu-button__menu", {
-        "menu-button__menu--fix-width": fixWidth,
-        "menu-button__menu--reverse": reverse,
-    });
 
     useEffect(() => {
         const handleBackgroundClick = (e: DocumentEventMap["click"]) => {
@@ -143,9 +139,12 @@ const EbayMenuButton: FC<MenuButtonProps> = ({
             {expanded && (
                 <EbayMenu
                     baseEl="div"
+                    classPrefix="menu-button"
+                    reverse={reverse}
+                    fixWidth={fixWidth}
+                    fixed={strategy === "fixed"}
                     ref={refs.setOverlay as unknown as RefCallback<FC<EbayMenuProps>>}
                     type={type}
-                    className={menuClasses}
                     tabIndex={-1}
                     id={menuId}
                     autofocus

--- a/packages/ebayui-core-react/src/ebay-menu-button/types.ts
+++ b/packages/ebayui-core-react/src/ebay-menu-button/types.ts
@@ -9,6 +9,7 @@ export type EbayMenuButtonProps = {
     className?: string;
     fixWidth?: boolean;
     reverse?: boolean;
+    strategy?: "absolute" | "fixed";
     text?: string;
     type?: EbayMenuType;
     variant?: EbayMenuButtonVariant;

--- a/packages/ebayui-core-react/src/ebay-menu/README.md
+++ b/packages/ebayui-core-react/src/ebay-menu/README.md
@@ -25,14 +25,18 @@ import "@ebay/skin/menu";
 
 ## EbayMenu Props
 
-| Name        | Type     | Required | Description                                                                                                                                            |
-| ----------- | -------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `type`      | String   | No       | Can be `radio`/`checkbox`                                                                                                                              |
-| `checked`   | Number   | No       | when used with `radio` type will check the item with the corresponding index                                                                           |
-| `baseEl`    | String   | No       | Container can be `span` (default) or `div`                                                                                                             |
-| `onKeydown` | Function | No       | props: (e: event, { index: number, checked: number[], checkedValues?: string[] })                                                                      |
-| `onSelect`  | Function | No       | props: (e: event, { index: number }), triggered on item clicked (not for type `radio`/`checkbox`)                                                      |
-| `onChange`  | Function | No       | props: (e: event, { index: number, checked: number[], checkedValues: string[]), triggered on item `checked` change, (for type `radio`/`checkbox` only) |
+| Name          | Type     | Required | Description                                                                                                                                                          |
+| ------------- | -------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `type`        | String   | No       | Can be `radio`/`checkbox`                                                                                                                                            |
+| `checked`     | Number   | No       | when used with `radio` type will check the item with the corresponding index                                                                                         |
+| `baseEl`      | String   | No       | Container can be `span` (default) or `div`                                                                                                                           |
+| `onKeydown`   | Function | No       | props: (e: event, { index: number, checked: number[], checkedValues?: string[] })                                                                                    |
+| `onSelect`    | Function | No       | props: (e: event, { index: number }), triggered on item clicked (not for type `radio`/`checkbox`)                                                                    |
+| `onChange`    | Function | No       | props: (e: event, { index: number, checked: number[], checkedValues: string[]), triggered on item `checked` change, (for type `radio`/`checkbox` only)               |
+| `classPrefix` | String   | No       | class prefix for the component, defaults to `menu`                                                                                                                   |
+| `reverse`     | Boolean  | No       | reverse the menu item layout, so that the badge is on the left and the text on the right (default: false)                                                            |
+| `fixWidth`    | Boolean  | No       | makes the menu width the same as its parent                                                                                                                          |
+| `fixed`       | Boolean  | No       | Swap between `fixed` and `absolute` positioning strategy. Use `fixed` when dropdown is in contained in an overflow and needs to be visible as you scroll the screen. |
 
 ## EbayMenuItem Props
 

--- a/packages/ebayui-core-react/src/ebay-menu/menu-item-separator.tsx
+++ b/packages/ebayui-core-react/src/ebay-menu/menu-item-separator.tsx
@@ -1,10 +1,12 @@
 import React, { ComponentProps, FC } from "react";
 import classNames from "classnames";
 
-type Props = ComponentProps<"hr">;
+type Props = ComponentProps<"hr"> & {
+    baseClass?: string;
+};
 
-const EbayMenuItemSeparator: FC<Props> = ({ className, ...rest }) => (
-    <hr {...rest} className={classNames(className, "menu__separator")} />
+const EbayMenuItemSeparator: FC<Props> = ({ className, baseClass = "menu", ...rest }) => (
+    <hr {...rest} className={classNames(className, `${baseClass}__separator`)} />
 );
 
 export default EbayMenuItemSeparator;

--- a/packages/ebayui-core-react/src/ebay-menu/menu-item.tsx
+++ b/packages/ebayui-core-react/src/ebay-menu/menu-item.tsx
@@ -13,6 +13,7 @@ export type MenuItemProps = ComponentProps<"div"> & {
     disabled?: boolean;
     badgeNumber?: number;
     badgeAriaLabel?: string;
+    baseClass?: string;
 };
 
 const EbayMenuItem: FC<MenuItemProps> = ({
@@ -25,6 +26,7 @@ const EbayMenuItem: FC<MenuItemProps> = ({
     badgeNumber,
     badgeAriaLabel,
     children,
+    baseClass = "menu",
     ...rest
 }) => {
     const ref = useRef(null);
@@ -43,7 +45,7 @@ const EbayMenuItem: FC<MenuItemProps> = ({
             aria-label={badgeAriaLabel}
             {...rest}
             ref={ref}
-            className={classNames(className, "menu__item", hasBadge && "menu__item--badged")}
+            className={classNames(className, `${baseClass}__item`, hasBadge && `${baseClass}__item--badged`)}
             role={roleFromType(type)}
             aria-checked={checkable.includes(type) ? checked : undefined}
             aria-disabled={disabled}

--- a/packages/ebayui-core-react/src/ebay-menu/menu.tsx
+++ b/packages/ebayui-core-react/src/ebay-menu/menu.tsx
@@ -13,6 +13,10 @@ const EbayMenu: FC<EbayMenuProps> = ({
     checked,
     className,
     autofocus,
+    classPrefix,
+    reverse,
+    fixWidth,
+    fixed,
     onClick = () => {},
     onKeyDown = () => {},
     onChange = () => {},
@@ -124,9 +128,21 @@ const EbayMenu: FC<EbayMenuProps> = ({
         }
     };
 
+    const baseClass = classPrefix || "menu";
+
     return (
-        <Container {...rest} className={classNames(className, "menu")} ref={forwardedRef}>
-            <div className="menu__items" role="menu" ref={menuRef}>
+        <Container
+            {...rest}
+            className={classNames(
+                className,
+                classPrefix ? `${baseClass}__menu` : "menu",
+                reverse && `${baseClass}__menu--reverse`,
+                fixed && `${baseClass}__menu--fixed`,
+                fixWidth && `${baseClass}__menu--fix-width`,
+            )}
+            ref={forwardedRef}
+        >
+            <div className={`${baseClass}__items`} role="menu" ref={menuRef}>
                 {childrenArray.map((child: ReactElement, i) => {
                     const {
                         onClick: onItemClick = () => {},
@@ -138,6 +154,7 @@ const EbayMenu: FC<EbayMenuProps> = ({
                     return cloneElement(child, {
                         ...itemRest,
                         type,
+                        baseClass,
                         focused: i === focusedIndex,
                         tabIndex: focusedIndex === undefined ? 0 : -1,
                         checked: checkedIndexes[i],

--- a/packages/ebayui-core-react/src/ebay-menu/types.ts
+++ b/packages/ebayui-core-react/src/ebay-menu/types.ts
@@ -23,6 +23,10 @@ export type EbayMenuProps = ContainerDivProps &
         priority?: EbayMenuPriority;
         checked?: number;
         autofocus?: boolean;
+        classPrefix?: "menu-button";
+        reverse?: boolean;
+        fixed?: boolean;
+        fixWidth?: boolean;
         baseEl?: "div" | "span";
         onKeyDown?: EbayMenuKeyDownEventHandler;
         onChange?: EbayMenuChangeEventHandler;

--- a/packages/ebayui-core-react/src/ebay-split-button/split-button.tsx
+++ b/packages/ebayui-core-react/src/ebay-split-button/split-button.tsx
@@ -35,6 +35,7 @@ const EbaySplitButton: FC<Props> = ({
                 priority={rest.priority}
                 disabled={rest.disabled}
                 transparent={rest.transparent}
+                partiallyDisabled={rest.partiallyDisabled}
                 size={rest.size}
                 type={type}
                 split="end"


### PR DESCRIPTION
<!-- Insert GitHub issue number below. An issue is required for all PRs -->

- Fixes #311

## Description

- Update `EbayMenu` to support all the marko attributes:
  - `fixed`
  - `reverse`
  - `fixWidth`
- Add support for `strategy` on `EbayMenuButton`, `EbayFakeMenuButton` and `EbayListboxButton`

## Checklist

<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->

- [x] I verify all changes are within scope of the linked issue
- [ ] I added/updated/removed testing (Storybook in Skin) coverage as appropriate

<!-- For CSS changes -->

- [ ] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [ ] I tested the UI in dark mode and RTL mode
