### PR TITLE
docs(website): color contrast issues and added storybook links

### DIFF
--- a/src/routes/_index/components/+page.marko
+++ b/src/routes/_index/components/+page.marko
@@ -1,4 +1,4 @@
-import { components } from "../../../data";
+import { components, urls } from "../../../data";
 
 <style.scss>
   main ul.components-list {
@@ -7,6 +7,7 @@ import { components } from "../../../data";
     display: flex;
     flex-wrap: wrap;
     gap: 20px;
+    justify-content: center;
     list-style: none;
     padding: 0 0 30px;
     margin: 0;
@@ -55,18 +56,55 @@ import { components } from "../../../data";
     padding: 3px 6px;
   }
 
-  @container components-list (min-width: 480px) {
+  @container components-list (min-width: 512px) {
     main li {
       width: calc(100% / 2 - 14px);
     }
   }
 
-  @container components-list (min-width: 700px) {
+  @container components-list (min-width: 768px) {
     main li {
       width: calc(100% / 3 - 14px);
     }
   }
+  main {
+    container-type: inline-size;
+  }
+
+  .link-container {
+    display: flex;
+    gap: var(--spacing-200);
+    justify-content: center;
+    margin-block-end: var(--spacing-400);
+    .nav-link {
+      display: inline-flex;
+      gap: var(--spacing-50);
+      font-weight: var(--font-weight-bold);
+    }
+  }
+
+  @container (width < 512px) {
+    .link-container {
+      align-items: center;
+      flex-direction: column;
+    }
+  }
 </style>
+
+<div class="link-container">
+  <a class="nav-link" href=urls.markoStorybook>
+    <span>Marko Components Storybook</span>
+    <svg class="icon icon--16" height="16" width="16" aria-hidden="true">
+      <use href="#icon-external-link-16"/>
+    </svg>
+  </a>
+  <a class="nav-link" href=urls.reactStorybook>
+    <span>React Components Storybook</span>
+    <svg class="icon icon--16" height="16" width="16" aria-hidden="true">
+      <use href="#icon-external-link-16"/>
+    </svg>
+  </a>
+</div>
 
 <div class="component-listings">
   <ul class="components-list">
@@ -102,12 +140,16 @@ import { components } from "../../../data";
                     CSS v${dsComponent?.version}
                   </span>
                 </if>
-                <if=dsComponent?.markoVersion && component?.componentUrls.marko>
+                <if=(
+                  dsComponent?.markoVersion && component?.componentUrls.marko
+                )>
                   <span class="component-version">
                     Marko v${dsComponent?.markoVersion}
                   </span>
                 </if>
-                <if=dsComponent?.reactVersion && component?.componentUrls.react>
+                <if=(
+                  dsComponent?.reactVersion && component?.componentUrls.react
+                )>
                   <span class="component-version">
                     React v${dsComponent?.reactVersion}
                   </span>

--- a/src/routes/_index/sitemap+page.marko
+++ b/src/routes/_index/sitemap+page.marko
@@ -12,10 +12,6 @@ import {urls} from "../../data";
     a.nav-link {
       text-decoration: underline;
     }
-    a.nav-link:visited,
-    a:visited {
-      color: revert;
-    }
   }
 
   .site-nav {

--- a/src/tags/site-header/index.marko
+++ b/src/tags/site-header/index.marko
@@ -1,4 +1,4 @@
-import { components, a11yDocs, urls} from "../../data";
+import { components, a11yDocs, urls } from "../../data";
 
 <let/navExpanded=false>
 
@@ -147,15 +147,13 @@ import { components, a11yDocs, urls} from "../../data";
             onClick() {
               navExpanded = !navExpanded;
             }>
-            <div class="mobile-menu__icon">
-              <svg
-                class="icon icon-20 mobile-menu__open"
-                height="18"
-                width="18"
-                aria-hidden="true">
-                <use href="#icon-menu-20"/>
-              </svg>
-            </div>
+            <svg
+              class="icon icon-20 mobile-menu__open"
+              height="18"
+              width="18"
+              aria-hidden="true">
+              <use href="#icon-menu-20"/>
+            </svg>
           </button>
         </div>
       </div>


### PR DESCRIPTION
- Fixes #419, #417, #420 

## Description

* Removed visited links override in sitemap (this now defaults to dark/light mode styles we have defined already in our links module)
* Removed extra container on the small screens icon button. This prevented color swapping styles to trigger since it targets the direct SVG
* Added links to components page. I made them look similar to those in the nav. They are also responsive using container queries. 

## Screenshots

### New links
<img width="1112" height="479" alt="Screenshot 2026-01-12 at 12 31 56 PM" src="https://github.com/user-attachments/assets/9a81ec84-4569-47e9-a745-7e3df85fa62a" />

### New links small screen
<img width="363" height="544" alt="Screenshot 2026-01-12 at 12 32 04 PM" src="https://github.com/user-attachments/assets/e81018b7-6ac2-44d7-92a3-ddaeecd64f6c" />

### Dark mode icon button
<img width="339" height="70" alt="Screenshot 2026-01-12 at 12 32 19 PM" src="https://github.com/user-attachments/assets/d48df0c3-a672-46f2-a355-b5e404c80b71" />

### Dark mode sitemap
<img width="477" height="803" alt="Screenshot 2026-01-12 at 12 33 14 PM" src="https://github.com/user-attachments/assets/a1053452-1c99-4801-9769-3394aa727486" />


## Checklist

- [X] I verify all changes are within scope of the linked issue
- [X] I added/updated/removed testing (Storybook in Skin) coverage as appropriate
