### PR TITLE
fix: added prevention to scroll up and down on page for menu

### DIFF
--- a/.changeset/smart-suits-shave.md
+++ b/.changeset/smart-suits-shave.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ui-core-react": patch
+---
+
+fix: added prevention to scroll up and down on page for menu

--- a/packages/ebayui-core-react/src/ebay-filter-menu/filter-menu.tsx
+++ b/packages/ebayui-core-react/src/ebay-filter-menu/filter-menu.tsx
@@ -94,6 +94,10 @@ const EbayFilterMenu: FC<EbayFilterMenuProps> = ({
                 rovingTabIndex.destroy();
                 rovingTabIndex = null;
             }
+
+            if (menuRef.current) {
+                scrollKeyPreventer.remove(menuRef.current);
+            }
         };
     }, [isForm]);
 

--- a/packages/ebayui-core-react/src/ebay-menu/menu.tsx
+++ b/packages/ebayui-core-react/src/ebay-menu/menu.tsx
@@ -1,7 +1,7 @@
 import React, { Children, cloneElement, FC, KeyboardEvent, MouseEvent, ReactElement, useEffect, useState } from "react";
 import classNames from "classnames";
 import useRovingIndex from "../common/event-utils/use-roving-index";
-import { isActionKey } from "../common/event-utils";
+import { isActionKey, handleUpDownArrowsKeydown } from "../common/event-utils";
 import { withForwardRef } from "../common/component-utils";
 import EbayMenuItem, { MenuItemProps } from "./menu-item";
 import { Key } from "../common/event-utils/types";
@@ -105,6 +105,12 @@ const EbayMenu: FC<EbayMenuProps> = ({
 
     const handleKeyDown = (e: KeyboardEvent<HTMLElement>, index: number) => {
         let newValues;
+
+        handleUpDownArrowsKeydown(e, () => {
+            // Prevent page scroll
+            e.preventDefault();
+        });
+
         if (isActionKey(e.key as Key)) {
             newValues = selectIndex(index);
             if (newValues) {


### PR DESCRIPTION
- Fixes #349
## Description
* Added preventDefault when key is up or down in menu button
* Bonus change, added cleanup for scroll key prevention in filter menu
## Checklist
- [X] I verify all changes are within scope of the linked issue
- [X] I added/updated/removed testing (Storybook in Skin) coverage as appropriate
