### PR TITLE
feat(evo-react): enable CSS tree-shaking with preserveModules

### DIFF
--- a/packages/evo-react/package.json
+++ b/packages/evo-react/package.json
@@ -15,9 +15,7 @@
     "directory": "packages/evo-react"
   },
   "license": "MIT",
-  "sideEffects": [
-    "./**/*.css"
-  ],
+  "sideEffects": false,
   "type": "module",
   "exports": {
     "./package.json": "./package.json",

--- a/packages/evo-react/tsconfig.prod.json
+++ b/packages/evo-react/tsconfig.prod.json
@@ -1,5 +1,5 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["./**/__tests__/*", "./**/*.stories.tsx"],
+  "exclude": ["./**/*.stories.tsx", "./**/test/*"],
   "include": ["./src/**/*"]
 }

--- a/packages/evo-react/vite.config.js
+++ b/packages/evo-react/vite.config.js
@@ -18,10 +18,12 @@ export default defineConfig({
     lib: {
       entry: "./src/index.ts",
       formats: ["es"],
-      fileName: "index",
     },
     rollupOptions: {
       output: {
+        preserveModules: true,
+        preserveModulesRoot: "src",
+        entryFileNames: "[name].js",
         banner: `"use client";\n`,
       },
       plugins: [


### PR DESCRIPTION
## Description

- Change evo-react vite output to maintain the folder structure instead of bundling one single `dist/index.js` file. This is so we can tree-shake also the skin css

## Checklist

<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->

- [x] I verify all changes are within scope of the linked issue
- [x] I added/updated/removed testing (Storybook in Skin) coverage as appropriate

<!-- For CSS changes -->

- [ ] I tested the UI in all supported browsers
- [ ] I tested the UI in dark mode and RTL mode
