### PR TITLE
fix(ebayNumberInput): add aria-label to ebayNumberInput

### DIFF
--- a/.changeset/three-donuts-stick.md
+++ b/.changeset/three-donuts-stick.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ui-core-react": patch
+---
+
+Add aria-label to ebayNumberInput

--- a/packages/ebayui-core-react/src/ebay-number-input/__tests__/index.spec.tsx
+++ b/packages/ebayui-core-react/src/ebay-number-input/__tests__/index.spec.tsx
@@ -129,6 +129,14 @@ describe("given a number input textbox with delete", () => {
     });
 });
 
+describe("given a number input textbox with aria-label", () => {
+    it("should render aria-label attribute on input", () => {
+        const { container } = render(<EbayNumberInput aria-label="Qty" value={1} />);
+        const input = container.querySelector('input[type="number"]');
+        expect(input).toHaveAttribute("aria-label", "Qty");
+    });
+});
+
 describe("given a number input textbox with constraints", () => {
     let onChange: jest.Mock;
     let onIncrement: jest.Mock;

--- a/packages/ebayui-core-react/src/ebay-number-input/__tests__/index.stories.tsx
+++ b/packages/ebayui-core-react/src/ebay-number-input/__tests__/index.stories.tsx
@@ -22,3 +22,7 @@ export const WithDelete: StoryFn<typeof EbayNumberInput> = () => (
 export const WithLabel: StoryFn<typeof EbayNumberInput> = () => (
     <EbayNumberInput min={1} max={10} value={1} label={"Enter a number"} />
 );
+
+export const WithAriaLabel: StoryFn<typeof EbayNumberInput> = () => (
+    <EbayNumberInput min={1} max={10} value={1} aria-label="Qty" />
+);

--- a/packages/ebayui-core-react/src/ebay-number-input/number-input.tsx
+++ b/packages/ebayui-core-react/src/ebay-number-input/number-input.tsx
@@ -120,6 +120,7 @@ const EbayNumberInput: FC<EbayNumberInputProps> = (props) => {
             )}
         >
             <EbayTextbox
+                {...rest}
                 max={max}
                 min={min}
                 onBlur={handleBlur}

--- a/packages/ebayui-core-react/src/ebay-number-input/types.ts
+++ b/packages/ebayui-core-react/src/ebay-number-input/types.ts
@@ -1,4 +1,5 @@
-import type { EbayTextboxProps as TextboxInput } from "../ebay-textbox";
+import type { ComponentProps } from "react";
+import { EbayTextbox } from "../ebay-textbox";
 
 import {
     EbayChangeEventHandler,
@@ -16,7 +17,7 @@ export type NumberInputFocusHandler = EbayFocusEventHandler<HTMLInputElement, Nu
 export type NumberInputKeyDownHandler = EbayKeyboardEventHandler<HTMLInputElement, NumberInputEventProps>;
 
 export type EbayNumberInputProps = Omit<
-    TextboxInput,
+    ComponentProps<typeof EbayTextbox>,
     "onChange" | "onInputChange" | "onFocus" | "onBlur" | "onKeyDown" | "onKeyPress" | "onKeyUp" | "forwardedRef"
 > & {
     label?: string;


### PR DESCRIPTION
<!-- Insert GitHub issue number below. An issue is required for all PRs -->

- Fixes #

## Description
Added aria-label to ebayNumberInput input textbox

<!-- Briefly describe the proposed changes -->

## Notes

<!-- Be sure to mention anything unusual, out-of-scope or new technical debt, etc -->

## Screenshots

Before:-
<img width="1428" height="202" alt="Screenshot 2025-12-17 at 11 15 24 AM" src="https://github.com/user-attachments/assets/8f977e85-30c3-404b-a24c-6a21d51697d9" />

After:-
<img width="1430" height="409" alt="Screenshot 2025-12-17 at 11 16 22 AM" src="https://github.com/user-attachments/assets/69425403-b11d-4132-b5f2-767efe24cae1" />


## Checklist

<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->

- [ ] I verify all changes are within scope of the linked issue
- [x] I added/updated/removed testing (Storybook in Skin) coverage as appropriate

<!-- For CSS changes -->

- [x] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [ ] I tested the UI in dark mode and RTL mode
