### PR TITLE
fix(tips): fixed issue with small screens not fitting correctly

### DIFF
--- a/.changeset/tiny-gifts-itch.md
+++ b/.changeset/tiny-gifts-itch.md
@@ -1,0 +1,6 @@
+---
+"@ebay/ebayui-core": patch
+"@ebay/skin": patch
+---
+
+fix(tips): fixed issue with small screens not fitting correctly

--- a/packages/ebayui-core/src/components/components/ebay-tooltip-base/component-browser.ts
+++ b/packages/ebayui-core/src/components/components/ebay-tooltip-base/component-browser.ts
@@ -119,7 +119,7 @@ class TooltipBase extends Marko.Component<Input> {
             this.cleanup = autoUpdate(
                 this.hostEl,
                 this.overlayEl,
-                this.update.bind(this),
+                this.updateTip.bind(this),
             );
         }
     }
@@ -136,7 +136,11 @@ class TooltipBase extends Marko.Component<Input> {
                 middleware: [
                     offset(this.input.offset || 6),
                     !this.input.notInline && inline(),
-                    !this.input.noFlip && flip(),
+                    !this.input.noFlip &&
+                        flip({
+                            fallbackAxisSideDirection: "end",
+                            flipAlignment: false,
+                        }),
                     !this.input.noShift && shift(),
                     arrow({
                         element: this.arrowEl as HTMLElement,

--- a/packages/skin/dist/infotip/infotip.css
+++ b/packages/skin/dist/infotip/infotip.css
@@ -12,11 +12,11 @@ span.infotip {
     display: none;
     font-size: 14px;
     left: 0;
-    max-width: 344px;
+    min-width: 280px;
     position: absolute;
     top: 0;
     transform: scaleX(1);
-    width: max-content;
+    width: fit-content;
 }
 .infotip__mask,
 .infotip__overlay {
@@ -143,5 +143,6 @@ button.infotip__close {
 @media (min-width: 512px) {
     .infotip__overlay {
         max-width: 400px;
+        width: max-content;
     }
 }

--- a/packages/skin/dist/tooltip/tooltip.css
+++ b/packages/skin/dist/tooltip/tooltip.css
@@ -12,11 +12,11 @@ span.tooltip {
     display: none;
     font-size: 14px;
     left: 0;
-    max-width: 344px;
+    min-width: 280px;
     position: absolute;
     top: 0;
     transform: scaleX(1);
-    width: max-content;
+    width: fit-content;
 }
 .tooltip__mask,
 .tooltip__overlay {
@@ -143,5 +143,6 @@ button.tooltip__close {
 @media (min-width: 512px) {
     .tooltip__overlay {
         max-width: 400px;
+        width: max-content;
     }
 }

--- a/packages/skin/dist/tourtip/tourtip.css
+++ b/packages/skin/dist/tourtip/tourtip.css
@@ -12,11 +12,11 @@ span.tourtip {
     display: none;
     font-size: 14px;
     left: 0;
-    max-width: 344px;
+    min-width: 280px;
     position: absolute;
     top: 0;
     transform: scaleX(1);
-    width: max-content;
+    width: fit-content;
 }
 .tourtip__mask,
 .tourtip__overlay {
@@ -185,5 +185,6 @@ span.tourtip__heading {
 @media (min-width: 512px) {
     .tourtip__overlay {
         max-width: 400px;
+        width: max-content;
     }
 }

--- a/packages/skin/src/sass/mixins/private/_bubble-mixins.scss
+++ b/packages/skin/src/sass/mixins/private/_bubble-mixins.scss
@@ -19,12 +19,12 @@
     display: none;
     font-size: 14px;
     left: 0;
-    max-width: 344px;
+    min-width: 280px;
     position: absolute;
     top: 0;
     /* kick in hardware acceleration for GPU processing - fixes issues with filter/display reflow/repaint */
     transform: scale3d(1, 1, 1);
-    width: max-content;
+    width: fit-content;
     z-index: 1;
 }
 
@@ -40,6 +40,7 @@
 
 @mixin large-screen() {
     max-width: 400px;
+    width: max-content;
 }
 
 /* creates basic layout */


### PR DESCRIPTION
- Fixes #24 
## Description

* As discussed with design, made tourtip to shrink to 280px. This fits in 320px screen sizes
* Changed the calculation as follows: when above small screen viewport (~550px), tourtip fixes to around 400px. When below small screen view port, then it fits to the screen size and shrinks down to 280px. 
* Updated ebayui positioning to force it to always be in view. Currently, it was moving out of view even with shift enabled. 

## Notes
* partially fixes https://github.com/eBay/evo-web/issues/443


## Screenshots
<img width="332" height="487" alt="Screenshot 2026-01-21 at 1 52 07 PM" src="https://github.com/user-attachments/assets/03e0034b-010f-4363-b54c-bdc596cf7b06" />
<img width="531" height="264" alt="Screenshot 2026-01-21 at 1 52 21 PM" src="https://github.com/user-attachments/assets/a56e5d7a-ca95-4a75-8eb3-4442842bf0c7" />

### With placement right (instead of forcing right position, it shows below since there's not enough space)
<img width="1113" height="723" alt="Screenshot 2026-01-21 at 1 57 46 PM" src="https://github.com/user-attachments/assets/0ee2c652-89fc-4764-a47a-f105ebc6d148" />


## Checklist

- [X] I verify all changes are within scope of the linked issue
- [X] I added/updated/removed testing (Storybook in Skin) coverage as appropriate

- [X] I tested the UI in all supported browsers
- [X] I tested the UI in dark mode and RTL mode
