### PR TITLE
fix(PhoneInput): change to use React events for masking and add defaultValue

### DIFF
--- a/.changeset/wide-tires-remain.md
+++ b/.changeset/wide-tires-remain.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ui-core-react": patch
+---
+
+fix(PhoneInput): change to use react events for masking and add defaultValue

--- a/packages/ebayui-core-react/src/ebay-phone-input/__tests__/__snapshots__/render.spec.tsx.snap
+++ b/packages/ebayui-core-react/src/ebay-phone-input/__tests__/__snapshots__/render.spec.tsx.snap
@@ -1594,7 +1594,7 @@ exports[`EbayPhoneInput render renders disabled state 1`] = `
         class="textbox__control"
         disabled=""
         type="tel"
-        value="5551234567"
+        value="(555) 123-4567"
       />
     </span>
   </span>
@@ -2399,7 +2399,7 @@ exports[`EbayPhoneInput render renders invalid state 1`] = `
         aria-invalid="true"
         class="textbox__control"
         type="tel"
-        value="invalid"
+        value=""
       />
     </span>
   </span>
@@ -3205,7 +3205,7 @@ exports[`EbayPhoneInput render renders readonly state 1`] = `
         class="textbox__control"
         readonly=""
         type="tel"
-        value="5551234567"
+        value="(555) 123-4567"
       />
     </span>
   </span>
@@ -4010,7 +4010,7 @@ exports[`EbayPhoneInput render renders with all props 1`] = `
         aria-invalid="false"
         class="textbox__control"
         type="tel"
-        value="5551234567"
+        value="(555) 123-4567"
       />
     </span>
   </span>
@@ -5618,7 +5618,7 @@ exports[`EbayPhoneInput render renders with different country 1`] = `
         aria-describedby="phone-prefix"
         class="textbox__control"
         type="tel"
-        value="2071234567"
+        value="20712 34567"
       />
     </span>
   </span>

--- a/packages/ebayui-core-react/src/ebay-phone-input/__tests__/index.stories.tsx
+++ b/packages/ebayui-core-react/src/ebay-phone-input/__tests__/index.stories.tsx
@@ -205,9 +205,9 @@ export const Interactive: StoryFn<typeof EbayPhoneInput> = (args) => {
                 countryCode="us"
                 floatingLabel="Phone Number"
                 value={value}
-                onChange={(event, data) => {
+                onInputChange={(event, data) => {
                     setValue(data?.value || "");
-                    args.onChange?.(event, data);
+                    args.onInputChange?.(event, data);
                 }}
                 onFocus={args.onFocus}
                 onBlur={args.onBlur}

--- a/packages/ebayui-core-react/src/ebay-textbox/textbox.tsx
+++ b/packages/ebayui-core-react/src/ebay-textbox/textbox.tsx
@@ -12,6 +12,7 @@ import React, {
     useEffect,
     useState,
     LegacyRef,
+    useRef,
 } from "react";
 import classNames from "classnames";
 import { findComponent, withForwardRef } from "../common/component-utils";
@@ -86,7 +87,7 @@ const EbayTextbox: FC<EbayTextboxProps> = ({
     opaqueLabel,
     ...rest
 }) => {
-    const [value, setValue] = useState(defaultValue);
+    const oldValue = useRef(defaultValue);
     const [inputValue, setInputValue] = useState(defaultValue);
     const floatingLabel = useFloatingLabel({
         text: floatingLabelText,
@@ -100,15 +101,16 @@ const EbayTextbox: FC<EbayTextboxProps> = ({
     });
 
     const handleFocus = (event?: FocusEvent<HTMLInputElement & HTMLTextAreaElement>) => {
+        oldValue.current = event?.target?.value;
         onFocus(event, { value: event?.target?.value || defaultValue });
     };
 
     const handleBlur = (event: FocusEvent<HTMLInputElement & HTMLTextAreaElement>) => {
         const newValue = event.target?.value;
         onBlur(event, { value: newValue });
-        if (newValue !== value) {
+        if (newValue !== oldValue.current) {
             onChange(event, { value: newValue });
-            setValue(newValue);
+            oldValue.current = newValue;
         }
     };
 
@@ -131,7 +133,7 @@ const EbayTextbox: FC<EbayTextboxProps> = ({
     };
 
     const handleButtonClick = (event?: KeyboardEvent<HTMLInputElement> & MouseEvent<HTMLInputElement>) => {
-        onButtonClick(event, { value });
+        onButtonClick(event, { value: inputValue });
     };
 
     useEffect(() => {
@@ -143,9 +145,7 @@ const EbayTextbox: FC<EbayTextboxProps> = ({
     const handleInputChange = (e: ChangeEvent<HTMLTextAreaElement & HTMLInputElement>) => {
         const newValue = e.target?.value;
 
-        if (!isControlled(controlledValue)) {
-            setInputValue(newValue);
-        }
+        setInputValue(newValue);
 
         onInputChange(e, { value: newValue });
     };


### PR DESCRIPTION
<!-- Insert GitHub issue number below. An issue is required for all PRs -->

- Fixes #385 

## Description

<!-- Briefly describe the proposed changes -->
- Move from html event to react event to handle masking
- Add uncontrolled vs controlled use cases with new `defaultValue`

## Notes

<!-- Be sure to mention anything unusual, out-of-scope or new technical debt, etc -->
Previously we were doing the masking with normal DOM events, but those were conflicting with react events triggered by `EbayTextbox` causing the `onInputChange` event to not be triggered. Here we modify to have one single approach and use only React events. The `EbayPhoneInput` now has a `defaultValue` so it can support both controlled and uncontrolled behavior, but uses EbayTextbox as a controlled value.

## Checklist

<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->

- [x] I verify all changes are within scope of the linked issue
- [x] I added/updated/removed testing (Storybook in Skin) coverage as appropriate

<!-- For CSS changes -->

- [ ] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [ ] I tested the UI in dark mode and RTL mode
