### PR TITLE
fix(menu-button): added nullish coalescing selector to focus

### DIFF
--- a/.changeset/fine-comics-punch.md
+++ b/.changeset/fine-comics-punch.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ebayui-core": patch
+---
+
+fix(menu-button): added nullish coalescing selector to focus

--- a/packages/ebayui-core/src/components/ebay-menu-button/component.ts
+++ b/packages/ebayui-core/src/components/ebay-menu-button/component.ts
@@ -122,9 +122,7 @@ export default class extends MenuUtils<Input, MenuState> {
     }
 
     focus() {
-        (
-            (this.getComponent("button") as Marko.Component).el as HTMLElement
-        ).focus();
+        (this.getEl("button") as HTMLElement)?.focus();
     }
 
     handleButtonEscape() {


### PR DESCRIPTION
- Fixes #363
## Description

## Notes
Added nullish coalescing to focus event in case the element is removed

- [X] I verify all changes are within scope of the linked issue
- [X] I added/updated/removed testing (Storybook in Skin) coverage as appropriate
