### PR TITLE
fix(ebay-tabs): prevent onSelect from firing on initial render

### DIFF
--- a/.changeset/cyan-toes-happen.md
+++ b/.changeset/cyan-toes-happen.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ui-core-react": patch
+---
+
+prevent onSelect from firing on initial render

--- a/packages/ebayui-core-react/src/ebay-tabs/__tests__/index.spec.tsx
+++ b/packages/ebayui-core-react/src/ebay-tabs/__tests__/index.spec.tsx
@@ -58,6 +58,14 @@ describe("<EbayTabs>", () => {
         });
     });
 
+    describe("on initial render", () => {
+        it("should not fire onSelect", () => {
+            const spy = vi.fn();
+            render(<DefaultTabs onSelect={spy} />);
+            expect(spy).not.toHaveBeenCalled();
+        });
+    });
+
     describe("on tab click", () => {
         let spy, tabs;
 

--- a/packages/ebayui-core-react/src/ebay-tabs/tabs.tsx
+++ b/packages/ebayui-core-react/src/ebay-tabs/tabs.tsx
@@ -1,4 +1,4 @@
-import React, { cloneElement, FC, KeyboardEvent, useEffect, useRef, useState } from "react";
+import React, { cloneElement, FC, KeyboardEvent, useState } from "react";
 import classNames from "classnames";
 
 import { handleActionKeydown, handleLeftRightArrowsKeydown } from "../common/event-utils";
@@ -60,15 +60,6 @@ const Tabs: FC<TabsProps> = ({
             }
         });
     };
-
-    const prevIndex = useRef(index);
-    useEffect(() => {
-        if (prevIndex.current !== index) {
-            prevIndex.current = index;
-            setSelectedIndex(index);
-            setFocusedIndex(index);
-        }
-    }, [index]);
 
     const isLarge = size === "large";
 

--- a/packages/ebayui-core-react/src/ebay-tabs/tabs.tsx
+++ b/packages/ebayui-core-react/src/ebay-tabs/tabs.tsx
@@ -1,4 +1,4 @@
-import React, { cloneElement, FC, KeyboardEvent, useEffect, useState } from "react";
+import React, { cloneElement, FC, KeyboardEvent, useEffect, useRef, useState } from "react";
 import classNames from "classnames";
 
 import { handleActionKeydown, handleLeftRightArrowsKeydown } from "../common/event-utils";
@@ -61,8 +61,12 @@ const Tabs: FC<TabsProps> = ({
         });
     };
 
+    const prevIndex = useRef(index);
     useEffect(() => {
-        handleSelect(index);
+        if (prevIndex.current !== index) {
+            prevIndex.current = index;
+            handleSelect(index);
+        }
     }, [index]);
 
     const isLarge = size === "large";

--- a/packages/ebayui-core-react/src/ebay-tabs/tabs.tsx
+++ b/packages/ebayui-core-react/src/ebay-tabs/tabs.tsx
@@ -65,7 +65,8 @@ const Tabs: FC<TabsProps> = ({
     useEffect(() => {
         if (prevIndex.current !== index) {
             prevIndex.current = index;
-            handleSelect(index);
+            setSelectedIndex(index);
+            setFocusedIndex(index);
         }
     }, [index]);
 


### PR DESCRIPTION
<!-- Insert GitHub issue number below. An issue is required for all PRs -->

- Fixes #407

## Description

`onSelect` fired on mount because `useEffect(() => { handleSelect(index) }, [index])` runs on the initial render. Broke any analytics/tracking code that expected `onSelect` to mean "user clicked a tab."

Switched to tracking the previous index with a `useRef`. `onSelect` only fires when `index` actually changes. This is cleaner than the `isMounted` pattern -`isMounted` just suppresses the first call, while `prevIndex` expresses what we actually want: skip if nothing changed.

## Notes

`isMounted` would've also worked, but it gets the edge case wrong: if the component mounts with a non-zero index and then receives the same value again, `isMounted` would fire `onSelect` anyway. `prevIndex` doesn't.

## Screenshots

http://localhost:9001/?path=/story/navigation-disclosure-ebay-tabs--default-tabs

**As-Is**

<img width="699" height="269" alt="스크린샷 2026-03-25 오후 7 36 16" src="https://github.com/user-attachments/assets/71d35fb3-f589-4a76-a064-895915ea783f" />

**To-Be**

<img width="690" height="282" alt="스크린샷 2026-03-25 오후 7 36 27" src="https://github.com/user-attachments/assets/ff727602-3bf3-4755-a057-aa1de35af691" />


## Checklist

<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->

- [x] I verify all changes are within scope of the linked issue
- [ ] I added/updated/removed testing (Storybook in Skin) coverage as appropriate

<!-- For CSS changes -->

- [ ] I tested the UI in all supported browsers
- [ ] I tested the UI in dark mode and RTL mode