### PR TITLE
fix: remove `-webkit-overflow-scrolling: touch`

### DIFF
--- a/.changeset/cold-trees-relax.md
+++ b/.changeset/cold-trees-relax.md
@@ -1,0 +1,5 @@
+---
+"@ebay/skin": patch
+---
+
+fix: remove `-webkit-overflow-scrolling: touch`

--- a/packages/skin/dist/alert-dialog/alert-dialog.css
+++ b/packages/skin/dist/alert-dialog/alert-dialog.css
@@ -8,7 +8,6 @@
     background-color: var(--dialog-scrim-color-show);
     inset: 0;
     justify-content: center;
-    -webkit-overflow-scrolling: touch;
     position: fixed;
     will-change: background-color;
     z-index: 100000;

--- a/packages/skin/dist/carousel/carousel.css
+++ b/packages/skin/dist/carousel/carousel.css
@@ -250,7 +250,6 @@ span.carousel__container {
     }
     .carousel:not(.carousel__autoplay) .carousel__list {
         border-color: rgba(0, 0, 0, 0);
-        -webkit-overflow-scrolling: touch;
         overflow-x: auto;
         overflow-y: hidden;
         padding-bottom: 10px;

--- a/packages/skin/dist/confirm-dialog/confirm-dialog.css
+++ b/packages/skin/dist/confirm-dialog/confirm-dialog.css
@@ -8,7 +8,6 @@
     background-color: var(--dialog-scrim-color-show);
     inset: 0;
     justify-content: center;
-    -webkit-overflow-scrolling: touch;
     position: fixed;
     will-change: background-color;
     z-index: 100000;

--- a/packages/skin/dist/drawer-dialog/drawer-dialog.css
+++ b/packages/skin/dist/drawer-dialog/drawer-dialog.css
@@ -10,7 +10,6 @@
     background-color: var(--dialog-scrim-color-show);
     inset: 0;
     overflow: hidden;
-    -webkit-overflow-scrolling: touch;
     position: fixed;
     will-change: background-color;
     z-index: 100000;
@@ -112,9 +111,8 @@ button.icon-btn.drawer-dialog__close {
     max-height: 50%;
     max-width: 100%;
     min-height: 55px;
-    will-change: opacity, transform;
-    -webkit-overflow-scrolling: touch;
     overflow-y: hidden;
+    will-change: opacity, transform;
 }
 .drawer-dialog__window--expanded {
     height: 95%;

--- a/packages/skin/dist/fullscreen-dialog/fullscreen-dialog.css
+++ b/packages/skin/dist/fullscreen-dialog/fullscreen-dialog.css
@@ -8,7 +8,6 @@
 .fullscreen-dialog[role="dialog"] {
     background-color: var(--dialog-scrim-color-show);
     inset: 0;
-    -webkit-overflow-scrolling: touch;
     position: fixed;
     will-change: background-color;
     z-index: 100000;
@@ -28,10 +27,9 @@
     flex: 1 0 auto;
     flex-direction: column;
     min-height: 55px;
-    will-change: opacity, transform;
-    -webkit-overflow-scrolling: touch;
     overflow-y: auto;
     width: 100%;
+    will-change: opacity, transform;
 }
 .fullscreen-dialog__header {
     display: flex;

--- a/packages/skin/dist/lightbox-dialog/lightbox-dialog.css
+++ b/packages/skin/dist/lightbox-dialog/lightbox-dialog.css
@@ -10,7 +10,6 @@
     background-color: var(--dialog-scrim-color-show);
     inset: 0;
     justify-content: center;
-    -webkit-overflow-scrolling: touch;
     position: fixed;
     will-change: background-color;
     z-index: 100000;

--- a/packages/skin/dist/mixins/_utility.scss
+++ b/packages/skin/dist/mixins/_utility.scss
@@ -60,7 +60,6 @@
 
 @mixin scrollbars-permanent($target) {
     #{$target} {
-        -webkit-overflow-scrolling: touch;
         scroll-behavior: smooth;
         /* stylelint-disable declaration-block-no-duplicate-properties */
         -webkit-scroll-snap-type: mandatory;

--- a/packages/skin/dist/panel-dialog/panel-dialog.css
+++ b/packages/skin/dist/panel-dialog/panel-dialog.css
@@ -8,7 +8,6 @@
     flex-direction: column;
     inset: 0;
     overflow: hidden;
-    -webkit-overflow-scrolling: touch;
     position: fixed;
     will-change: background-color;
     z-index: 100000;
@@ -26,10 +25,9 @@
     flex: 1 0 auto;
     flex-direction: column;
     min-height: 55px;
-    will-change: opacity, transform;
-    -webkit-overflow-scrolling: touch;
     overflow-y: auto;
     width: 100%;
+    will-change: opacity, transform;
 }
 .panel-dialog__window--end {
     align-self: flex-end;

--- a/packages/skin/dist/table/table.css
+++ b/packages/skin/dist/table/table.css
@@ -1,7 +1,6 @@
 .table {
     overflow-x: auto;
     position: relative;
-    -webkit-overflow-scrolling: touch;
     scroll-behavior: smooth;
     scroll-snap-type: proximity;
     scroll-snap-type: x proximity;

--- a/packages/skin/dist/utility/utility.css
+++ b/packages/skin/dist/utility/utility.css
@@ -94,7 +94,6 @@
     white-space: nowrap;
 }
 .scrollbars-permanent {
-    -webkit-overflow-scrolling: touch;
     scroll-behavior: smooth;
     scroll-snap-type: proximity;
     scroll-snap-type: x proximity;

--- a/packages/skin/src/sass/carousel/carousel.scss
+++ b/packages/skin/src/sass/carousel/carousel.scss
@@ -247,7 +247,6 @@ span.carousel__container {
         .carousel__list {
             /* Add transition on border-color in order to support fade in/out of scrollbar */
             border-color: rgb(0 0 0 / 0);
-            -webkit-overflow-scrolling: touch;
             overflow-x: auto; /* also used in js to determine scroll behavior */
             overflow-y: hidden;
             padding-bottom: 10px;

--- a/packages/skin/src/sass/drawer-dialog/drawer-dialog.scss
+++ b/packages/skin/src/sass/drawer-dialog/drawer-dialog.scss
@@ -90,7 +90,6 @@ button.icon-btn.drawer-dialog__close {
     border-radius: var(--border-radius-100) var(--border-radius-100) 0 0;
     max-height: 50%;
     max-width: 100%;
-    -webkit-overflow-scrolling: touch;
     overflow-y: hidden;
 }
 

--- a/packages/skin/src/sass/fullscreen-dialog/fullscreen-dialog.scss
+++ b/packages/skin/src/sass/fullscreen-dialog/fullscreen-dialog.scss
@@ -15,7 +15,6 @@
 .fullscreen-dialog__window {
     @include dialog-mixins.window;
 
-    -webkit-overflow-scrolling: touch;
     overflow-y: auto;
     width: 100%;
 }

--- a/packages/skin/src/sass/mixins/private/_dialog-mixins.scss
+++ b/packages/skin/src/sass/mixins/private/_dialog-mixins.scss
@@ -11,7 +11,6 @@
 @mixin base() {
     background-color: var(--dialog-scrim-color-show);
     inset: 0;
-    -webkit-overflow-scrolling: touch;
     position: fixed;
     will-change: background-color;
     z-index: 100000; /* because global header has an element with 99999 */

--- a/packages/skin/src/sass/mixins/public/_utility.scss
+++ b/packages/skin/src/sass/mixins/public/_utility.scss
@@ -60,7 +60,6 @@
 
 @mixin scrollbars-permanent($target) {
     #{$target} {
-        -webkit-overflow-scrolling: touch;
         scroll-behavior: smooth;
         /* stylelint-disable declaration-block-no-duplicate-properties */
         -webkit-scroll-snap-type: mandatory;

--- a/packages/skin/src/sass/panel-dialog/panel-dialog.scss
+++ b/packages/skin/src/sass/panel-dialog/panel-dialog.scss
@@ -16,7 +16,6 @@
     @include dialog-mixins.window;
 
     border-right: 1px solid rgb(153 153 153 / 0.18);
-    -webkit-overflow-scrolling: touch;
     overflow-y: auto;
     width: 100%;
 }


### PR DESCRIPTION
- Fixes #375 

## Description

Removes `-webkit-overflow-scrolling: touch;` usage from Skin.

## Notes

`-webkit-overflow-scrolling: touch;` should be safe to remove as this momentum scrolling behavior has been built-in since Safari 13.

From the [Safari 13 release notes](https://developer.apple.com/documentation/safari-release-notes/safari-13-release-notes#Layout-and-Rendering):
> Added support for one-finger accelerated scrolling to all frames and overflow:scroll elements eliminating the need to set -webkit-overflow-scrolling: touch.

## Screenshots

|Before|After|
|-|-|
|<img width="331" alt="image" src="https://github.com/user-attachments/assets/b707fe0c-bbaf-4ba9-ad32-8d5b4a0f66bb" />|<img width="331" alt="Building Blocks  OverflowMenu - Fixed ⋅ Storybook 4" src="https://github.com/user-attachments/assets/76f9a37d-02dc-41f6-96bf-237e284b0d2f" />|


## Checklist

<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->

- [x] I verify all changes are within scope of the linked issue
- [ ] I added/updated/removed testing (Storybook in Skin) coverage as appropriate

<!-- For CSS changes -->

- [ ] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [ ] I tested the UI in dark mode and RTL mode
