### PR TITLE
fix: ignore icon updates in evo-react for now

### DIFF
--- a/packages/evo-react/package.json
+++ b/packages/evo-react/package.json
@@ -36,7 +36,7 @@
     "start": "storybook dev -p 9001",
     "test": "vitest --browser.headless --passWithNoTests",
     "type:check": "tsc --noEmit",
-    "update-icons": "node ./scripts/update-icons",
+    "update-icons": "exit 0",
     "version": "npm run update-icons && git add -A src"
   },
   "dependencies": {


### PR DESCRIPTION

## Description

Since `@evo-web/react` is only a scaffold for now, we should ignore `update-icons` to allow the CI to pass through
