### PR TITLE
feat(evo-react): add EvoButton component

### DIFF
--- a/.changeset/add-evo-button.md
+++ b/.changeset/add-evo-button.md
@@ -1,0 +1,5 @@
+---
+"@evo-web/react": patch
+---
+
+feat(evo-react): add EvoButton component

--- a/package-lock.json
+++ b/package-lock.json
@@ -294,7 +294,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2133,7 +2132,6 @@
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -2969,7 +2967,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -3010,7 +3007,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -4676,7 +4672,6 @@
       "resolved": "https://registry.npmjs.org/@marko/compiler/-/compiler-5.39.50.tgz",
       "integrity": "sha512-vioiV1ViXvyztd7Yd4kmmM8lxvHMv5T8WusfGLKudRKOWlZFj4gOYnnieYbUPVKv82/P4CSi8iZWb0HTqW2yHg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/core": "^7.29.0",
@@ -4728,7 +4723,6 @@
       "integrity": "sha512-BxsS7EnvsFeHK0O64y6wSKk+8Dfe3c1OKfMbmYd4+NpxgUw6dyY20iTttp+6RZWmoUYXF1VBBmRxiFLAOZpfyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@marko/run-explorer": "^2.0.1",
         "@marko/vite": "^5.4.2",
@@ -4935,7 +4929,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -4959,7 +4952,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -5568,7 +5560,6 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -7513,7 +7504,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -7826,7 +7816,6 @@
       "integrity": "sha512-CPrnr8voK8vC6eEtyRzvMpgp3VyVRhgclonE7qYi6P9sXwYb59ucfrnmFBTaP0yUi8Gk4yZg/LlTJULGxvTNsg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -7844,7 +7833,6 @@
       "integrity": "sha512-KkiJeU6VbYbUOp5ITMIc7kBfqlYkKA5KhEHVrGMmUUMt7NeaZg65ojdPk+FtNrBAOXNVM5QM72jnADjM+XVRAQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -7855,7 +7843,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -7926,7 +7913,6 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -8172,7 +8158,6 @@
       "integrity": "sha512-gVQqh7paBz3gC+ZdcCmNSWJMk70IUjDeVqi+5m5vYpEHsIwRgw3Y545jljtajhkekIpIp5Gg8oK7bctgY0E2Ng==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/mocker": "4.0.18",
         "@vitest/utils": "4.0.18",
@@ -8553,7 +8538,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -9478,7 +9462,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -9976,8 +9959,7 @@
       "resolved": "https://registry.npmjs.org/cldr-core/-/cldr-core-48.1.0.tgz",
       "integrity": "sha512-Br9lHQHRhFVyQ/4dY2AnTOuJVEwzDSFR9tE4EzaZxdtux4BFZ4V6oY0SiSAe/8H9+CJ6njpBiPJdDv+vdXnvfA==",
       "dev": true,
-      "license": "Unicode-3.0",
-      "peer": true
+      "license": "Unicode-3.0"
     },
     "node_modules/cldr-dates-full": {
       "version": "48.1.0",
@@ -10649,7 +10631,6 @@
       "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -12199,7 +12180,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -12321,7 +12301,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -12389,7 +12368,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -16399,7 +16377,6 @@
       "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
       "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@lit/reactive-element": "^2.1.0",
         "lit-element": "^4.2.0",
@@ -19248,7 +19225,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -20014,7 +19990,6 @@
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -20102,7 +20077,6 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -20447,7 +20421,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -20502,7 +20475,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -21297,7 +21269,6 @@
       "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -22371,7 +22342,6 @@
       "integrity": "sha512-LFKSuZyF6EW2/Kkl5d7CvqgwhXXfuWv+aLBuoc616boLKJ3mxXuea+GxIgfk02NEyTKctJ0QsnSh5pAomf6Qkg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@storybook/global": "^5.0.0",
         "@storybook/icons": "^2.0.1",
@@ -22824,7 +22794,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@csstools/css-parser-algorithms": "^3.0.5",
         "@csstools/css-syntax-patches-for-csstree": "^1.0.19",
@@ -23094,7 +23063,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -23118,7 +23086,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -23711,8 +23678,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tsx": {
       "version": "4.21.0",
@@ -23720,7 +23686,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -24383,7 +24348,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -24930,7 +24894,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -25742,7 +25705,6 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -26520,7 +26482,6 @@
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -26623,7 +26584,6 @@
       "resolved": "https://registry.npmjs.org/marko/-/marko-5.38.20.tgz",
       "integrity": "sha512-bsiabDqyXP9wmllhAeBJBv2RsL1nEC8mxBA+fan8ykb5bxn/D3HHBlWBPA/mGgyup/1Xr9h6AhBfBMv0wUTKOw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.6",
         "@marko/compiler": "^5.39.50",

--- a/packages/evo-react/.gitignore
+++ b/packages/evo-react/.gitignore
@@ -1,3 +1,4 @@
 /dist
 /_site
 coverage
+__screenshots__

--- a/packages/evo-react/src/evo-button/button-cell.tsx
+++ b/packages/evo-react/src/evo-button/button-cell.tsx
@@ -1,0 +1,21 @@
+import type { ComponentProps } from "react";
+
+type ButtonType = "cta" | "fake" | "expand" | "default";
+type Props = ComponentProps<"span"> & {
+  type?: ButtonType;
+};
+
+const classPrefixes: { [key in ButtonType]: string } = {
+  cta: "cta-",
+  fake: "fake-",
+  expand: "expand-",
+  default: "",
+};
+
+export function EvoButtonCell({ type = "default", children, ...rest }: Props) {
+  return (
+    <span className={`${classPrefixes[type]}btn__cell`} {...rest}>
+      {children}
+    </span>
+  );
+}

--- a/packages/evo-react/src/evo-button/button.stories.tsx
+++ b/packages/evo-react/src/evo-button/button.stories.tsx
@@ -1,0 +1,113 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { EvoButton } from "./button";
+import { EvoButtonCell } from "./button-cell";
+
+const meta: Meta<typeof EvoButton> = {
+  title: "Components/EvoButton",
+  component: EvoButton,
+  tags: ["autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component: `
+A flexible button component that can render as either a \`<button>\` or \`<a>\` element based on the \`href\` prop.
+
+## Usage
+
+\`\`\`tsx
+import { EvoButton } from "@evo-web/react";
+\`\`\`
+        `,
+      },
+    },
+  },
+  argTypes: {
+    priority: {
+      control: "select",
+      options: ["primary", "secondary", "tertiary", "none"],
+      description: "Button priority level",
+    },
+    variant: {
+      control: "select",
+      options: ["standard", "destructive", "form"],
+      description: "Button variant style",
+    },
+    size: {
+      control: "select",
+      options: ["small", "large"],
+      description: "Button size",
+    },
+    bodyState: {
+      control: "select",
+      options: ["loading", "expand", "reset", "none"],
+      description: "Button body state",
+    },
+    split: {
+      control: "select",
+      options: ["start", "end"],
+      description: "Split button position",
+    },
+    fluid: {
+      control: "boolean",
+      description: "Full width button",
+    },
+    disabled: {
+      control: "boolean",
+      description: "Disabled state",
+    },
+    partiallyDisabled: {
+      control: "boolean",
+      description: "Partially disabled (aria-disabled)",
+    },
+    transparent: {
+      control: "boolean",
+      description: "Transparent background",
+    },
+    borderless: {
+      control: "boolean",
+      description: "No border",
+    },
+    fixedHeight: {
+      control: "boolean",
+      description: "Fixed height",
+    },
+    truncate: {
+      control: "boolean",
+      description: "Truncate text with ellipsis",
+    },
+    href: {
+      control: "text",
+      description: "Link URL (renders as anchor)",
+    },
+    children: {
+      control: "text",
+      description: "Button text content",
+    },
+  },
+  args: {
+    priority: "primary",
+    variant: "standard",
+    children: "Button",
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof EvoButton>;
+
+export const Default: Story = {
+  args: {
+    children: "Button",
+  },
+};
+
+export const WithButtonCell: Story = {
+  render: (args) => (
+    <EvoButton {...args}>
+      <EvoButtonCell style={{ justifyContent: "space-between" }}>
+        <span>Select</span>
+        <span>Any</span>
+      </EvoButtonCell>
+    </EvoButton>
+  ),
+};

--- a/packages/evo-react/src/evo-button/button.tsx
+++ b/packages/evo-react/src/evo-button/button.tsx
@@ -1,0 +1,138 @@
+import type { KeyboardEvent } from "react";
+import React from "react";
+import classNames from "classnames";
+import type {
+  AnchorButtonProps,
+  NativeButtonProps,
+  Priority,
+  Size,
+  Split,
+} from "./types";
+import "@ebay/skin/button";
+
+export function EvoButton(props: AnchorButtonProps): React.JSX.Element;
+export function EvoButton(props: NativeButtonProps): React.JSX.Element;
+export function EvoButton(
+  props: AnchorButtonProps | NativeButtonProps,
+): React.JSX.Element {
+  const {
+    priority = "secondary",
+    variant = "standard",
+    size,
+    bodyState,
+    split,
+    transparent = false,
+    fluid = false,
+    disabled,
+    partiallyDisabled,
+    children,
+    onKeyDown,
+    onEscape,
+    truncate = false,
+    href,
+    className: extraClasses,
+    borderless,
+    fixedHeight,
+    ...rest
+  } = props;
+  const classPrefix = href ? "fake-btn" : "btn";
+  const priorityStyles: { [key in Priority]: string } = {
+    primary: `${classPrefix}--primary`,
+    secondary: `${classPrefix}--secondary`,
+    tertiary: `${classPrefix}--tertiary`,
+    none: "",
+  };
+  const sizeStyles: { [key in Size]: string } = {
+    large: `${classPrefix}--large`,
+    small: `${classPrefix}--small`,
+  };
+  const splitStyles: { [key in Split]: string } = {
+    start: `${classPrefix}--split-start`,
+    end: `${classPrefix}--split-end`,
+  };
+  const isDestructive = variant === "destructive";
+  const isForm = variant === "form";
+  const className = classNames(
+    classPrefix,
+    extraClasses,
+    priorityStyles[isForm || borderless ? "none" : priority],
+    size && sizeStyles[size],
+    split && splitStyles[split],
+    isDestructive && `${classPrefix}--destructive`,
+    isForm && `${classPrefix}--form`,
+    transparent && `${classPrefix}--transparent`,
+    fluid && `${classPrefix}--fluid`,
+    truncate && `${classPrefix}--truncated`,
+    borderless && `${classPrefix}--borderless`,
+    fixedHeight &&
+      (size && sizeStyles[size]
+        ? `${sizeStyles[size]}-fixed-height`
+        : `${classPrefix}--fixed-height`),
+  );
+
+  const bodyContent = (() => {
+    switch (bodyState) {
+      case "loading":
+        return (
+          <span className="btn__cell">
+            {/* TODO: Replace with <EvoProgressSpinner /> when available */}
+            <span>Loading...</span>
+          </span>
+        );
+      case "expand":
+        return (
+          <span className="btn__cell">
+            <span className="btn__text">{children}</span>
+            {/* TODO: Replace with <EvoIconChevronDown16 /> when available */}
+            <span>▼</span>
+          </span>
+        );
+      default:
+        return children;
+    }
+  })();
+
+  const ariaLive = bodyState === "loading" ? "polite" : undefined;
+
+  const keyDownHandler = (
+    event: KeyboardEvent<HTMLButtonElement | HTMLAnchorElement>,
+  ) => {
+    onKeyDown?.(
+      event as KeyboardEvent<HTMLButtonElement> &
+        KeyboardEvent<HTMLAnchorElement>,
+    );
+    if (event.key === "Escape" && !disabled && onEscape) {
+      onEscape(
+        event as KeyboardEvent<HTMLButtonElement> &
+          KeyboardEvent<HTMLAnchorElement>,
+      );
+    }
+  };
+
+  if (href) {
+    return (
+      <a
+        {...(rest as React.ComponentProps<"a">)}
+        className={className}
+        href={disabled ? undefined : href}
+        onKeyDown={keyDownHandler}
+        aria-live={ariaLive}
+      >
+        {bodyContent}
+      </a>
+    );
+  }
+
+  return (
+    <button
+      {...(rest as React.ComponentProps<"button">)}
+      disabled={disabled}
+      aria-disabled={partiallyDisabled ? "true" : undefined}
+      aria-live={ariaLive}
+      className={className}
+      onKeyDown={keyDownHandler}
+    >
+      {bodyContent}
+    </button>
+  );
+}

--- a/packages/evo-react/src/evo-button/index.ts
+++ b/packages/evo-react/src/evo-button/index.ts
@@ -1,0 +1,10 @@
+export { EvoButton } from "./button";
+export { EvoButtonCell } from "./button-cell";
+export type {
+  EvoButtonProps,
+  Size,
+  Priority,
+  Variant,
+  BodyState,
+  Split,
+} from "./types";

--- a/packages/evo-react/src/evo-button/test/__snapshots__/test.server.tsx.snap
+++ b/packages/evo-react/src/evo-button/test/__snapshots__/test.server.tsx.snap
@@ -1,0 +1,83 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`EvoButton SSR > should render button with bodyState=expand 1`] = `"<button class="btn btn--secondary"><span class="btn__cell"><span class="btn__text">Button</span><span>▼</span></span></button>"`;
+
+exports[`EvoButton SSR > should render button with bodyState=loading 1`] = `"<button aria-live="polite" class="btn btn--secondary"><span class="btn__cell"><span>Loading...</span></span></button>"`;
+
+exports[`EvoButton SSR > should render button with borderless=false 1`] = `"<button class="btn btn--secondary">Button</button>"`;
+
+exports[`EvoButton SSR > should render button with borderless=true 1`] = `"<button class="btn btn--borderless">Button</button>"`;
+
+exports[`EvoButton SSR > should render button with disabled=false 1`] = `"<button class="btn btn--secondary">Button</button>"`;
+
+exports[`EvoButton SSR > should render button with disabled=true 1`] = `"<button disabled="" class="btn btn--secondary">Button</button>"`;
+
+exports[`EvoButton SSR > should render button with fixedHeight=false 1`] = `"<button class="btn btn--secondary">Button</button>"`;
+
+exports[`EvoButton SSR > should render button with fixedHeight=true 1`] = `"<button class="btn btn--secondary btn--fixed-height">Button</button>"`;
+
+exports[`EvoButton SSR > should render button with fluid=false 1`] = `"<button class="btn btn--secondary">Button</button>"`;
+
+exports[`EvoButton SSR > should render button with fluid=true 1`] = `"<button class="btn btn--secondary btn--fluid">Button</button>"`;
+
+exports[`EvoButton SSR > should render button with partiallyDisabled=false 1`] = `"<button class="btn btn--secondary">Button</button>"`;
+
+exports[`EvoButton SSR > should render button with partiallyDisabled=true 1`] = `"<button aria-disabled="true" class="btn btn--secondary">Button</button>"`;
+
+exports[`EvoButton SSR > should render button with priority=none 1`] = `"<button class="btn">Button</button>"`;
+
+exports[`EvoButton SSR > should render button with priority=primary 1`] = `"<button class="btn btn--primary">Button</button>"`;
+
+exports[`EvoButton SSR > should render button with priority=secondary 1`] = `"<button class="btn btn--secondary">Button</button>"`;
+
+exports[`EvoButton SSR > should render button with priority=tertiary 1`] = `"<button class="btn btn--tertiary">Button</button>"`;
+
+exports[`EvoButton SSR > should render button with size=large 1`] = `"<button class="btn btn--secondary btn--large">Button</button>"`;
+
+exports[`EvoButton SSR > should render button with size=small 1`] = `"<button class="btn btn--secondary btn--small">Button</button>"`;
+
+exports[`EvoButton SSR > should render button with split=end 1`] = `"<button class="btn btn--primary btn--split-end">Button</button>"`;
+
+exports[`EvoButton SSR > should render button with split=start 1`] = `"<button class="btn btn--primary btn--split-start">Button</button>"`;
+
+exports[`EvoButton SSR > should render button with transparent=false 1`] = `"<button class="btn btn--secondary">Button</button>"`;
+
+exports[`EvoButton SSR > should render button with transparent=true 1`] = `"<button class="btn btn--secondary btn--transparent">Button</button>"`;
+
+exports[`EvoButton SSR > should render button with truncate=false 1`] = `"<button class="btn btn--secondary">Button</button>"`;
+
+exports[`EvoButton SSR > should render button with truncate=true 1`] = `"<button class="btn btn--secondary btn--truncated">Button</button>"`;
+
+exports[`EvoButton SSR > should render button with variant=destructive 1`] = `"<button class="btn btn--secondary btn--destructive">Button</button>"`;
+
+exports[`EvoButton SSR > should render button with variant=form 1`] = `"<button class="btn btn--form">Button</button>"`;
+
+exports[`EvoButton SSR > should render button with variant=standard 1`] = `"<button class="btn btn--secondary">Button</button>"`;
+
+exports[`EvoButton SSR > should render combined: primary large fluid 1`] = `"<button class="btn btn--primary btn--large btn--fluid">Combined</button>"`;
+
+exports[`EvoButton SSR > should render defaults 1`] = `"<button class="btn btn--secondary">Default Button</button>"`;
+
+exports[`EvoButton SSR > should render destructive primary large 1`] = `"<button class="btn btn--primary btn--large btn--destructive">Delete</button>"`;
+
+exports[`EvoButton SSR > should render disabled link without href 1`] = `"<a class="fake-btn fake-btn--secondary">Disabled Link</a>"`;
+
+exports[`EvoButton SSR > should render fake version (anchor) 1`] = `"<a aria-label="fake button" class="fake-btn fake-btn--primary fake-btn--large" href="https://ebay.com">Link Button</a>"`;
+
+exports[`EvoButton SSR > should render form variant with expand 1`] = `"<button class="btn btn--form"><span class="btn__cell"><span class="btn__text">Form Expand</span><span>▼</span></span></button>"`;
+
+exports[`EvoButton SSR > should render large fixed-height button 1`] = `"<button class="btn btn--secondary btn--large btn--large-fixed-height">Large Fixed Height</button>"`;
+
+exports[`EvoButton SSR > should render large truncated button 1`] = `"<button class="btn btn--secondary btn--large btn--truncated">Large Truncated</button>"`;
+
+exports[`EvoButton SSR > should render with ButtonCell 1`] = `"<button class="btn btn--secondary"><span class="btn__cell" style="justify-content:space-between"><span>Left</span><span>Right</span></span></button>"`;
+
+exports[`EvoButton SSR > should render with aria-label 1`] = `"<button aria-label="Submit form" class="btn btn--secondary">Submit</button>"`;
+
+exports[`EvoButton SSR > should render with custom className 1`] = `"<button class="btn custom-class btn--secondary">Button</button>"`;
+
+exports[`EvoButton SSR > should render with data attributes 1`] = `"<button data-testid="button" class="btn btn--secondary">Button</button>"`;
+
+exports[`EvoButton SSR > should render with id override 1`] = `"<button id="test" class="btn btn--secondary">Button</button>"`;
+
+exports[`EvoButton SSR > should render with type override 1`] = `"<button type="submit" class="btn btn--secondary">Submit</button>"`;

--- a/packages/evo-react/src/evo-button/test/test.browser.tsx
+++ b/packages/evo-react/src/evo-button/test/test.browser.tsx
@@ -1,0 +1,298 @@
+import React from "react";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render } from "vitest-browser-react";
+import { userEvent } from "vitest/browser";
+import { EvoButton } from "../button";
+import { EvoButtonCell } from "../button-cell";
+
+describe("evo-button", () => {
+  let user: ReturnType<typeof userEvent.setup>;
+
+  beforeEach(() => {
+    user = userEvent.setup();
+  });
+
+  afterEach(() => {
+    user.cleanup();
+  });
+
+  describe("given button is enabled", () => {
+    it("emits click event when clicked", async () => {
+      const onClick = vi.fn();
+      const screen = await render(
+        <EvoButton onClick={onClick}>Click Me</EvoButton>,
+      );
+
+      await user.click(screen.getByRole("button"));
+
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it("emits escape event when escape key is pressed", async () => {
+      const onEscape = vi.fn();
+      const screen = await render(
+        <EvoButton onEscape={onEscape}>Button</EvoButton>,
+      );
+
+      const button = screen.getByRole("button");
+      await user.click(button);
+      await user.keyboard("{Escape}");
+
+      expect(onEscape).toHaveBeenCalledTimes(1);
+    });
+
+    it("emits both onKeyDown and onEscape on escape key", async () => {
+      const onKeyDown = vi.fn();
+      const onEscape = vi.fn();
+      const screen = await render(
+        <EvoButton onKeyDown={onKeyDown} onEscape={onEscape}>
+          Button
+        </EvoButton>,
+      );
+
+      const button = screen.getByRole("button");
+      await user.click(button);
+      await user.keyboard("{Escape}");
+
+      expect(onKeyDown).toHaveBeenCalledTimes(1);
+      expect(onEscape).toHaveBeenCalledTimes(1);
+    });
+
+    it("emits focus event when focused", async () => {
+      const onFocus = vi.fn();
+      const screen = await render(
+        <EvoButton onFocus={onFocus}>Button</EvoButton>,
+      );
+
+      await user.click(screen.getByRole("button"));
+
+      expect(onFocus).toHaveBeenCalledTimes(1);
+    });
+
+    it("emits blur event when blurred", async () => {
+      const onBlur = vi.fn();
+      const screen = await render(
+        <EvoButton onBlur={onBlur}>Button</EvoButton>,
+      );
+
+      const button = screen.getByRole("button");
+      await user.click(button);
+      await user.tab();
+
+      expect(onBlur).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("given button is disabled", () => {
+    it("does not emit click event when clicked", async () => {
+      const onClick = vi.fn();
+      const screen = await render(
+        <EvoButton onClick={onClick} disabled>
+          Button
+        </EvoButton>,
+      );
+
+      const button = screen.getByRole("button");
+      await expect.element(button).toBeDisabled();
+      expect(onClick).not.toHaveBeenCalled();
+    });
+
+    it("does not emit escape event when escape key is pressed", async () => {
+      const onEscape = vi.fn();
+      const screen = await render(
+        <EvoButton onEscape={onEscape} disabled>
+          Button
+        </EvoButton>,
+      );
+
+      const button = screen.getByRole("button");
+      await expect.element(button).toBeDisabled();
+      expect(onEscape).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("ref forwarding", () => {
+    it("forwards ref to button element", async () => {
+      const ref = React.createRef<HTMLButtonElement>();
+      await render(<EvoButton ref={ref}>Button</EvoButton>);
+
+      expect(ref.current).toBeInstanceOf(HTMLButtonElement);
+      expect(ref.current?.tagName).toBe("BUTTON");
+    });
+
+    it("forwards ref to anchor element when href is provided", async () => {
+      const ref = React.createRef<HTMLAnchorElement>();
+      await render(
+        <EvoButton href="https://ebay.com" ref={ref}>
+          Link
+        </EvoButton>,
+      );
+
+      expect(ref.current).toBeInstanceOf(HTMLAnchorElement);
+      expect(ref.current?.tagName).toBe("A");
+    });
+  });
+
+  describe("anchor element behavior", () => {
+    it("renders as link when href is provided", async () => {
+      const screen = await render(
+        <EvoButton
+          href="https://ebay.com"
+          priority="primary"
+          onClick={(e) => e.preventDefault()}
+        >
+          Link Button
+        </EvoButton>,
+      );
+
+      const link = screen.getByRole("link");
+      await expect.element(link).toHaveAttribute("href", "https://ebay.com");
+    });
+
+    it("does not render href when disabled", async () => {
+      const screen = await render(
+        <EvoButton href="https://ebay.com" disabled>
+          Disabled Link
+        </EvoButton>,
+      );
+
+      const link = screen.getByText("Disabled Link");
+      await expect.element(link).not.toHaveAttribute("href");
+    });
+
+    it("emits escape event on anchor element", async () => {
+      const onEscape = vi.fn();
+      const screen = await render(
+        <EvoButton
+          href="https://ebay.com"
+          onEscape={onEscape}
+          onClick={(e) => e.preventDefault()}
+        >
+          Link
+        </EvoButton>,
+      );
+
+      const link = screen.getByRole("link");
+      await user.click(link);
+      await user.keyboard("{Escape}");
+
+      expect(onEscape).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("body states", () => {
+    it("renders loading state with aria-live", async () => {
+      const screen = await render(
+        <EvoButton bodyState="loading">Submit</EvoButton>,
+      );
+
+      const button = screen.getByRole("button");
+      expect(button).toHaveAttribute("aria-live", "polite");
+    });
+
+    it("renders expand state with correct structure", async () => {
+      const screen = await render(
+        <EvoButton bodyState="expand">Options</EvoButton>,
+      );
+
+      const text = screen.getByText("Options");
+      await expect.element(text).toBeInTheDocument();
+    });
+
+    it("maintains interactivity in loading state", async () => {
+      const onClick = vi.fn();
+      const screen = await render(
+        <EvoButton bodyState="loading" onClick={onClick}>
+          Submit
+        </EvoButton>,
+      );
+
+      await user.click(screen.getByRole("button"));
+
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("partially disabled state", () => {
+    it("renders with aria-disabled but remains clickable", async () => {
+      const onClick = vi.fn();
+      const screen = await render(
+        <EvoButton partiallyDisabled onClick={onClick}>
+          Partially Disabled
+        </EvoButton>,
+      );
+
+      const button = screen.getByRole("button");
+      await expect.element(button).toHaveAttribute("aria-disabled", "true");
+
+      await button.click({ force: true });
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("keyboard navigation", () => {
+    it("can be focused via keyboard", async () => {
+      const onFocus = vi.fn();
+      await render(<EvoButton onFocus={onFocus}>Button</EvoButton>);
+
+      await user.tab();
+
+      expect(onFocus).toHaveBeenCalledTimes(1);
+    });
+
+    it("emits onKeyDown for all keys", async () => {
+      const onKeyDown = vi.fn();
+      const screen = await render(
+        <EvoButton onKeyDown={onKeyDown}>Button</EvoButton>,
+      );
+
+      const button = screen.getByRole("button");
+      await user.click(button);
+      await user.keyboard("{Enter}");
+
+      expect(onKeyDown).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("button cell", () => {
+    it("renders custom layout with ButtonCell", async () => {
+      const onClick = vi.fn();
+      const screen = await render(
+        <EvoButton onClick={onClick}>
+          <EvoButtonCell style={{ justifyContent: "space-between" }}>
+            <span>Left</span>
+            <span>Right</span>
+          </EvoButtonCell>
+        </EvoButton>,
+      );
+
+      await expect.element(screen.getByText("Left")).toBeInTheDocument();
+      await expect.element(screen.getByText("Right")).toBeInTheDocument();
+
+      await user.click(screen.getByRole("button"));
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("accessibility", () => {
+    it("has correct role for button", async () => {
+      const screen = await render(<EvoButton>Button</EvoButton>);
+      await expect.element(screen.getByRole("button")).toBeInTheDocument();
+    });
+
+    it("has correct role for link", async () => {
+      const screen = await render(
+        <EvoButton href="https://ebay.com">Link</EvoButton>,
+      );
+      await expect.element(screen.getByRole("link")).toBeInTheDocument();
+    });
+
+    it("supports aria-label", async () => {
+      const screen = await render(
+        <EvoButton aria-label="Submit form">Submit</EvoButton>,
+      );
+      const button = screen.getByRole("button", { name: "Submit form" });
+      await expect.element(button).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/evo-react/src/evo-button/test/test.server.tsx
+++ b/packages/evo-react/src/evo-button/test/test.server.tsx
@@ -1,0 +1,245 @@
+import { it, expect, describe } from "vitest";
+import { renderToString } from "react-dom/server";
+import { EvoButton } from "../button";
+import { EvoButtonCell } from "../button-cell";
+import type { Priority, Size, Variant, Split, BodyState } from "../types";
+
+describe("EvoButton SSR", () => {
+  it.each<Priority>(["primary", "secondary", "tertiary", "none"])(
+    "should render button with priority=%s",
+    (priority) => {
+      expect(
+        renderToString(<EvoButton priority={priority}>Button</EvoButton>),
+      ).toMatchSnapshot();
+    },
+  );
+
+  it.each<Size>(["large", "small"])(
+    "should render button with size=%s",
+    (size) => {
+      expect(
+        renderToString(<EvoButton size={size}>Button</EvoButton>),
+      ).toMatchSnapshot();
+    },
+  );
+
+  it.each<Variant>(["standard", "destructive", "form"])(
+    "should render button with variant=%s",
+    (variant) => {
+      expect(
+        renderToString(<EvoButton variant={variant}>Button</EvoButton>),
+      ).toMatchSnapshot();
+    },
+  );
+
+  it.each<Split>(["start", "end"])(
+    "should render button with split=%s",
+    (split) => {
+      expect(
+        renderToString(
+          <EvoButton split={split} priority="primary">
+            Button
+          </EvoButton>,
+        ),
+      ).toMatchSnapshot();
+    },
+  );
+
+  it.each<BodyState>(["loading", "expand"])(
+    "should render button with bodyState=%s",
+    (bodyState) => {
+      expect(
+        renderToString(<EvoButton bodyState={bodyState}>Button</EvoButton>),
+      ).toMatchSnapshot();
+    },
+  );
+
+  it.each<boolean>([false, true])(
+    "should render button with fluid=%s",
+    (fluid) => {
+      expect(
+        renderToString(<EvoButton fluid={fluid}>Button</EvoButton>),
+      ).toMatchSnapshot();
+    },
+  );
+
+  it.each<boolean>([false, true])(
+    "should render button with disabled=%s",
+    (disabled) => {
+      expect(
+        renderToString(<EvoButton disabled={disabled}>Button</EvoButton>),
+      ).toMatchSnapshot();
+    },
+  );
+
+  it.each<boolean>([false, true])(
+    "should render button with partiallyDisabled=%s",
+    (partiallyDisabled) => {
+      expect(
+        renderToString(
+          <EvoButton partiallyDisabled={partiallyDisabled}>Button</EvoButton>,
+        ),
+      ).toMatchSnapshot();
+    },
+  );
+
+  it.each<boolean>([false, true])(
+    "should render button with transparent=%s",
+    (transparent) => {
+      expect(
+        renderToString(<EvoButton transparent={transparent}>Button</EvoButton>),
+      ).toMatchSnapshot();
+    },
+  );
+
+  it.each<boolean>([false, true])(
+    "should render button with borderless=%s",
+    (borderless) => {
+      expect(
+        renderToString(<EvoButton borderless={borderless}>Button</EvoButton>),
+      ).toMatchSnapshot();
+    },
+  );
+
+  it.each<boolean>([false, true])(
+    "should render button with truncate=%s",
+    (truncate) => {
+      expect(
+        renderToString(<EvoButton truncate={truncate}>Button</EvoButton>),
+      ).toMatchSnapshot();
+    },
+  );
+
+  it.each<boolean>([false, true])(
+    "should render button with fixedHeight=%s",
+    (fixedHeight) => {
+      expect(
+        renderToString(<EvoButton fixedHeight={fixedHeight}>Button</EvoButton>),
+      ).toMatchSnapshot();
+    },
+  );
+
+  it("should render defaults", () => {
+    expect(
+      renderToString(<EvoButton>Default Button</EvoButton>),
+    ).toMatchSnapshot();
+  });
+
+  it("should render with id override", () => {
+    expect(
+      renderToString(<EvoButton id="test">Button</EvoButton>),
+    ).toMatchSnapshot();
+  });
+
+  it("should render with type override", () => {
+    expect(
+      renderToString(<EvoButton type="submit">Submit</EvoButton>),
+    ).toMatchSnapshot();
+  });
+
+  it("should render fake version (anchor)", () => {
+    expect(
+      renderToString(
+        <EvoButton
+          href="https://ebay.com"
+          size="large"
+          priority="primary"
+          aria-label="fake button"
+        >
+          Link Button
+        </EvoButton>,
+      ),
+    ).toMatchSnapshot();
+  });
+
+  it("should render disabled link without href", () => {
+    expect(
+      renderToString(
+        <EvoButton href="https://ebay.com" disabled>
+          Disabled Link
+        </EvoButton>,
+      ),
+    ).toMatchSnapshot();
+  });
+
+  it("should render large truncated button", () => {
+    expect(
+      renderToString(
+        <EvoButton truncate size="large">
+          Large Truncated
+        </EvoButton>,
+      ),
+    ).toMatchSnapshot();
+  });
+
+  it("should render large fixed-height button", () => {
+    expect(
+      renderToString(
+        <EvoButton fixedHeight size="large">
+          Large Fixed Height
+        </EvoButton>,
+      ),
+    ).toMatchSnapshot();
+  });
+
+  it("should render form variant with expand", () => {
+    expect(
+      renderToString(
+        <EvoButton variant="form" bodyState="expand">
+          Form Expand
+        </EvoButton>,
+      ),
+    ).toMatchSnapshot();
+  });
+
+  it("should render destructive primary large", () => {
+    expect(
+      renderToString(
+        <EvoButton variant="destructive" priority="primary" size="large">
+          Delete
+        </EvoButton>,
+      ),
+    ).toMatchSnapshot();
+  });
+
+  it("should render with custom className", () => {
+    expect(
+      renderToString(<EvoButton className="custom-class">Button</EvoButton>),
+    ).toMatchSnapshot();
+  });
+
+  it("should render with aria-label", () => {
+    expect(
+      renderToString(<EvoButton aria-label="Submit form">Submit</EvoButton>),
+    ).toMatchSnapshot();
+  });
+
+  it("should render with data attributes", () => {
+    expect(
+      renderToString(<EvoButton data-testid="button">Button</EvoButton>),
+    ).toMatchSnapshot();
+  });
+
+  it("should render with ButtonCell", () => {
+    expect(
+      renderToString(
+        <EvoButton>
+          <EvoButtonCell style={{ justifyContent: "space-between" }}>
+            <span>Left</span>
+            <span>Right</span>
+          </EvoButtonCell>
+        </EvoButton>,
+      ),
+    ).toMatchSnapshot();
+  });
+
+  it("should render combined: primary large fluid", () => {
+    expect(
+      renderToString(
+        <EvoButton priority="primary" size="large" fluid>
+          Combined
+        </EvoButton>,
+      ),
+    ).toMatchSnapshot();
+  });
+});

--- a/packages/evo-react/src/evo-button/types.ts
+++ b/packages/evo-react/src/evo-button/types.ts
@@ -1,0 +1,36 @@
+import type { ComponentProps, KeyboardEvent } from "react";
+
+export type Priority = "primary" | "secondary" | "tertiary" | "none";
+export type Variant = "standard" | "destructive" | "form";
+export type Size = "small" | "large";
+export type BodyState = "loading" | "expand" | "reset" | "none";
+export type Split = "start" | "end";
+
+type BaseButtonProps = {
+  fluid?: boolean;
+  partiallyDisabled?: boolean;
+  truncate?: boolean;
+  priority?: Priority;
+  variant?: Variant;
+  size?: Size;
+  bodyState?: BodyState;
+  split?: Split;
+  transparent?: boolean;
+  borderless?: boolean;
+  fixedHeight?: boolean;
+};
+
+export type AnchorButtonProps = ComponentProps<"a"> &
+  BaseButtonProps & {
+    href: string;
+    onEscape?: (e: KeyboardEvent<HTMLAnchorElement>) => void;
+    disabled?: boolean;
+  };
+
+export type NativeButtonProps = ComponentProps<"button"> &
+  BaseButtonProps & {
+    href?: never;
+    onEscape?: (e: KeyboardEvent<HTMLButtonElement>) => void;
+  };
+
+export type EvoButtonProps = AnchorButtonProps | NativeButtonProps;

--- a/packages/evo-react/src/index.ts
+++ b/packages/evo-react/src/index.ts
@@ -1,1 +1,9 @@
-export const VERSION = "0.0.0";
+export { EvoButton, EvoButtonCell } from "./evo-button";
+export type {
+  EvoButtonProps,
+  Size,
+  Priority,
+  Variant,
+  BodyState,
+  Split,
+} from "./evo-button";

--- a/packages/evo-react/test.setup.ts
+++ b/packages/evo-react/test.setup.ts
@@ -1,3 +1,4 @@
+import "vitest-browser-react";
 import "@ebay/skin/dist/tokens/evo-core.css";
 import "@ebay/skin/dist/tokens/evo-light.css";
 import "@ebay/skin/dist/tokens/evo-dark.css";

--- a/packages/evo-react/vite.config.js
+++ b/packages/evo-react/vite.config.js
@@ -59,6 +59,7 @@ export default defineConfig({
         extends: true,
         test: {
           name: "browser",
+          setupFiles: ["./test.setup.ts"],
           browser: {
             enabled: true,
             provider: playwright(),


### PR DESCRIPTION
## Description

- Add new `EvoButton` component following EbayButton component but with new structure
- Make sure types are automatically detected based on `href` presence or not
- Improve storybook documentation (from original EbayButton)
- Automatically import `@ebay/skin/button` file

## Notes

<!-- Be sure to mention anything unusual, out-of-scope or new technical debt, etc -->
- Some dependencies like ProgressSpinner and ChevronIcon will be implemented later and added to the EvoButton component, currently hard coded
- To support React Router and other framework links, we will also add a `as=` property, that will be in a different PR

## Screenshots

<!-- Upload screenshots of UI before & after these changes -->
<img width="1108" height="1100" alt="Screenshot 2026-02-18 at 6 12 46 PM" src="https://github.com/user-attachments/assets/bcd3e2cf-1598-4d39-8d6a-935da215e346" />

## Checklist

<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->

- [x] I verify all changes are within scope of the linked issue
- [x] I added/updated/removed testing (Storybook in Skin) coverage as appropriate

<!-- For CSS changes -->

- [ ] I tested the UI in all supported browsers
- [ ] I tested the UI in dark mode and RTL mode
