### PR TITLE
fix(video): window focus event should not autoplay if video not in viewport

### DIFF
--- a/.changeset/four-buckets-shine.md
+++ b/.changeset/four-buckets-shine.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ebayui-core": patch
+---
+
+fix(video): window focus event should not autoplay if video not in viewport

--- a/packages/ebayui-core/src/components/ebay-video/component.ts
+++ b/packages/ebayui-core/src/components/ebay-video/component.ts
@@ -137,6 +137,7 @@ class Video extends Marko.Component<Input, State> {
     declare ui: any;
     declare shaka: any;
     declare observer: IntersectionObserver;
+    declare isInViewport: boolean;
     declare isAutoPlay: boolean;
     declare isAutoPause: boolean;
     declare userPaused: boolean;
@@ -509,6 +510,7 @@ class Video extends Marko.Component<Input, State> {
                 }
 
                 if (entry.isIntersecting) {
+                    this.isInViewport = true;
                     if (
                         this.state.isLoaded &&
                         !this.state.failed &&
@@ -520,6 +522,7 @@ class Video extends Marko.Component<Input, State> {
                         });
                     }
                 } else {
+                    this.isInViewport = false;
                     if (!this.video.paused) {
                         this.isAutoPause = true;
                         this.video.pause();
@@ -543,7 +546,7 @@ class Video extends Marko.Component<Input, State> {
             this.isFocusFromVideoClick = false;
             return;
         }
-        if (this.video.paused && !this.userPaused) {
+        if (this.isInViewport && this.video.paused && !this.userPaused) {
             this.isAutoPlay = true;
             this.video.play().catch((e) => {
                 this.isAutoPlay = false;


### PR DESCRIPTION
Followup to https://github.com/eBay/evo-web/pull/459

## Description

Manual testing revealed a bug with my initial implementation of pause/play on window.blur/focus.

We should continue to respect the viewport check of `offscreenPause` and not play on window.focus if the video is out of view.
