### PR TITLE
fix(skin): reverted line height value in global.scss

### DIFF
--- a/.changeset/some-crabs-itch.md
+++ b/.changeset/some-crabs-itch.md
@@ -1,0 +1,5 @@
+---
+"@ebay/skin": patch
+---
+
+fix(skin): reverted line height value in global.scss

--- a/packages/skin/dist/global/global.css
+++ b/packages/skin/dist/global/global.css
@@ -6,7 +6,7 @@ body {
         Arial,
         sans-serif;
     font-size: var(--font-size-body);
-    line-height: var(--font-line-height-250);
+    line-height: var(--font-line-height-default);
     -webkit-text-size-adjust: 100%;
 }
 button {

--- a/packages/skin/src/sass/global/global.scss
+++ b/packages/skin/src/sass/global/global.scss
@@ -7,7 +7,7 @@ body {
 
     font-family: variables.$font-family-default;
     font-size: var(--font-size-body);
-    line-height: var(--font-line-height-250);
+    line-height: var(--font-line-height-default);
     /* stylelint-disable-next-line plugin/no-unsupported-browser-features */
     -webkit-text-size-adjust: 100%;
 }


### PR DESCRIPTION
When we did the changes in tokens, should have left line height as is. 