### PR TITLE
docs: evo-web storybook fixes

### DIFF
--- a/packages/evo-marko/src/tags/evo-3d-viewer/3d-viewer.stories.ts
+++ b/packages/evo-marko/src/tags/evo-3d-viewer/3d-viewer.stories.ts
@@ -1,7 +1,6 @@
-import { tagToString } from "../../common/storybook/storybook-code-source";
 import { buildExtensionTemplate } from "../../common/storybook/utils";
 import Readme from "./README.md";
-import Component, { type Input } from "./index.marko";
+import Component from "./index.marko";
 import DefaultTemplate from "./examples/default.marko";
 import DefaultTemplateCode from "./examples/default.marko?raw";
 
@@ -135,4 +134,7 @@ export default {
   },
 };
 
-export const Default = buildExtensionTemplate(DefaultTemplate, DefaultTemplateCode);
+export const Default = buildExtensionTemplate(
+  DefaultTemplate,
+  DefaultTemplateCode,
+);

--- a/packages/evo-marko/src/tags/evo-avatar/avatar.stories.ts
+++ b/packages/evo-marko/src/tags/evo-avatar/avatar.stories.ts
@@ -10,8 +10,6 @@ import autoImageTemplateCode from "./examples/with-auto-placement.marko?raw";
 import signedOutTemplate from "./examples/signedout.marko";
 import signedOutTemplateCode from "./examples/signedout.marko?raw";
 
-import type { Input } from "./index.marko";
-
 export default {
   title: "graphics & icons/evo-avatar",
   component: avatar,

--- a/packages/evo-marko/src/tags/evo-badge/badge.stories.ts
+++ b/packages/evo-marko/src/tags/evo-badge/badge.stories.ts
@@ -1,12 +1,7 @@
-import { Story } from "@storybook/marko";
-import { tagToString } from "../../common/storybook/storybook-code-source";
-import {
-  buildExtensionTemplate,
-} from "../../common/storybook/utils";
+import { buildExtensionTemplate } from "../../common/storybook/utils";
 import Readme from "./README.md";
 import DefaultTemplate from "./examples/default.marko";
 import DefaultTemplateCode from "./examples/default.marko?raw";
-import { type Input } from "./index.marko";
 
 export default {
   title: "graphics & icons/evo-badge",

--- a/packages/evo-marko/src/tags/evo-button/button.stories.ts
+++ b/packages/evo-marko/src/tags/evo-button/button.stories.ts
@@ -1,7 +1,5 @@
-import {
-  buildExtensionTemplate,
-} from "../../common/storybook/utils";
-import button, { type Input } from "./index.marko";
+import { buildExtensionTemplate } from "../../common/storybook/utils";
+import button from "./index.marko";
 import Readme from "./README.md";
 import ButtonTemplate from "./examples/button.marko";
 import ButtonTemplateCode from "./examples/button.marko?raw";

--- a/packages/evo-marko/src/tags/evo-ccd/ccd.stories.ts
+++ b/packages/evo-marko/src/tags/evo-ccd/ccd.stories.ts
@@ -38,7 +38,8 @@ export default {
     },
     a11yText: {
       control: { type: "text" },
-      description: "Required: The aria-label accessibility label for the ccd component. This is for internationalization. It should use min, max, and charger included or not included, and secondaryText in the label in order to demonstrate to screen readers the content on the component. Expected value `Charger included. ${min} - ${max} Watts. USB PD`",
+      description:
+        "Required: The aria-label accessibility label for the ccd component. This is for internationalization. It should use min, max, and charger included or not included, and secondaryText in the label in order to demonstrate to screen readers the content on the component. Expected value `Charger included. ${min} - ${max} Watts. USB PD`",
     },
     secondaryType: {
       control: { type: "select" },

--- a/packages/evo-marko/src/tags/evo-character-count/character-count.stories.ts
+++ b/packages/evo-marko/src/tags/evo-character-count/character-count.stories.ts
@@ -1,6 +1,6 @@
 import { buildExtensionTemplate } from "../../common/storybook/utils";
 import Readme from "./README.md";
-import Component, { type Input } from "./index.marko";
+import Component from "./index.marko";
 import IsolatedTemplate from "./examples/isolated.marko";
 import IsolatedCode from "./examples/isolated.marko?raw";
 import InFieldTemplate from "./examples/in-field.marko";

--- a/packages/evo-marko/src/tags/evo-checkbox/checkbox.stories.ts
+++ b/packages/evo-marko/src/tags/evo-checkbox/checkbox.stories.ts
@@ -1,6 +1,4 @@
-import { tagToString } from "../../common/storybook/storybook-code-source";
 import { buildExtensionTemplate } from "../../common/storybook/utils";
-
 import Readme from "./README.md";
 import Checkbox from "./index.marko";
 import GroupTemplate from "./examples/group.marko";
@@ -11,7 +9,6 @@ import GroupCode from "./examples/group.marko?raw";
 import WithLabelCode from "./examples/WithLabel.marko?raw";
 import DisabledCode from "./examples/DisabledWithLabel.marko?raw";
 import IsolatedTemplateCode from "./examples/isolated.marko?raw";
-import type { Input } from "./index.marko";
 
 export default {
   title: "form input/evo-checkbox",

--- a/packages/evo-marko/src/tags/evo-cta-button/cta-button.stories.ts
+++ b/packages/evo-marko/src/tags/evo-cta-button/cta-button.stories.ts
@@ -1,11 +1,8 @@
-import { Story } from "@storybook/marko";
 import { buildExtensionTemplate } from "../../common/storybook/utils";
 import DefaultTemplate from "./examples/default.marko";
 import DefaultTemplateCode from "./examples/default.marko?raw";
 
-import { tagToString } from "../../common/storybook/storybook-code-source";
 import Readme from "./README.md";
-import { type Input } from "./index.marko";
 
 export default {
   title: "buttons/evo-cta-button",

--- a/packages/evo-marko/src/tags/evo-details/details.stories.ts
+++ b/packages/evo-marko/src/tags/evo-details/details.stories.ts
@@ -1,7 +1,6 @@
-import { Story } from "@storybook/marko";
 import { buildExtensionTemplate } from "../../common/storybook/utils";
 import Readme from "./README.md";
-import Details, { type Input } from "./index.marko";
+import Details from "./index.marko";
 import DefaultTemplate from "./examples/default.marko";
 import DefaultTemplateCode from "./examples/default.marko?raw";
 

--- a/packages/evo-marko/src/tags/evo-eek/eek.stories.ts
+++ b/packages/evo-marko/src/tags/evo-eek/eek.stories.ts
@@ -11,7 +11,7 @@ import example2Code from "./examples/A++.marko?raw";
 import example3Code from "./examples/A+.marko?raw";
 import example4Code from "./examples/A.marko?raw";
 import example5Code from "./examples/invalid.marko?raw";
-import { Story } from "@storybook/marko";
+import type { StoryFn } from "@storybook/marko";
 
 export default {
   title: "graphics & icons/evo-eek",
@@ -25,7 +25,7 @@ export default {
   },
 
   argTypes: {
-    "a11yText": {
+    a11yText: {
       control: { type: "text" },
       description:
         "Required: The aria-label accessibility label for the eek component. This is for internationalization. It should use min, max, and rating in the label in order to demonstrate to screen readers the content on the component. Expected value `Energy efficiency class ${rating}. ${min} - ${max}`",
@@ -56,7 +56,7 @@ export default {
   },
 };
 
-export const Default: Story<Input> = (args) => ({ input: args });
+export const Default: StoryFn<Input> = (args) => ({ input: args });
 Default.args = {
   max: "A+++",
   min: "E",

--- a/packages/evo-marko/src/tags/evo-fake-tabs/fake-tabs.stories.ts
+++ b/packages/evo-marko/src/tags/evo-fake-tabs/fake-tabs.stories.ts
@@ -1,5 +1,5 @@
 import Readme from "./README.md";
-import Component, { type Input } from "./index.marko";
+import Component from "./index.marko";
 import { buildExtensionTemplate } from "../../common/storybook/utils";
 import DefaultTemplate from "./examples/default.marko";
 import DefaultTemplateCode from "./examples/default.marko?raw";
@@ -47,4 +47,3 @@ export const NoPanel = buildExtensionTemplate(
   NoPanelTemplate,
   NoPanelTemplateCode,
 );
-

--- a/packages/evo-marko/src/tags/evo-file-input/file-input.stories.ts
+++ b/packages/evo-marko/src/tags/evo-file-input/file-input.stories.ts
@@ -5,7 +5,7 @@ import WithPreviewCardsTemplate from "./examples/with-preview-cards.marko";
 import WithPreviewCardsCode from "./examples/with-preview-cards.marko?raw";
 import WithMockUploadsTemplate from "./examples/with-mock-uploads.marko";
 import WithMockUploadsCode from "./examples/with-mock-uploads.marko?raw";
-import { Story } from "@storybook/marko";
+import type { StoryFn } from "@storybook/marko";
 import component, { type Input } from "./index.marko";
 
 export default {
@@ -39,7 +39,7 @@ export default {
   },
 };
 
-export const Default: Story<Input> = (args) => ({
+export const Default: StoryFn<Input> = (args) => ({
   input: args,
   component: DefaultTemplate,
 });
@@ -56,7 +56,7 @@ Default.parameters = {
   },
 };
 
-export const WithPreviewCards: Story<Input> = (args) => ({
+export const WithPreviewCards: StoryFn<Input> = (args) => ({
   input: args,
   component: WithPreviewCardsTemplate,
 });
@@ -73,7 +73,7 @@ WithPreviewCards.parameters = {
   },
 };
 
-export const WithMockUploads: Story<Input> = (args) => ({
+export const WithMockUploads: StoryFn<Input> = (args) => ({
   input: args,
   component: WithMockUploadsTemplate,
 });

--- a/packages/evo-marko/src/tags/evo-file-preview-card-group/file-preview-card-group.stories.ts
+++ b/packages/evo-marko/src/tags/evo-file-preview-card-group/file-preview-card-group.stories.ts
@@ -1,6 +1,5 @@
-import { Story } from "@storybook/marko";
 import Readme from "./README.md";
-import component, { type Input } from "./index.marko";
+import component from "./index.marko";
 import { buildExtensionTemplate } from "../../common/storybook/utils";
 import DefaultTemplate from "./examples/default.marko";
 import DefaultTemplateCode from "./examples/default.marko?raw";

--- a/packages/evo-marko/src/tags/evo-file-preview-card/file-preview-card.stories.ts
+++ b/packages/evo-marko/src/tags/evo-file-preview-card/file-preview-card.stories.ts
@@ -1,8 +1,5 @@
-import { Story } from "@storybook/marko";
-import { tagToString } from "../../common/storybook/storybook-code-source";
 import Readme from "./README.md";
 import component from "./index.marko";
-import type { Input } from "./temp";
 import { buildExtensionTemplate } from "../../common/storybook/utils";
 import DefaultTemplate from "./examples/default.marko";
 import DefaultTemplateCode from "./examples/default.marko?raw";

--- a/packages/evo-marko/src/tags/evo-filter-chip/filter-chip.stories.ts
+++ b/packages/evo-marko/src/tags/evo-filter-chip/filter-chip.stories.ts
@@ -1,8 +1,6 @@
-import {
-    buildExtensionTemplate,
-} from "../../common/storybook/utils";
+import { buildExtensionTemplate } from "../../common/storybook/utils";
 import Readme from "./README.md";
-import Component  from "./index.marko";
+import Component from "./index.marko";
 import DefaultTemplate from "./examples/default.marko";
 import DefaultTemplateCode from "./examples/default.marko?raw";
 import ExpressiveTemplate from "./examples/expressive.marko";
@@ -11,69 +9,69 @@ import MenuButtonTemplate from "./examples/menu-button.marko";
 import MenuButtonTemplateCode from "./examples/menu-button.marko?raw";
 
 export default {
-    title: "form input/evo-filter-chip",
-    component: Component,
-    parameters: {
-        docs: {
-            description: {
-                component: Readme,
-            },
-        },
+  title: "form input/evo-filter-chip",
+  component: Component,
+  parameters: {
+    docs: {
+      description: {
+        component: Readme,
+      },
     },
+  },
 
-    argTypes: {
-        content: {
-            control: { type: "text" },
-            description: "Text to be displayed in the chip",
-        },
-        selected: {
-            control: { type: "boolean" },
-            description: "True/false if the chip is selected or not",
-        },
-        variant: {
-            options: ["default", "expressive", "menu"],
-            description:
-                "The variant of the filter. Default and expressive are toggle buttons, while menu turns it into a dropdown.",
-            control: { type: "select" },
-        },
-        icon: {
-            name: "@icon",
-            description: "The leading icon. Only used for default variant",
-            table: {
-                category: "@attribute tags",
-            },
-        },
-        image: {
-            name: "@image",
-            description: "The leading image. Only used for expressive variant",
-            table: {
-                category: "@attribute tags",
-            },
-        },
-        expanded: {
-            control: { type: "boolean" },
-            description:
-                "Only used for menu variant. True/false if the menu is in expanded state or not",
-        },
-        a11ySelectedText: {
-            control: { type: "string" },
-            description:
-                "For anchor variant: The clipped text to show when the filter is set. This is required to switch to anchor type along with href",
-        },
+  argTypes: {
+    content: {
+      control: { type: "text" },
+      description: "Text to be displayed in the chip",
     },
+    selected: {
+      control: { type: "boolean" },
+      description: "True/false if the chip is selected or not",
+    },
+    variant: {
+      options: ["default", "expressive", "menu"],
+      description:
+        "The variant of the filter. Default and expressive are toggle buttons, while menu turns it into a dropdown.",
+      control: { type: "select" },
+    },
+    icon: {
+      name: "@icon",
+      description: "The leading icon. Only used for default variant",
+      table: {
+        category: "@attribute tags",
+      },
+    },
+    image: {
+      name: "@image",
+      description: "The leading image. Only used for expressive variant",
+      table: {
+        category: "@attribute tags",
+      },
+    },
+    expanded: {
+      control: { type: "boolean" },
+      description:
+        "Only used for menu variant. True/false if the menu is in expanded state or not",
+    },
+    a11ySelectedText: {
+      control: { type: "string" },
+      description:
+        "For anchor variant: The clipped text to show when the filter is set. This is required to switch to anchor type along with href",
+    },
+  },
 };
 
 export const Default = buildExtensionTemplate(
-    DefaultTemplate,
-    DefaultTemplateCode,
+  DefaultTemplate,
+  DefaultTemplateCode,
 );
 
 export const MenuButton = buildExtensionTemplate(
-    MenuButtonTemplate,
-    MenuButtonTemplateCode,
+  MenuButtonTemplate,
+  MenuButtonTemplateCode,
 );
 
 export const Expressive = buildExtensionTemplate(
-    ExpressiveTemplate,
-    ExpressiveTemplateCode,
+  ExpressiveTemplate,
+  ExpressiveTemplateCode,
 );

--- a/packages/evo-marko/src/tags/evo-icon-button/icon-button.stories.ts
+++ b/packages/evo-marko/src/tags/evo-icon-button/icon-button.stories.ts
@@ -1,11 +1,7 @@
-import { Story } from "@storybook/marko";
-import {
-  buildExtensionTemplate,
-} from "../../common/storybook/utils";
+import { buildExtensionTemplate } from "../../common/storybook/utils";
 import DefaultTemplate from "./examples/default.marko";
 import DefaultTemplateCode from "./examples/default.marko?raw";
 import Readme from "./README.md";
-import type { Input } from "./index.marko";
 
 export default {
   title: "buttons/evo-icon-button",

--- a/packages/evo-marko/src/tags/evo-icon/icon.stories.ts
+++ b/packages/evo-marko/src/tags/evo-icon/icon.stories.ts
@@ -1,12 +1,7 @@
-import { Story } from "@storybook/marko";
-import { tagToString } from "../../common/storybook/storybook-code-source";
-import {
-  buildExtensionTemplate,
-} from "../../common/storybook/utils";
+import { buildExtensionTemplate } from "../../common/storybook/utils";
 
 import Readme from "./README.md";
 import Component from "./examples/all.marko";
-import type { Input } from "./index.marko";
 
 export default {
   title: "graphics & icons/evo-icon",

--- a/packages/evo-marko/src/tags/evo-image-placeholder/image-placeholder.stories.ts
+++ b/packages/evo-marko/src/tags/evo-image-placeholder/image-placeholder.stories.ts
@@ -7,31 +7,31 @@ import ResizedTemplate from "./examples/resized.marko";
 import ResizedTemplateCode from "./examples/resized.marko?raw";
 
 export default {
-    title: "graphics & icons/evo-image-placeholder",
-    component: Component,
-    parameters: {
-        docs: {
-            description: {
-                component: Readme,
-            },
-        },
+  title: "graphics & icons/evo-image-placeholder",
+  component: Component,
+  parameters: {
+    docs: {
+      description: {
+        component: Readme,
+      },
     },
+  },
 
-    argTypes: {
-        a11yText: {
-            control: { type: "text" },
-            description:
-                "text for non-decorative inline icon; icon is assumed to be decorative if this is not passed",
-        },
+  argTypes: {
+    a11yText: {
+      control: { type: "text" },
+      description:
+        "text for non-decorative inline icon; icon is assumed to be decorative if this is not passed",
     },
+  },
 };
 
 export const Default = buildExtensionTemplate(
-    DefaultTemplate,
-    DefaultTemplateCode,
+  DefaultTemplate,
+  DefaultTemplateCode,
 );
 
 export const Resized = buildExtensionTemplate(
-    ResizedTemplate,
-    ResizedTemplateCode,
+  ResizedTemplate,
+  ResizedTemplateCode,
 );

--- a/packages/evo-marko/src/tags/evo-list/list.stories.ts
+++ b/packages/evo-marko/src/tags/evo-list/list.stories.ts
@@ -6,7 +6,7 @@ import InteractiveTemplate from "./examples/interactive.marko";
 import InteractiveTemplateCode from "./examples/interactive.marko?raw";
 import WithSeparatorTemplate from "./examples/with-separator.marko";
 import WithSeparatorTemplateCode from "./examples/with-separator.marko?raw";
-import { Story } from "@storybook/marko";
+import type { StoryFn } from "@storybook/marko";
 
 export default {
   title: "building blocks/evo-list",
@@ -59,7 +59,7 @@ export default {
   },
 };
 
-export const Static: Story<Input> = (args) => ({
+export const Static: StoryFn<Input> = (args) => ({
   input: args,
   component: StaticTemplate,
 });
@@ -72,7 +72,7 @@ Static.parameters = {
   },
 };
 
-export const Interactive: Story<Input> = (args) => ({
+export const Interactive: StoryFn<Input> = (args) => ({
   input: args,
   component: InteractiveTemplate,
 });
@@ -85,7 +85,7 @@ Interactive.parameters = {
   },
 };
 
-export const WithSeparator: Story<Input> = (args) => ({
+export const WithSeparator: StoryFn<Input> = (args) => ({
   input: args,
   component: WithSeparatorTemplate,
 });

--- a/packages/evo-marko/src/tags/evo-listbox-button/listbox-button.stories.ts
+++ b/packages/evo-marko/src/tags/evo-listbox-button/listbox-button.stories.ts
@@ -1,4 +1,3 @@
-import { tagToString } from "../../common/storybook/storybook-code-source";
 import { buildExtensionTemplate } from "../../common/storybook/utils";
 import Readme from "./README.md";
 import Component from "./index.marko";
@@ -8,7 +7,6 @@ import WithDescriptionTemplate from "./examples/with-description.marko";
 import WithDescriptionTemplateCode from "./examples/with-description.marko?raw";
 import WithErrorTemplate from "./examples/with-error.marko";
 import WithErrorTemplateCode from "./examples/with-error.marko?raw";
-import { Story } from "@storybook/marko";
 
 export default {
   title: "buttons/evo-listbox-button",

--- a/packages/evo-marko/src/tags/evo-listbox/listbox.stories.ts
+++ b/packages/evo-marko/src/tags/evo-listbox/listbox.stories.ts
@@ -1,12 +1,10 @@
 import { buildExtensionTemplate } from "../../common/storybook/utils";
-import { tagToString } from "../../common/storybook/storybook-code-source";
 import Readme from "./README.md";
 import Component from "./index.marko";
 import DefaultTemplate from "./examples/default.marko";
 import DefaultTemplateCode from "./examples/default.marko?raw";
 import WithDescriptionTemplate from "./examples/with-description.marko";
 import WithDescriptionTemplateCode from "./examples/with-description.marko?raw";
-import type { Input } from "./component";
 
 export default {
   title: "building blocks/evo-listbox",

--- a/packages/evo-marko/src/tags/evo-menu-button/index.marko
+++ b/packages/evo-marko/src/tags/evo-menu-button/index.marko
@@ -98,16 +98,13 @@ export interface Input<
         priority,
     };
 })()>
-<id/menu>
 <evo-expander/expander
     open:=open
     reverse=reverse
     strategy=strategy
     collapseOnSelect=collapseOnSelect
     host=root
-    overlay=() => {
-        return document.getElementById(menu)!;
-    }/>
+    overlay=$menu/>
 <span/root ...htmlInput class=["menu-button", inputClass]>
     <${tagName}
         class=[`menu-button__button`]
@@ -138,9 +135,8 @@ export interface Input<
             <evo-icon-chevron-down-12/>
         </if>
     </>
-    <evo-menu
+    <evo-menu/$menu:(() => HTMLSpanElement)
         style=expander.floatingStyles
-        id=menu
         selected:=input.selected
         classPrefix="menu-button"
         fixed=strategy === "fixed"

--- a/packages/evo-marko/src/tags/evo-menu-button/menu-button.stories.ts
+++ b/packages/evo-marko/src/tags/evo-menu-button/menu-button.stories.ts
@@ -1,4 +1,3 @@
-import { tagToString } from "../../common/storybook/storybook-code-source";
 import { buildExtensionTemplate } from "../../common/storybook/utils";
 import Readme from "./README.md";
 import DefaultTemplate from "./examples/default.marko";
@@ -18,8 +17,6 @@ import FilterTemplateCode from "./examples/filter.marko?raw";
 import FooterTemplate from "./examples/footer.marko";
 import FooterTemplateCode from "./examples/footer.marko?raw";
 import Component from "./index.marko";
-import { Story } from "@storybook/marko";
-import type { Input } from "./component";
 
 export default {
   title: "buttons/evo-menu-button",

--- a/packages/evo-marko/src/tags/evo-menu/index.marko
+++ b/packages/evo-marko/src/tags/evo-menu/index.marko
@@ -48,7 +48,7 @@ export interface Input<
 <let/selected:=input.selected>
 
 <id/menu>
-<span
+<span/$el
     ...htmlInput
     class=[
         classPrefix ? `${baseClass}__menu` : "menu",
@@ -154,3 +154,5 @@ export interface Input<
         </div>
     </if>
 </span>
+
+<return=$el>

--- a/packages/evo-marko/src/tags/evo-menu/menu.stories.ts
+++ b/packages/evo-marko/src/tags/evo-menu/menu.stories.ts
@@ -1,7 +1,4 @@
-import {
-    buildExtensionTemplate,
-} from "../../common/storybook/utils";
-import { tagToString } from "../../common/storybook/storybook-code-source";
+import { buildExtensionTemplate } from "../../common/storybook/utils";
 import Readme from "./README.md";
 import Component from "./index.marko";
 import DefaultTemplate from "./examples/default.marko";
@@ -24,158 +21,155 @@ import FooterTemplate from "./examples/footer.marko";
 import FooterTemplateCode from "./examples/footer.marko?raw";
 
 export default {
-    title: "building blocks/evo-menu",
-    component: Component,
-    parameters: {
-        docs: {
-            description: {
-                component: Readme,
-            },
-        },
+  title: "building blocks/evo-menu",
+  component: Component,
+  parameters: {
+    docs: {
+      description: {
+        component: Readme,
+      },
+    },
+  },
+
+  argTypes: {
+    type: {
+      control: { type: "select" },
+      options: ["radio", "checkbox", "none"],
+      description: 'Can be "radio" / "checkbox"',
+    },
+    variant: {
+      control: { type: "select" },
+      options: ["filter", "none"],
+      description:
+        'Either "none" for default menu or "filter" for filter variant',
     },
 
-    argTypes: {
-        type: {
-            control: { type: "select" },
-            options: ["radio", "checkbox", "none"],
-            description: 'Can be "radio" / "checkbox"',
-        },
-        variant: {
-            control: { type: "select" },
-            options: ["filter", "none"],
-            description:
-                'Either "none" for default menu or "filter" for filter variant',
-        },
-
-        priority: {
-            control: { type: "select" },
-            options: ["primary", "secondary", "none"],
-            description:
-                'button priority, "primary" / "secondary" (default) / "none"',
-        },
-        checked: {
-            description:
-                "will set the corresponding index item to `checked` state and use the `aria-checked` attribute in markup",
-        },
-        item: {
-            name: "@item",
-            table: {
-                category: "@attribute tags",
-            },
-        },
-        value: {
-            control: { type: "text" },
-            table: {
-                category: "@item attributes",
-            },
-            description:
-                "the value to use with event responses for for the `checked` array",
-        },
-        badgeNumber: {
-            controls: { hideNoControlsWarning: true },
-            table: {
-                category: "@item attributes",
-            },
-            description: "used as the number to be placed in the badge",
-        },
-        "aria-label": {
-            controls: { hideNoControlsWarning: true },
-            table: {
-                category: "@item attributes",
-            },
-            description:
-                "Passed as the `aria-label` directly to the badge. Required only if badge number is provided",
-        },
-        footerButton: {
-            name: "@footer-button",
-            table: {
-                category: "@attribute tags",
-            },
-            description:
-                "The footer content. Renders an evo-button. Used for filter type generally.",
-        },
-        "onFooter-button-click": {
-            action: "on-footer-button-click",
-            description: "Triggered on click of footer button",
-            table: {
-                category: "Events",
-                defaultValue: {
-                    summary: "{ }",
-                },
-            },
-        },
-        onKeydown: {
-            action: "on-keydown",
-            description: "Triggered on keydown",
-            table: {
-                category: "Events",
-                defaultValue: {
-                    summary: "{ el, index, checked }",
-                },
-            },
-        },
-        onChange: {
-            action: "on-change",
-            description:
-                "Triggered on item checked change, (checkbox/radio type only)",
-            table: {
-                category: "Events",
-                defaultValue: {
-                    summary:
-                        "radio: { el, index, checked } | checkbox: { el, [indexes], [checked] }",
-                },
-            },
-        },
-
-        onSelect: {
-            action: "on-select",
-            description: "Triggered on item clicked (non radio/checkbox)",
-            table: {
-                category: "Events",
-                defaultValue: {
-                    summary: "{ el, index, checked }",
-                },
-            },
-        },
+    priority: {
+      control: { type: "select" },
+      options: ["primary", "secondary", "none"],
+      description:
+        'button priority, "primary" / "secondary" (default) / "none"',
     },
+    checked: {
+      description:
+        "will set the corresponding index item to `checked` state and use the `aria-checked` attribute in markup",
+    },
+    item: {
+      name: "@item",
+      table: {
+        category: "@attribute tags",
+      },
+    },
+    value: {
+      control: { type: "text" },
+      table: {
+        category: "@item attributes",
+      },
+      description:
+        "the value to use with event responses for for the `checked` array",
+    },
+    badgeNumber: {
+      controls: { hideNoControlsWarning: true },
+      table: {
+        category: "@item attributes",
+      },
+      description: "used as the number to be placed in the badge",
+    },
+    "aria-label": {
+      controls: { hideNoControlsWarning: true },
+      table: {
+        category: "@item attributes",
+      },
+      description:
+        "Passed as the `aria-label` directly to the badge. Required only if badge number is provided",
+    },
+    footerButton: {
+      name: "@footer-button",
+      table: {
+        category: "@attribute tags",
+      },
+      description:
+        "The footer content. Renders an evo-button. Used for filter type generally.",
+    },
+    "onFooter-button-click": {
+      action: "on-footer-button-click",
+      description: "Triggered on click of footer button",
+      table: {
+        category: "Events",
+        defaultValue: {
+          summary: "{ }",
+        },
+      },
+    },
+    onKeydown: {
+      action: "on-keydown",
+      description: "Triggered on keydown",
+      table: {
+        category: "Events",
+        defaultValue: {
+          summary: "{ el, index, checked }",
+        },
+      },
+    },
+    onChange: {
+      action: "on-change",
+      description:
+        "Triggered on item checked change, (checkbox/radio type only)",
+      table: {
+        category: "Events",
+        defaultValue: {
+          summary:
+            "radio: { el, index, checked } | checkbox: { el, [indexes], [checked] }",
+        },
+      },
+    },
+
+    onSelect: {
+      action: "on-select",
+      description: "Triggered on item clicked (non radio/checkbox)",
+      table: {
+        category: "Events",
+        defaultValue: {
+          summary: "{ el, index, checked }",
+        },
+      },
+    },
+  },
 };
 
 export const Default = buildExtensionTemplate(
-    DefaultTemplate,
-    DefaultTemplateCode,
+  DefaultTemplate,
+  DefaultTemplateCode,
 );
 
-export const Radio = buildExtensionTemplate(
-    RadioTemplate,
-    RadioTemplateCode,
-);
+export const Radio = buildExtensionTemplate(RadioTemplate, RadioTemplateCode);
 
 export const Checkbox = buildExtensionTemplate(
-    CheckboxTemplate,
-    CheckboxTemplateCode,
+  CheckboxTemplate,
+  CheckboxTemplateCode,
 );
 
 export const Typeahead = buildExtensionTemplate(
-    TypeaheadTemplate,
-    TypeaheadTemplateCode,
+  TypeaheadTemplate,
+  TypeaheadTemplateCode,
 );
 export const Badged = buildExtensionTemplate(
-    BadgedTemplate,
-    BadgedTemplateCode,
+  BadgedTemplate,
+  BadgedTemplateCode,
 );
 export const Filter = buildExtensionTemplate(
-    FilterTemplate,
-    FilterTemplateCode,
+  FilterTemplate,
+  FilterTemplateCode,
 );
 export const Sprites = buildExtensionTemplate(
-    SpritesTemplate,
-    SpritesTemplateCode,
+  SpritesTemplate,
+  SpritesTemplateCode,
 );
 export const Separator = buildExtensionTemplate(
-    SeparatorTemplate,
-    SeparatorTemplateCode,
+  SeparatorTemplate,
+  SeparatorTemplateCode,
 );
 export const Footer = buildExtensionTemplate(
-    FooterTemplate,
-    FooterTemplateCode,
+  FooterTemplate,
+  FooterTemplateCode,
 );

--- a/packages/evo-marko/src/tags/evo-number-input/number-input.stories.ts
+++ b/packages/evo-marko/src/tags/evo-number-input/number-input.stories.ts
@@ -1,7 +1,7 @@
 import Readme from "./README.md";
 import Component from "./index.marko";
-import { Story } from "@storybook/marko";
-import type { Input } from "./component";
+import type { StoryFn } from "@storybook/marko";
+import type { Input } from "./index.marko";
 import defaultTemplate from "./examples/default.marko";
 import defaultTemplateCode from "./examples/default.marko?raw";
 import withDeleteTemplate from "./examples/with-delete.marko";
@@ -10,128 +10,127 @@ import withLabelTemplate from "./examples/with-label.marko";
 import withLabelTemplateCode from "./examples/with-label.marko?raw";
 
 export default {
-    title: "form input/evo-number-input",
-    component: Component,
-    parameters: {
-        docs: {
-            description: {
-                component: Readme,
-            },
-        },
+  title: "form input/evo-number-input",
+  component: Component,
+  parameters: {
+    docs: {
+      description: {
+        component: Readme,
+      },
     },
+  },
 
-    argTypes: {
-        fluid: {
-            type: "boolean",
-            control: { type: "boolean" },
-        },
-        inputSize: {
-            options: ["regular", "large"],
-            type: { category: "Options" },
-            description:
-                'either "regular" or "large". If large, then renders larger sized textbox',
-            table: {
-                defaultValue: {
-                    summary: "regular",
-                },
-            },
-        },
-        multiline: {
-            type: "boolean",
-            control: { type: "boolean" },
-            description: "renders a multi-line texbox if true",
-        },
-        invalid: {
-            type: "boolean",
-            control: { type: "boolean" },
-            description:
-                "indicates a field-level error with red border if true",
-        },
-        "aria-label": {
-            type: "string",
-            control: { type: "Options" },
-            description:
-                "Either this or @label is required. Renders text for screen readers",
-        },
-        label: {
-            description:
-                "Either this or aria-label is required. Renders label inside input if set",
-            control: { type: "text" },
-            table: {
-                category: "@attribute tag",
-                defaultValue: {
-                    summary: "",
-                },
-            },
-        },
-        onIncrement: {
-            action: "onIncrement",
-            description: "Triggered when increment button is clicked",
-            table: {
-                category: "Events",
-                defaultValue: {
-                    summary: "",
-                },
-            },
-        },
-        onDecrement: {
-            action: "onDecrement",
-            description: "Triggered when decrement button is clicked",
-            table: {
-                category: "Events",
-                defaultValue: {
-                    summary: "",
-                },
-            },
-        },
-        onDelete: {
-            action: "onDelete",
-            description: "Triggered when delete button is clicked",
-            table: {
-                category: "Events",
-                defaultValue: {
-                    summary: "",
-                },
-            },
-        },
+  argTypes: {
+    fluid: {
+      type: "boolean",
+      control: { type: "boolean" },
     },
+    inputSize: {
+      options: ["regular", "large"],
+      type: { category: "Options" },
+      description:
+        'either "regular" or "large". If large, then renders larger sized textbox',
+      table: {
+        defaultValue: {
+          summary: "regular",
+        },
+      },
+    },
+    multiline: {
+      type: "boolean",
+      control: { type: "boolean" },
+      description: "renders a multi-line texbox if true",
+    },
+    invalid: {
+      type: "boolean",
+      control: { type: "boolean" },
+      description: "indicates a field-level error with red border if true",
+    },
+    "aria-label": {
+      type: "string",
+      control: { type: "Options" },
+      description:
+        "Either this or @label is required. Renders text for screen readers",
+    },
+    label: {
+      description:
+        "Either this or aria-label is required. Renders label inside input if set",
+      control: { type: "text" },
+      table: {
+        category: "@attribute tag",
+        defaultValue: {
+          summary: "",
+        },
+      },
+    },
+    onIncrement: {
+      action: "onIncrement",
+      description: "Triggered when increment button is clicked",
+      table: {
+        category: "Events",
+        defaultValue: {
+          summary: "",
+        },
+      },
+    },
+    onDecrement: {
+      action: "onDecrement",
+      description: "Triggered when decrement button is clicked",
+      table: {
+        category: "Events",
+        defaultValue: {
+          summary: "",
+        },
+      },
+    },
+    onDelete: {
+      action: "onDelete",
+      description: "Triggered when delete button is clicked",
+      table: {
+        category: "Events",
+        defaultValue: {
+          summary: "",
+        },
+      },
+    },
+  },
 };
 
-export const Default: Story<Input> = (args) => ({
-    input: args,
-    component: defaultTemplate,
+export const Default: StoryFn<Input> = (args) => ({
+  input: args,
+  component: defaultTemplate,
 });
 Default.args = {};
 Default.parameters = {
-    docs: {
-        source: {
-            code: defaultTemplateCode,
-        },
+  docs: {
+    source: {
+      code: defaultTemplateCode,
     },
+  },
 };
 
-export const withDelete: Story<Input> = (args) => ({
-    input: args,
-    component: withDeleteTemplate,
+export const withDelete: StoryFn<Input> = (args) => ({
+  input: args,
+  component: withDeleteTemplate,
 });
 withDelete.args = {};
 withDelete.parameters = {
-    docs: {
-        source: {
-            code: withDeleteTemplateCode,
-        },
+  docs: {
+    source: {
+      code: withDeleteTemplateCode,
     },
+  },
 };
 
-export const withLabel: Story<Input> = (args) => ({
-    input: args,
-    component: withLabelTemplate,
+export const withLabel: StoryFn<Input> = (args) => ({
+  input: args,
+  component: withLabelTemplate,
 });
 withLabel.args = {};
 withLabel.parameters = {
-    docs: {
-        source: {
-            code: withLabelTemplateCode,
-        },
+  docs: {
+    source: {
+      code: withLabelTemplateCode,
     },
+  },
 };

--- a/packages/evo-marko/src/tags/evo-pagination/pagination.stories.ts
+++ b/packages/evo-marko/src/tags/evo-pagination/pagination.stories.ts
@@ -7,8 +7,6 @@ import buttonsTemplate from "./examples/buttons.marko";
 import buttonsTemplateCode from "./examples/buttons.marko?raw";
 import interactiveTemplate from "./examples/buttons-interactive.marko";
 import interactiveTemplateCode from "./examples/buttons-interactive.marko?raw";
-import { Story } from "@storybook/marko";
-import type { Input } from "./temp";
 
 export default {
   title: "navigation & disclosure/evo-pagination",

--- a/packages/evo-marko/src/tags/evo-progress-spinner/progress-spinner.stories.ts
+++ b/packages/evo-marko/src/tags/evo-progress-spinner/progress-spinner.stories.ts
@@ -1,10 +1,8 @@
-import { Story } from "@storybook/marko";
-import { tagToString } from "../../common/storybook/storybook-code-source";
 import { buildExtensionTemplate } from "../../common/storybook/utils";
 import DefaultTemplate from "./examples/default.marko";
 import DefaultTemplateCode from "./examples/default.marko?raw";
 import Readme from "./README.md";
-import Component, { type Input } from "./index.marko";
+import Component from "./index.marko";
 
 export default {
   title: "progress/evo-progress-spinner",

--- a/packages/evo-marko/src/tags/evo-progress-stepper/progress-stepper.stories.ts
+++ b/packages/evo-marko/src/tags/evo-progress-stepper/progress-stepper.stories.ts
@@ -1,8 +1,6 @@
-import { Story } from "@storybook/marko";
 import { buildExtensionTemplate } from "../../common/storybook/utils";
-import { tagToString } from "../../common/storybook/storybook-code-source";
 import Readme from "./README.md";
-import Component, { type Input } from "./index.marko";
+import Component from "./index.marko";
 import DefaultTemplate from "./examples/default.marko";
 import DefaultTemplateCode from "./examples/default.marko?raw";
 

--- a/packages/evo-marko/src/tags/evo-radio/radio.stories.ts
+++ b/packages/evo-marko/src/tags/evo-radio/radio.stories.ts
@@ -7,7 +7,7 @@ import DisabledTemplate from "./examples/disabled-with-label.marko";
 import groupCode from "./examples/grouped-radio.marko?raw";
 import WithLabelCode from "./examples/with-label.marko?raw";
 import DisabledCode from "./examples/disabled-with-label.marko?raw";
-import { Story } from "@storybook/marko";
+import type { StoryFn } from "@storybook/marko";
 
 export default {
   title: "form input/evo-radio",
@@ -42,7 +42,7 @@ export default {
   },
 };
 
-export const WithLabel: Story<Input> = (args) => ({
+export const WithLabel: StoryFn<Input> = (args) => ({
   input: args,
   component: WithLabelTemplate,
 });
@@ -55,7 +55,7 @@ WithLabel.parameters = {
   },
 };
 
-export const Disabled: Story<Input> = (args) => ({
+export const Disabled: StoryFn<Input> = (args) => ({
   input: args,
   component: DisabledTemplate,
 });
@@ -68,7 +68,7 @@ Disabled.parameters = {
   },
 };
 
-export const Group: Story<Input> = (args) => ({
+export const Group: StoryFn<Input> = (args) => ({
   input: {
     ...args,
   },

--- a/packages/evo-marko/src/tags/evo-segmented-buttons/segmented-buttons.stories.ts
+++ b/packages/evo-marko/src/tags/evo-segmented-buttons/segmented-buttons.stories.ts
@@ -1,65 +1,61 @@
-import { tagToString } from "../../common/storybook/storybook-code-source";
-import {
-    buildExtensionTemplate,
-} from "../../common/storybook/utils";
-import button, { type Input } from "./index.marko";
+import { buildExtensionTemplate } from "../../common/storybook/utils";
+import button from "./index.marko";
 import Readme from "./README.md";
 import DefaultTemplate from "./examples/default.marko";
 import DefaultTemplateCode from "./examples/default.marko?raw";
 import WithIconsTemplate from "./examples/with-icons.marko";
 import WithIconsTemplateCode from "./examples/with-icons.marko?raw";
-import { Story } from "@storybook/marko";
 
 export default {
-    title: "buttons/evo-segmented-buttons",
-    component: button,
-    parameters: {
-        docs: {
-            description: {
-                component: Readme,
-            },
-        },
+  title: "buttons/evo-segmented-buttons",
+  component: button,
+  parameters: {
+    docs: {
+      description: {
+        component: Readme,
+      },
     },
-    argTypes: {
-        button: {
-            description: "Each button in the segmented button",
-            name: "@button",
-            table: {
-                category: "@Attribute Tags",
-            },
-        },
-        selected: {
-            description: "If true, this will be the selected button",
-            table: {
-                category: "@button attribute",
-            },
-        },
-        size: {
-            options: ["large", "regular"],
-            description: "",
-            table: {
-                defaultValue: {
-                    summary: "none",
-                },
-            },
-            type: { category: "Options" },
-        },
-        icon: {
-            description: "The icon to show before the text",
-            name: "@icon",
-            table: {
-                category: "@button attribute",
-            },
-        },
+  },
+  argTypes: {
+    button: {
+      description: "Each button in the segmented button",
+      name: "@button",
+      table: {
+        category: "@Attribute Tags",
+      },
     },
+    selected: {
+      description: "If true, this will be the selected button",
+      table: {
+        category: "@button attribute",
+      },
+    },
+    size: {
+      options: ["large", "regular"],
+      description: "",
+      table: {
+        defaultValue: {
+          summary: "none",
+        },
+      },
+      type: { category: "Options" },
+    },
+    icon: {
+      description: "The icon to show before the text",
+      name: "@icon",
+      table: {
+        category: "@button attribute",
+      },
+    },
+  },
 };
 
 export const Default = buildExtensionTemplate(
-    DefaultTemplate,
-    DefaultTemplateCode
+  DefaultTemplate,
+  DefaultTemplateCode,
 );
 
 export const WithIcons = buildExtensionTemplate(
-    WithIconsTemplate,
-    WithIconsTemplateCode,
+  WithIconsTemplate,
+  WithIconsTemplateCode,
 );

--- a/packages/evo-marko/src/tags/evo-select/select.stories.ts
+++ b/packages/evo-marko/src/tags/evo-select/select.stories.ts
@@ -7,184 +7,183 @@ import DisabledTemplate from "./examples/disabled-with-label.marko";
 import WithLabelCode from "./examples/external-label.marko?raw";
 import InFormCode from "./examples/in-form.marko";
 import DisabledCode from "./examples/disabled-with-label.marko";
-import { Story } from "@storybook/marko";
-import type { Input } from "./component";
+import type { StoryFn } from "@storybook/marko";
+import type { Input } from "./index.marko";
 
-const Template: Story<Input> = (args) => ({
-    input: {
-        ...args,
-        renderBody: (args.renderBody
-            ? (out: any) => {
-                  out.html(args.renderBody);
-              }
-            : null) as any,
-    },
+const Template: StoryFn<Input> = (args) => ({
+  input: {
+    ...args,
+    renderBody: (args.renderBody
+      ? (out: any) => {
+          out.html(args.renderBody);
+        }
+      : null) as any,
+  },
 });
 
 export default {
-    title: "form input/evo-select",
-    component: Component,
-    parameters: {
-        docs: {
-            description: {
-                component: Readme,
-            },
-        },
+  title: "form input/evo-select",
+  component: Component,
+  parameters: {
+    docs: {
+      description: {
+        component: Readme,
+      },
+    },
+  },
+
+  argTypes: {
+    floatingLabel: {
+      type: "string",
+      control: { type: "string" },
+      description:
+        "if set, then label will move up and down. Need to have first option to have a nullable value.",
+    },
+    borderless: {
+      type: "boolean",
+      control: { type: "boolean" },
+      description: "whether button has borders",
+    },
+    fluid: {
+      type: "boolean",
+      control: { type: "boolean" },
+      description: "Select takes 100% of the container width",
+    },
+    isLarge: {
+      type: "boolean",
+      control: { type: "boolean" },
+      description: "to show large version",
     },
 
-    argTypes: {
-        floatingLabel: {
-            type: "string",
-            control: { type: "string" },
-            description:
-                "if set, then label will move up and down. Need to have first option to have a nullable value.",
-        },
-        borderless: {
-            type: "boolean",
-            control: { type: "boolean" },
-            description: "whether button has borders",
-        },
-        fluid: {
-            type: "boolean",
-            control: { type: "boolean" },
-            description: "Select takes 100% of the container width",
-        },
-        isLarge: {
-            type: "boolean",
-            control: { type: "boolean" },
-            description: "to show large version",
-        },
-
-        text: {
-            control: { type: "text" },
-            description: "text to use in the option",
-            table: {
-                category: "@option attributes",
-            },
-        },
-        value: {
-            control: { type: "text" },
-            description:
-                "used for the `value` attribute of the native `<option>`",
-            table: {
-                category: "@option attributes",
-            },
-        },
-        selected: {
-            control: { type: "text" },
-            description:
-                "used to determine which option is selected. This should be included in one and only one option.",
-            table: {
-                category: "@option attributes",
-            },
-        },
-        option: {
-            name: "@option",
-            table: {
-                category: "@attribute tags",
-            },
-        },
-        onChange: {
-            action: "on-change",
-            description: "Triggered on option selected",
-            table: {
-                category: "Events",
-                defaultValue: {
-                    summary: "{ el, index, selected }",
-                },
-            },
-        },
+    text: {
+      control: { type: "text" },
+      description: "text to use in the option",
+      table: {
+        category: "@option attributes",
+      },
     },
+    value: {
+      control: { type: "text" },
+      description: "used for the `value` attribute of the native `<option>`",
+      table: {
+        category: "@option attributes",
+      },
+    },
+    selected: {
+      control: { type: "text" },
+      description:
+        "used to determine which option is selected. This should be included in one and only one option.",
+      table: {
+        category: "@option attributes",
+      },
+    },
+    option: {
+      name: "@option",
+      table: {
+        category: "@attribute tags",
+      },
+    },
+    onChange: {
+      action: "on-change",
+      description: "Triggered on option selected",
+      table: {
+        category: "Events",
+        defaultValue: {
+          summary: "{ el, index, selected }",
+        },
+      },
+    },
+  },
 };
 
 export const Floating = Template.bind({});
 Floating.args = {
-    floatingLabel: "Option",
-    option: [
-        {
-            text: "Select an option",
-            value: "",
-        },
-        {
-            text: "option 1",
-            value: "option 1",
-        },
-        {
-            text: "option 2",
-            value: "option 2",
-        },
-        {
-            text: "option 3",
-            value: "option 3",
-        },
-    ] as any,
+  floatingLabel: "Option",
+  option: [
+    {
+      text: "Select an option",
+      value: "",
+    },
+    {
+      text: "option 1",
+      value: "option 1",
+    },
+    {
+      text: "option 2",
+      value: "option 2",
+    },
+    {
+      text: "option 3",
+      value: "option 3",
+    },
+  ] as any,
 };
 Floating.parameters = {
-    docs: {
-        source: {
-            code: tagToString("evo-select", Floating.args, {
-                options: "option",
-            }),
-        },
+  docs: {
+    source: {
+      code: tagToString("evo-select", Floating.args, {
+        options: "option",
+      }),
     },
+  },
 };
 
-export const ExternalLabel: Story<Input> = (args) => ({
-    input: args,
-    component: WithLabelTemplate,
+export const ExternalLabel: StoryFn<Input> = (args) => ({
+  input: args,
+  component: WithLabelTemplate,
 });
 
 ExternalLabel.parameters = {
-    docs: {
-        source: {
-            code: WithLabelCode,
-        },
+  docs: {
+    source: {
+      code: WithLabelCode,
     },
+  },
 };
 
 ExternalLabel.args = {
-    option: [
-        {
-            text: "Select an option",
-            value: "",
-        },
-        {
-            text: "option 1",
-            value: "option 1",
-        },
-        {
-            text: "option 2",
-            value: "option 2",
-        },
-        {
-            text: "option 3",
-            value: "option 3",
-        },
-    ] as any,
+  option: [
+    {
+      text: "Select an option",
+      value: "",
+    },
+    {
+      text: "option 1",
+      value: "option 1",
+    },
+    {
+      text: "option 2",
+      value: "option 2",
+    },
+    {
+      text: "option 3",
+      value: "option 3",
+    },
+  ] as any,
 };
 
-export const Disabled: Story<Input> = (args) => ({
-    input: args,
-    component: DisabledTemplate,
+export const Disabled: StoryFn<Input> = (args) => ({
+  input: args,
+  component: DisabledTemplate,
 });
 
 Disabled.parameters = {
-    docs: {
-        source: {
-            code: DisabledCode,
-        },
+  docs: {
+    source: {
+      code: DisabledCode,
     },
+  },
 };
 
-export const InForm: Story<Input> = (args) => ({
-    input: args,
-    component: InFormTemplate,
+export const InForm: StoryFn<Input> = (args) => ({
+  input: args,
+  component: InFormTemplate,
 });
 
 InForm.parameters = {
-    docs: {
-        source: {
-            code: InFormCode,
-        },
+  docs: {
+    source: {
+      code: InFormCode,
     },
+  },
 };

--- a/packages/evo-marko/src/tags/evo-selection-chip/selection-chip.stories.ts
+++ b/packages/evo-marko/src/tags/evo-selection-chip/selection-chip.stories.ts
@@ -1,13 +1,9 @@
-import { Story } from "@storybook/marko";
-import { tagToString } from "../../common/storybook/storybook-code-source";
-import {
-  buildExtensionTemplate,
-} from "../../common/storybook/utils";
+import { buildExtensionTemplate } from "../../common/storybook/utils";
 import DefaultTemplate from "./examples/default.marko";
 import DefaultTemplateCode from "./examples/default.marko?raw";
 
 import Readme from "./README.md";
-import Component, { type Input } from "./index.marko";
+import Component from "./index.marko";
 
 export default {
   title: "form input/evo-selection-chip",

--- a/packages/evo-marko/src/tags/evo-signal/signal.stories.ts
+++ b/packages/evo-marko/src/tags/evo-signal/signal.stories.ts
@@ -1,30 +1,29 @@
-import { Story } from "@storybook/marko";
 import { buildExtensionTemplate } from "../../common/storybook/utils";
 import Readme from "./README.md";
-import Component, { type Input } from "./index.marko";
+import Component from "./index.marko";
 import DefaultTemplate from "./examples/default.marko";
 import DefaultTemplateCode from "./examples/default.marko?raw";
 
 export default {
-    title: "graphics & icons/evo-signal",
-    component: Component,
-    parameters: {
-        docs: {
-            description: {
-                component: Readme,
-            },
-        },
+  title: "graphics & icons/evo-signal",
+  component: Component,
+  parameters: {
+    docs: {
+      description: {
+        component: Readme,
+      },
     },
+  },
 
-    argTypes: {
-        status: {
-            type: "enum",
-            control: { type: "select" },
-            options: ["trustworthy", "recent", "time-sensitive", "neutral"],
-        },
+  argTypes: {
+    status: {
+      type: "enum",
+      control: { type: "select" },
+      options: ["trustworthy", "recent", "time-sensitive", "neutral"],
     },
+  },
 };
 export const Default = buildExtensionTemplate(
-    DefaultTemplate,
-    DefaultTemplateCode
+  DefaultTemplate,
+  DefaultTemplateCode,
 );

--- a/packages/evo-marko/src/tags/evo-skeleton/skeleton.stories.ts
+++ b/packages/evo-marko/src/tags/evo-skeleton/skeleton.stories.ts
@@ -1,8 +1,5 @@
-import { tagToString } from "../../common/storybook/storybook-code-source";
-import {
-  buildExtensionTemplate,
-} from "../../common/storybook/utils";
-import Component, { type Input } from "./index.marko";
+import { buildExtensionTemplate } from "../../common/storybook/utils";
+import Component from "./index.marko";
 import Readme from "./README.md";
 import DefaultTemplate from "./examples/default.marko";
 import DefaultTemplateCode from "./examples/default.marko?raw";
@@ -28,7 +25,6 @@ import compositeTemplate from "./examples/composite.marko";
 import compositeCode from "./examples/composite.marko?raw";
 import groupedTileTemplate from "./examples/grouped-tile.marko";
 import groupedTileCode from "./examples/grouped-tile.marko?raw";
-import { Story } from "@storybook/marko";
 
 export default {
   title: "building blocks/evo-skeleton",
@@ -77,7 +73,10 @@ export default {
   },
 };
 
-export const Default = buildExtensionTemplate(DefaultTemplate, DefaultTemplateCode);
+export const Default = buildExtensionTemplate(
+  DefaultTemplate,
+  DefaultTemplateCode,
+);
 export const Avatar = buildExtensionTemplate(avatarTemplate, avatarCode);
 
 export const Button = buildExtensionTemplate(buttonTemplate, buttonCode);

--- a/packages/evo-marko/src/tags/evo-switch/switch.stories.ts
+++ b/packages/evo-marko/src/tags/evo-switch/switch.stories.ts
@@ -1,4 +1,4 @@
-import type { Story } from "@storybook/marko";
+import type { StoryFn } from "@storybook/marko";
 import { tagToString } from "../../common/storybook/storybook-code-source";
 import Readme from "./README.md";
 import Component, { type Input } from "./index.marko";
@@ -7,7 +7,7 @@ import DisabledTemplate from "./examples/disabled-with-label.marko";
 import WithLabelCode from "./examples/with-label.marko?raw";
 import DisabledCode from "./examples/disabled-with-label.marko?raw";
 
-const Template: Story<Input> = (args) => ({ input: args });
+const Template: StoryFn<Input> = (args) => ({ input: args });
 
 export default {
   title: "form input/evo-switch",
@@ -33,7 +33,7 @@ export default {
   },
 };
 
-export const WithLabel: Story<Input> = (args) => ({
+export const WithLabel: StoryFn<Input> = (args) => ({
   input: args,
   component: WithLabelTemplate,
 });
@@ -46,7 +46,7 @@ WithLabel.parameters = {
   },
 };
 
-export const Disabled: Story<Input> = (args) => ({
+export const Disabled: StoryFn<Input> = (args) => ({
   input: args,
   component: DisabledTemplate,
 });

--- a/packages/evo-marko/src/tags/evo-tabs/tabs.stories.ts
+++ b/packages/evo-marko/src/tags/evo-tabs/tabs.stories.ts
@@ -1,50 +1,48 @@
 import { buildExtensionTemplate } from "../../common/storybook/utils";
-import { tagToString } from "../../common/storybook/storybook-code-source";
 import Readme from "./README.md";
-import Component, {type Input} from "./index.marko";
-import { Story } from "@storybook/marko";
-import DefaultTemplate from './examples/default.marko';
-import DefaultTemplateCode from './examples/default.marko?raw';
+import Component from "./index.marko";
+import DefaultTemplate from "./examples/default.marko";
+import DefaultTemplateCode from "./examples/default.marko?raw";
 
 export default {
-    title: "navigation & disclosure/evo-tabs",
-    component: Component,
-    parameters: {
-        docs: {
-            description: {
-                component: Readme,
-            },
-        },
+  title: "navigation & disclosure/evo-tabs",
+  component: Component,
+  parameters: {
+    docs: {
+      description: {
+        component: Readme,
+      },
     },
+  },
 
-    argTypes: {
-        index: {
-            control: { type: "text" },
-            description: "0-based index of selected tab tab and panel",
-        },
-        activation: {
-            control: { type: "select" },
-
-            options: ["manual", "auto"],
-            description:
-                'whether to use automatic or manual activation when navigating by keyboard, "auto" (default) / "manual"',
-        },
-        tab: {
-            name: "@tab",
-            table: {
-                category: "@attribute tags",
-            },
-        },
-        panel: {
-            name: "@panel",
-            table: {
-                category: "@attribute tags",
-            },
-        },
+  argTypes: {
+    index: {
+      control: { type: "text" },
+      description: "0-based index of selected tab tab and panel",
     },
+    activation: {
+      control: { type: "select" },
+
+      options: ["manual", "auto"],
+      description:
+        'whether to use automatic or manual activation when navigating by keyboard, "auto" (default) / "manual"',
+    },
+    tab: {
+      name: "@tab",
+      table: {
+        category: "@attribute tags",
+      },
+    },
+    panel: {
+      name: "@panel",
+      table: {
+        category: "@attribute tags",
+      },
+    },
+  },
 };
 
 export const Default = buildExtensionTemplate(
-    DefaultTemplate,
-    DefaultTemplateCode
-)
+  DefaultTemplate,
+  DefaultTemplateCode,
+);

--- a/packages/evo-marko/src/tags/evo-textbox/textbox.stories.ts
+++ b/packages/evo-marko/src/tags/evo-textbox/textbox.stories.ts
@@ -17,239 +17,238 @@ import WithBothIconsCode from "./examples/both-icons.marko?raw";
 import WithPostfixIconCode from "./examples/postfix-icon.marko?raw";
 import WithPrefixIconCode from "./examples/prefix-icon.marko?raw";
 import FullyDecoratedCode from "./examples/fully-decorated.marko?raw";
-import { Story } from "@storybook/marko";
+import type { StoryFn } from "@storybook/marko";
 import type { Input } from "./index.marko";
 
-const Template: Story<Input> = (args) => ({
-    input: {
-        ...args,
-   },
+const Template: StoryFn<Input> = (args) => ({
+  input: {
+    ...args,
+  },
 });
 
 export default {
-    title: "form input/evo-textbox",
-    component: Component,
-    parameters: {
-        docs: {
-            description: {
-                component: Readme,
-            },
-        },
+  title: "form input/evo-textbox",
+  component: Component,
+  parameters: {
+    docs: {
+      description: {
+        component: Readme,
+      },
     },
+  },
 
-    argTypes: {
-        "<input>": {
-            description:
-                'All attributes from the [native HTML `<input>` tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input) may be passed through',
-        },
-        fluid: {
-            type: "boolean",
-            control: { type: "boolean" },
-        },
-        inputSize: {
-            options: ["regular", "large"],
-            type: { category: "Options" },
-            description:
-                'either "regular" or "large". If large, then renders larger sized textbox',
-            table: {
-                defaultValue: {
-                    summary: "regular",
-                },
-            },
-        },
-        multiline: {
-            type: "boolean",
-            control: { type: "boolean" },
-            description: "renders a multi-line textbox if true",
-        },
-        invalid: {
-            type: "boolean",
-            control: { type: "boolean" },
-            description:
-                "indicates a field-level error with red border if true",
-        },
-        floatingLabel: {
-            description: "If set then shows this text as the floating label.",
-            control: { type: "text" },
-            table: {
-                category: "floating-label",
-                defaultValue: {
-                    summary: "",
-                },
-            },
-        },
-        opaqueLabel: {
-            description:
-                "Only works with floating label. If set, then background is obscured of the floating label. Used with textarea to prevent label overlap",
-            control: { type: "boolean" },
-            table: {
-                category: "floating-label",
-                defaultValue: {
-                    summary: "false",
-                },
-            },
-        },
-        a11yButtonText: {
-            control: { type: "text" },
-            description:
-                "aria-label for postfix. Required to be set in order to render postfix button and attach a `textbox-button-click event`",
-        },
-        prefixIcon: {
-            name: "@prefix-icon",
-            description:
-                "An `<evo-{name}-icon>` to show as the prefix icon. Cannot be used with floating-label.",
-            table: {
-                category: "@attribute tags",
-            },
-        },
-        postfixIcon: {
-            name: "@postfix-icon",
-            description:
-                "An `<evo-{name}-icon>` to show as the postfix icon. Cannot be used with floating-label.",
-            table: {
-                category: "@attribute tags",
-            },
-        },
-        prefixText: {
-            name: "@prefix-text",
-            description:
-                "Text to show before the input. Can be used alongside prefix-icon.",
-            table: {
-                category: "@attribute tags",
-            },
-        },
-        postfixText: {
-            name: "@postfix-text",
-            description:
-                "Text to show after the input. Can be used alongside postfix-icon.",
-            table: {
-                category: "@attribute tags",
-            },
-        },
-        onButtonClick: {
-            action: "onButtonClick",
-            description:
-                "Triggers when clicking on postfix-icon-button. Requires button-aria-label to be present in order to attach correctly",
-            table: {
-                category: "Events",
-                defaultValue: {
-                    summary: "{ }",
-                },
-            },
-        },
+  argTypes: {
+    "<input>": {
+      description:
+        "All attributes from the [native HTML `<input>` tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input) may be passed through",
     },
+    fluid: {
+      type: "boolean",
+      control: { type: "boolean" },
+    },
+    inputSize: {
+      options: ["regular", "large"],
+      type: { category: "Options" },
+      description:
+        'either "regular" or "large". If large, then renders larger sized textbox',
+      table: {
+        defaultValue: {
+          summary: "regular",
+        },
+      },
+    },
+    multiline: {
+      type: "boolean",
+      control: { type: "boolean" },
+      description: "renders a multi-line textbox if true",
+    },
+    invalid: {
+      type: "boolean",
+      control: { type: "boolean" },
+      description: "indicates a field-level error with red border if true",
+    },
+    floatingLabel: {
+      description: "If set then shows this text as the floating label.",
+      control: { type: "text" },
+      table: {
+        category: "floating-label",
+        defaultValue: {
+          summary: "",
+        },
+      },
+    },
+    opaqueLabel: {
+      description:
+        "Only works with floating label. If set, then background is obscured of the floating label. Used with textarea to prevent label overlap",
+      control: { type: "boolean" },
+      table: {
+        category: "floating-label",
+        defaultValue: {
+          summary: "false",
+        },
+      },
+    },
+    a11yButtonText: {
+      control: { type: "text" },
+      description:
+        "aria-label for postfix. Required to be set in order to render postfix button and attach a `textbox-button-click event`",
+    },
+    prefixIcon: {
+      name: "@prefix-icon",
+      description:
+        "An `<evo-{name}-icon>` to show as the prefix icon. Cannot be used with floating-label.",
+      table: {
+        category: "@attribute tags",
+      },
+    },
+    postfixIcon: {
+      name: "@postfix-icon",
+      description:
+        "An `<evo-{name}-icon>` to show as the postfix icon. Cannot be used with floating-label.",
+      table: {
+        category: "@attribute tags",
+      },
+    },
+    prefixText: {
+      name: "@prefix-text",
+      description:
+        "Text to show before the input. Can be used alongside prefix-icon.",
+      table: {
+        category: "@attribute tags",
+      },
+    },
+    postfixText: {
+      name: "@postfix-text",
+      description:
+        "Text to show after the input. Can be used alongside postfix-icon.",
+      table: {
+        category: "@attribute tags",
+      },
+    },
+    onButtonClick: {
+      action: "onButtonClick",
+      description:
+        "Triggers when clicking on postfix-icon-button. Requires button-aria-label to be present in order to attach correctly",
+      table: {
+        category: "Events",
+        defaultValue: {
+          summary: "{ }",
+        },
+      },
+    },
+  },
 };
 
-export const WithLabel: Story<Input> = (args) => ({
-    input: args,
-    component: WithLabelTemplate,
+export const WithLabel: StoryFn<Input> = (args) => ({
+  input: args,
+  component: WithLabelTemplate,
 });
 WithLabel.args = {};
 WithLabel.parameters = {
-    docs: {
-        source: {
-            code: WithLabelCode,
-        },
+  docs: {
+    source: {
+      code: WithLabelCode,
     },
+  },
 };
 
-export const Disabled: Story<Input> = (args) => ({
-    input: args,
-    component: DisabledTemplate,
+export const Disabled: StoryFn<Input> = (args) => ({
+  input: args,
+  component: DisabledTemplate,
 });
 Disabled.args = {};
 Disabled.parameters = {
-    docs: {
-        source: {
-            code: DisabledCode,
-        },
+  docs: {
+    source: {
+      code: DisabledCode,
     },
+  },
 };
 
-export const FloatingLabel: Story<Input> = (args) => ({
-    input: args,
-    component: FloatingLabelTemplate,
+export const FloatingLabel: StoryFn<Input> = (args) => ({
+  input: args,
+  component: FloatingLabelTemplate,
 });
 FloatingLabel.args = {};
 FloatingLabel.parameters = {
-    docs: {
-        source: {
-            code: FloatingLabelCode,
-        },
+  docs: {
+    source: {
+      code: FloatingLabelCode,
     },
+  },
 };
 
-export const FloatingLabelAutocomplete: Story<Input> = (args) => ({
-    input: args,
-    component: FloatingLabelAutocompleteTemplate,
+export const FloatingLabelAutocomplete: StoryFn<Input> = (args) => ({
+  input: args,
+  component: FloatingLabelAutocompleteTemplate,
 });
 FloatingLabelAutocomplete.args = {};
 FloatingLabelAutocomplete.parameters = {
-    docs: {
-        source: {
-            code: FloatingLabelAutocompleteCode,
-        },
+  docs: {
+    source: {
+      code: FloatingLabelAutocompleteCode,
     },
+  },
 };
 
 export const Isolated = Template.bind({});
 Isolated.args = {};
 Isolated.parameters = {
-    docs: {
-        source: {
-            code: tagToString("evo-textbox", Isolated.args),
-        },
+  docs: {
+    source: {
+      code: tagToString("evo-textbox", Isolated.args),
     },
+  },
 };
 
-export const PrefixIcon: Story<Input> = (args) => ({
-    input: args,
-    component: WithPrefixIcon,
+export const PrefixIcon: StoryFn<Input> = (args) => ({
+  input: args,
+  component: WithPrefixIcon,
 });
 PrefixIcon.args = {};
 PrefixIcon.parameters = {
-    docs: {
-        source: {
-            code: WithPrefixIconCode,
-        },
+  docs: {
+    source: {
+      code: WithPrefixIconCode,
     },
+  },
 };
 
-export const PostfixIcon: Story<Input> = (args) => ({
-    input: args,
-    component: WithPostfixIcon,
+export const PostfixIcon: StoryFn<Input> = (args) => ({
+  input: args,
+  component: WithPostfixIcon,
 });
 PostfixIcon.args = {};
 PostfixIcon.parameters = {
-    docs: {
-        source: {
-            code: WithPostfixIconCode,
-        },
+  docs: {
+    source: {
+      code: WithPostfixIconCode,
     },
+  },
 };
 
-export const BothIcons: Story<Input> = (args) => ({
-    input: args,
-    component: WithBothIcons,
+export const BothIcons: StoryFn<Input> = (args) => ({
+  input: args,
+  component: WithBothIcons,
 });
 BothIcons.args = {};
 BothIcons.parameters = {
-    docs: {
-        source: {
-            code: WithBothIconsCode,
-        },
+  docs: {
+    source: {
+      code: WithBothIconsCode,
     },
+  },
 };
 
-export const FullyDecorated: Story<Input> = (args) => ({
-    input: args,
-    component: FullyDecoratedTemplate,
+export const FullyDecorated: StoryFn<Input> = (args) => ({
+  input: args,
+  component: FullyDecoratedTemplate,
 });
 FullyDecorated.args = {};
 FullyDecorated.parameters = {
-    docs: {
-        source: {
-            code: FullyDecoratedCode,
-        },
+  docs: {
+    source: {
+      code: FullyDecoratedCode,
     },
+  },
 };

--- a/packages/evo-marko/src/tags/evo-toggle-button-group/toggle-button-group.stories.ts
+++ b/packages/evo-marko/src/tags/evo-toggle-button-group/toggle-button-group.stories.ts
@@ -1,4 +1,3 @@
-import { tagToString } from "../../common/storybook/storybook-code-source";
 import { buildExtensionTemplate } from "../../common/storybook/utils";
 import Readme from "./README.md";
 import component from "./index.marko";

--- a/packages/evo-marko/src/tags/evo-toggle-button/toggle-button.stories.ts
+++ b/packages/evo-marko/src/tags/evo-toggle-button/toggle-button.stories.ts
@@ -1,7 +1,6 @@
-import { tagToString } from "../../common/storybook/storybook-code-source";
 import { buildExtensionTemplate } from "../../common/storybook/utils";
 import Readme from "./README.md";
-import component, { type Input } from "./index.marko";
+import component from "./index.marko";
 import DefaultTemplate from "./examples/default.marko";
 import DefaultCode from "./examples/default.marko?raw";
 import WithIconTemplate from "./examples/with-icon.marko";
@@ -10,7 +9,6 @@ import WithImageTemplate from "./examples/with-image.marko";
 import WithImageCode from "./examples/with-image.marko?raw";
 import MultilineSubtitleTemplate from "./examples/multiline-subtitle.marko";
 import MultilineSubtitleCode from "./examples/multiline-subtitle.marko?raw";
-import { Story } from "@storybook/marko";
 
 export default {
   title: "buttons/evo-toggle-button",


### PR DESCRIPTION
- Fix broken imports
- Remove unused imports
- Run prettier
- **Bonus Change**: clean up types for menu button

> [!NOTE]
> No changeset required, since this is docs-only and doesn't effect users