### PR TITLE
feat(EbayConfirmDialog): add support for 'confirm' and 'reject' buttons extra props

### DIFF
--- a/.changeset/sweet-friends-beg.md
+++ b/.changeset/sweet-friends-beg.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ui-core-react": minor
+---
+
+feat(EbayAlertDialog|EbayConfirmDialog): Add support for "confirm" and "reject" button for extra props

--- a/packages/ebayui-core-react/src/ebay-alert-dialog/README.md
+++ b/packages/ebayui-core-react/src/ebay-alert-dialog/README.md
@@ -20,7 +20,8 @@
 | `open`          | Boolean | Yes      | No       | Whether dialog is open.                                                                         |
 | `focus`         | String  | No       | No       | An id for an element which will receive focus when the drawer opens (defaults to close button). |
 | `a11yCloseText` | String  | No       | Yes      | A11y text for close button and mask.                                                            |
-| `confirmText`   | String  | No       | Yes      | Text for confirm button                                                                         |
+| `confirmText`   | String  | No       | No       | Text for confirm button                                                                         |
+| `confirm`       | Node    | No       | No       | Custom confirm button (if you need to pass additional props)                                    |
 | `animated`      | Boolean | Yes      | No       | Renders the dialog with an animation. Note that the dialog will always be present in the DOM    |
 
 ## Events

--- a/packages/ebayui-core-react/src/ebay-alert-dialog/__tests__/index.stories.tsx
+++ b/packages/ebayui-core-react/src/ebay-alert-dialog/__tests__/index.stories.tsx
@@ -3,6 +3,7 @@ import { StoryFn, Meta } from "@storybook/react-vite";
 import { action } from "storybook/actions";
 import { EbayAlertDialog } from "../index";
 import { EbayDialogHeader } from "../../ebay-dialog-base";
+import { EbayButton } from "../../ebay-button";
 
 const story = {
     component: EbayAlertDialog,
@@ -58,6 +59,40 @@ export const WithAnimation: StoryFn<typeof EbayAlertDialog> = () => {
             </button>
             <p>Some outside content...</p>
             <EbayAlertDialog open={open} onConfirm={close} confirmText="Confirm" animated a11yCloseText="Close">
+                <EbayDialogHeader>Heading</EbayDialogHeader>
+                {textParagraph}
+                <p>
+                    <a href="http://www.ebay.com">www.ebay.com</a>
+                </p>
+            </EbayAlertDialog>
+        </div>
+    );
+};
+
+export const WithCustomConfirmButton: StoryFn<typeof EbayAlertDialog> = () => {
+    const [open, setOpen] = useState(true);
+    const close = () => setOpen(false);
+    return (
+        <div>
+            <button className="btn btn--secondary" onClick={() => setOpen(!open)}>
+                Open Dialog
+            </button>
+            <p>Some outside content...</p>
+            <EbayAlertDialog
+                open={open}
+                confirm={
+                    <EbayButton
+                        variant="destructive"
+                        onClick={() => {
+                            action("onConfirm")();
+                            close();
+                        }}
+                    >
+                        Custom Confirm
+                    </EbayButton>
+                }
+                a11yCloseText="Close"
+            >
                 <EbayDialogHeader>Heading</EbayDialogHeader>
                 {textParagraph}
                 <p>

--- a/packages/ebayui-core-react/src/ebay-alert-dialog/__tests__/render.spec.tsx
+++ b/packages/ebayui-core-react/src/ebay-alert-dialog/__tests__/render.spec.tsx
@@ -3,7 +3,7 @@ import { screen, render } from "@testing-library/react";
 import { composeStories } from "@storybook/react-vite";
 import * as stories from "./index.stories";
 
-const { Default } = composeStories(stories);
+const { Default, WithCustomConfirmButton } = composeStories(stories);
 
 describe("EbayAlertDialog rendering", () => {
     it("should render the default story correctly", () => {
@@ -12,5 +12,12 @@ describe("EbayAlertDialog rendering", () => {
         expect(screen.getByRole("heading", { level: 2 })).toBeInTheDocument();
         expect(screen.getByText(/Lorem ipsum dolor sit amet/)).toBeInTheDocument();
         expect(screen.getByRole("link", { name: "www.ebay.com" })).toBeInTheDocument();
+    });
+
+    it("should render the dialog with custom confirm button", () => {
+        render(<WithCustomConfirmButton />);
+        const buttonConfirm = screen.getByText("Custom Confirm");
+        expect(buttonConfirm).toBeInTheDocument();
+        expect(buttonConfirm).toHaveClass("btn--destructive");
     });
 });

--- a/packages/ebayui-core-react/src/ebay-alert-dialog/alert-dialog.tsx
+++ b/packages/ebayui-core-react/src/ebay-alert-dialog/alert-dialog.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useRef } from "react";
+import React, { ComponentProps, FC, ReactElement, useRef } from "react";
 import classNames from "classnames";
 import { DialogBaseProps, DialogBaseWithState, EbayDialogFooter } from "../ebay-dialog-base";
 import { EbayButton } from "../ebay-button";
@@ -8,14 +8,26 @@ const classPrefix = "alert-dialog";
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export interface Props<T = any> extends DialogBaseProps<T> {
     open?: boolean;
-    confirmText: string;
+    confirmText?: string;
+    confirm?: ReactElement<ComponentProps<typeof EbayButton>>;
     onConfirm?: () => void;
 }
 
-const EbayAlertDialog: FC<Props> = ({ a11yCloseText = "Close Dialog", confirmText, onConfirm = () => {}, ...rest }) => {
+const EbayAlertDialog: FC<Props> = ({
+    a11yCloseText = "Close Dialog",
+    confirmText,
+    confirm,
+    onConfirm = () => {},
+    ...rest
+}) => {
     const confirmBtnRef = useRef(null);
     const confirmId = "alert-dialog-confirm";
     const mainId = "alert-dialog-main";
+
+    if (!confirmText && !confirm) {
+        throw new Error('EbayAlertDialog: A "confirmText" or a "confirm" component needs to be passed');
+    }
+
     return (
         <DialogBaseWithState
             focus={confirmBtnRef}
@@ -33,13 +45,14 @@ const EbayAlertDialog: FC<Props> = ({ a11yCloseText = "Close Dialog", confirmTex
             <EbayDialogFooter>
                 <EbayButton
                     priority="primary"
-                    aria-describedby={mainId}
                     onClick={onConfirm}
+                    {...confirm?.props}
+                    aria-describedby={mainId}
                     ref={confirmBtnRef}
                     id={confirmId}
-                    className="alert-dialog__acknowledge"
+                    className={classNames("alert-dialog__acknowledge", confirm?.props?.className)}
                 >
-                    {confirmText}
+                    {confirm?.props?.children || confirmText}
                 </EbayButton>
             </EbayDialogFooter>
         </DialogBaseWithState>

--- a/packages/ebayui-core-react/src/ebay-confirm-dialog/README.md
+++ b/packages/ebayui-core-react/src/ebay-confirm-dialog/README.md
@@ -20,8 +20,10 @@
 | `open`          | Boolean | Yes      | No       | Whether dialog is open.                                                                         |
 | `focus`         | String  | No       | No       | An id for an element which will receive focus when the drawer opens (defaults to close button). |
 | `a11yCloseText` | String  | No       | Yes      | A11y text for close button and mask.                                                            |
-| `confirmText`   | String  | No       | Yes      | Text for confirm button                                                                         |
-| `rejectText`    | String  | No       | Yes      | Text for reject button                                                                          |
+| `confirmText`   | String  | No       | No       | Text for confirm button                                                                         |
+| `rejectText`    | String  | No       | No       | Text for reject button                                                                          |
+| `confirm`       | Node    | No       | No       | Custom confirm button (if you need to pass additional props)                                    |
+| `reject`        | Node    | No       | No       | Custom reject button (if you need to pass additional props)                                     |
 | `animated`      | Boolean | Yes      | No       | Renders the dialog with an animation. Note that the dialog will always be present in the DOM    |
 
 ## Callbacks

--- a/packages/ebayui-core-react/src/ebay-confirm-dialog/__tests__/index.stories.tsx
+++ b/packages/ebayui-core-react/src/ebay-confirm-dialog/__tests__/index.stories.tsx
@@ -3,6 +3,7 @@ import { EbayConfirmDialog } from "../index";
 import { EbayDialogHeader } from "../../ebay-dialog-base";
 import { action } from "storybook/actions";
 import { StoryFn, Meta } from "@storybook/react-vite";
+import { EbayButton } from "../../ebay-button";
 
 const story: Meta<typeof EbayConfirmDialog> = {
     component: EbayConfirmDialog,
@@ -58,6 +59,35 @@ export const WithAnimation: StoryFn<typeof EbayConfirmDialog> = () => {
                 confirmText="Cancel"
                 rejectText="Delete"
                 animated
+                a11yCloseText="Close"
+            >
+                <EbayDialogHeader>Delete Address?</EbayDialogHeader>
+                <p>You will permanently lose this address.</p>
+            </EbayConfirmDialog>
+        </div>
+    );
+};
+
+export const WithExtraButtonProps: StoryFn<typeof EbayConfirmDialog> = () => {
+    const [open, setOpen] = useState(false);
+    const close = () => setOpen(false);
+
+    return (
+        <div>
+            <button className="btn btn--secondary" onClick={() => setOpen(!open)}>
+                Open Dialog
+            </button>
+            <p>Some outside content...</p>
+            <EbayConfirmDialog
+                open={open}
+                onConfirm={close}
+                onReject={close}
+                confirm={<EbayButton variant="destructive">Cancel</EbayButton>}
+                reject={
+                    <EbayButton priority="tertiary" className="custom-class">
+                        Delete
+                    </EbayButton>
+                }
                 a11yCloseText="Close"
             >
                 <EbayDialogHeader>Delete Address?</EbayDialogHeader>

--- a/packages/ebayui-core-react/src/ebay-confirm-dialog/__tests__/render.spec.tsx
+++ b/packages/ebayui-core-react/src/ebay-confirm-dialog/__tests__/render.spec.tsx
@@ -1,10 +1,11 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import { composeStory } from "@storybook/react-vite";
-import Meta, { Default, WithAnimation } from "./index.stories";
+import Meta, { Default, WithAnimation, WithExtraButtonProps } from "./index.stories";
 
 const DefaultStory = composeStory(Default, Meta);
 const AnimationStory = composeStory(WithAnimation, Meta);
+const WithExtraButtonPropsStory = composeStory(WithExtraButtonProps, Meta);
 
 jest.mock("../../common/random-id");
 
@@ -38,5 +39,17 @@ describe("ebay-confirm-dialog rendering", () => {
 
         const dialog = screen.queryByRole("dialog");
         expect(dialog).not.toBeInTheDocument();
+    });
+
+    it("should render custom confirm and reject buttons", () => {
+        render(<WithExtraButtonPropsStory />);
+
+        const buttonDelete = screen.getByText("Delete");
+        const buttonCancel = screen.getByText("Cancel");
+
+        expect(buttonDelete.textContent).toEqual("Delete");
+        expect(buttonDelete).toHaveClass("btn confirm-dialog__reject custom-class btn--tertiary");
+        expect(buttonCancel.textContent).toEqual("Cancel");
+        expect(buttonCancel).toHaveClass("btn confirm-dialog__confirm btn--destructive");
     });
 });

--- a/packages/ebayui-core-react/src/ebay-confirm-dialog/confirm-dialog.tsx
+++ b/packages/ebayui-core-react/src/ebay-confirm-dialog/confirm-dialog.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useRef } from "react";
+import React, { ComponentProps, FC, ReactElement, useRef } from "react";
 import classNames from "classnames";
 import { DialogBaseProps, DialogBaseWithState, EbayDialogFooter } from "../ebay-dialog-base";
 import { DialogCloseEventHandler } from "../ebay-dialog-base/types";
@@ -9,8 +9,10 @@ const classPrefix = "confirm-dialog";
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export interface Props<T = any> extends DialogBaseProps<T> {
     open?: boolean;
-    confirmText: string;
-    rejectText: string;
+    confirmText?: string;
+    rejectText?: string;
+    confirm?: ReactElement<ComponentProps<typeof EbayButton>>;
+    reject?: ReactElement<ComponentProps<typeof EbayButton>>;
     onReject?: DialogCloseEventHandler;
     onConfirm?: () => void;
 }
@@ -19,6 +21,8 @@ const EbayConfirmDialog: FC<Props> = ({
     a11yCloseText = "Close Dialog",
     confirmText,
     rejectText,
+    confirm,
+    reject,
     onReject = () => {},
     onConfirm = () => {},
     ...rest
@@ -26,6 +30,15 @@ const EbayConfirmDialog: FC<Props> = ({
     const confirmBtnRef = useRef(null);
     const confirmId = "confirm-dialog-confirm";
     const mainId = "confirm-dialog-main";
+
+    if (!confirmText && !confirm) {
+        throw new Error('EbayConfirmDialog: A "confirmText" or a "confirm" component needs to be passed');
+    }
+
+    if (!rejectText && !reject) {
+        throw new Error('EbayConfirmDialog: A "rejectText" or a "reject" component needs to be passed');
+    }
+
     return (
         <DialogBaseWithState
             focus={confirmBtnRef}
@@ -41,18 +54,23 @@ const EbayConfirmDialog: FC<Props> = ({
         >
             {rest.children}
             <EbayDialogFooter>
-                <EbayButton onClick={onReject} className="confirm-dialog__reject">
-                    {rejectText}
+                <EbayButton
+                    onClick={onReject}
+                    {...reject?.props}
+                    className={classNames("confirm-dialog__reject", reject?.props?.className)}
+                >
+                    {reject?.props?.children || rejectText}
                 </EbayButton>
                 <EbayButton
-                    ref={confirmBtnRef}
-                    priority="primary"
-                    onClick={onConfirm}
                     id={confirmId}
+                    onClick={onConfirm}
+                    priority="primary"
+                    {...confirm?.props}
+                    ref={confirmBtnRef}
                     aria-describedby={mainId}
-                    className="confirm-dialog__confirm"
+                    className={classNames("confirm-dialog__confirm", confirm?.props?.className)}
                 >
-                    {confirmText}
+                    {confirm?.props?.children || confirmText}
                 </EbayButton>
             </EbayDialogFooter>
         </DialogBaseWithState>


### PR DESCRIPTION
<!-- Insert GitHub issue number below. An issue is required for all PRs -->

- Fixes #312 

## Description

<!-- Briefly describe the proposed changes -->
- Add `confirm` and `reject` support on `EbayConfirmDialog` and `EbayAlertDialog`

## Checklist

<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->

- [x] I verify all changes are within scope of the linked issue
- [x] I added/updated/removed testing (Storybook in Skin) coverage as appropriate

<!-- For CSS changes -->

- [ ] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [ ] I tested the UI in dark mode and RTL mode
