### PR TITLE
fix(fake-menu-button): add `size` option `small` to type

### DIFF
--- a/.changeset/fiery-berries-unite.md
+++ b/.changeset/fiery-berries-unite.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ebayui-core": patch
+---
+
+fix(fake-menu-button): add `size` option `small` to type

--- a/packages/ebayui-core/src/components/ebay-fake-menu-button/component.ts
+++ b/packages/ebayui-core/src/components/ebay-fake-menu-button/component.ts
@@ -10,7 +10,7 @@ import type { WithNormalizedProps } from "../../global";
 
 interface FakeMenuButtonInput extends Omit<Marko.HTML.Span, `on${string}`> {
     text?: string;
-    size?: "none" | "large";
+    size?: "none" | "small" | "large";
     "prefix-id"?: string;
     variant?: "overflow" | "form" | "button" | "icon";
     priority?: "primary" | "secondary" | "delete" | "tertiary" | "none";

--- a/packages/ebayui-core/src/components/ebay-fake-menu-button/fake-menu-button.stories.ts
+++ b/packages/ebayui-core/src/components/ebay-fake-menu-button/fake-menu-button.stories.ts
@@ -67,8 +67,9 @@ export default {
             description: "whether button has borders",
         },
         size: {
-            control: { type: "text" },
-            description: 'button size, "large" (default: "none")',
+            control: { type: "select" },
+            options: ["large", "small", "none"],
+            description: 'button size, "large", "small" (default: "none")',
         },
         priority: {
             control: { type: "select" },


### PR DESCRIPTION
## Description

Adds type support for `size: small` to `ebay-fake-menu-button`. 

`small` renders the overflow icon button as 32x32px which is [DS spec](https://playbook.ebay.com/design-system/components/item-tile#specs) for Overflow menu button.
