### PR TITLE
feat(site): added skip to main

### DIFF
--- a/src/routes/_index/+layout.marko
+++ b/src/routes/_index/+layout.marko
@@ -58,6 +58,9 @@ static declare global {
     </script>
   </head>
   <body class="evo-theme">
+    <div class="skip-to-main-content">
+      <a href="#main" class="clipped clipped--stealth">Skip to main content</a>
+    </div>
     <master-icons/>
     <site-header/>
     <navrail page=page>

--- a/src/sass/site-main.scss
+++ b/src/sass/site-main.scss
@@ -52,6 +52,7 @@ body > main:last-child {
 
 main {
   margin-bottom: var(--spacing-400);
+  scroll-margin-top: var(--spacing-600);
 }
 
 .icon-header {
@@ -120,4 +121,13 @@ main {
 
 .nav-link[aria-current] {
   font-weight: var(--font-weight-bold);
+}
+
+.skip-to-main-content a:focus {
+  background-color: var(--color-background-primary);
+  left: 0;
+  padding: var(--spacing-100) var(--spacing-200);
+  position: absolute;
+  top: 0;
+  z-index: 100000;
 }

--- a/src/tags/navrail.marko
+++ b/src/tags/navrail.marko
@@ -51,7 +51,7 @@ export interface Input {
                     </ul>
                 </nav>
             </div>
-            <main>
+            <main id="main">
                 <breadcrumbs/>
                 <component-tabs>
                     <${input.content}/>
@@ -61,7 +61,7 @@ export interface Input {
     </div>
 </if>
 <else>
-    <main class="landing-page">
+    <main id="main" class="landing-page">
         <${input.content}/>
     </main>
 </else>


### PR DESCRIPTION
<!-- Insert GitHub issue number below. An issue is required for all PRs -->

- Fixes #426 

## Description

<!-- Briefly describe the proposed changes -->

- Added skip-to-main link as first focusable element in `body`
- Added scroll-margin-top: var(--spacing-600) to main for proper scroll offset under sticky header

## Notes

- Felt odd to have breadcrumbs(as this is nav not primary content) as part of main. We can do a refactor to move breadcrumbs out of main. If we all agree, I can tackle it in next PR.

## Screenshots

<!-- Upload screenshots of UI before & after these changes -->
**Light Mode**
<img width="1162" height="312" alt="image" src="https://github.com/user-attachments/assets/3641dbba-38a8-4b13-9507-a3d7a65a8da4" />

**Dark Mode**
<img width="1162" height="312" alt="image" src="https://github.com/user-attachments/assets/195ff31e-61d2-4b4e-bb37-07256077e859" />



## Checklist

<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->

- [x] I verify all changes are within scope of the linked issue
- [ ] I added/updated/removed testing (Storybook in Skin) coverage as appropriate

<!-- For CSS changes -->

- [ ] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [ ] I tested the UI in dark mode and RTL mode
