### PR TITLE
fix(filter-chip): replace aria-pressed with CSS class for menu button selected state

### DIFF
--- a/.changeset/loose-lizards-drop.md
+++ b/.changeset/loose-lizards-drop.md
@@ -1,5 +1,8 @@
 ---
 "@ebay/skin": patch
+"@ebay/ebayui-core": patch
+"@ebay/ebayui-core-react": patch
+"@evo-web/marko": patch
 ---
 
 replace aria-pressed with CSS class for menu button selected state

--- a/.changeset/loose-lizards-drop.md
+++ b/.changeset/loose-lizards-drop.md
@@ -1,0 +1,5 @@
+---
+"@ebay/skin": patch
+---
+
+replace aria-pressed with CSS class for menu button selected state

--- a/packages/ebayui-core-react/src/ebay-filter-chip/__tests__/__snapshots__/render.spec.tsx.snap
+++ b/packages/ebayui-core-react/src/ebay-filter-chip/__tests__/__snapshots__/render.spec.tsx.snap
@@ -76,7 +76,6 @@ exports[`<EbayFilterChip /> rendering > renders collection story correctly 1`] =
     </button>
     <button
       aria-expanded="false"
-      aria-pressed="false"
       class="filter-chip filter-chip--animated"
       type="button"
     >
@@ -197,7 +196,6 @@ exports[`<EbayFilterChip /> rendering > renders menu expanded story correctly 1`
 <div>
   <button
     aria-expanded="true"
-    aria-pressed="false"
     class="filter-chip filter-chip--animated"
     type="button"
   >
@@ -220,11 +218,42 @@ exports[`<EbayFilterChip /> rendering > renders menu expanded story correctly 1`
 </div>
 `;
 
+exports[`<EbayFilterChip /> rendering > renders menu selected story correctly 1`] = `
+<div>
+  <button
+    aria-expanded="false"
+    class="filter-chip filter-chip--selected filter-chip--animated"
+    type="button"
+  >
+    <span
+      class="filter-chip__text"
+    >
+      Menu Selected
+      <span
+        class="clipped"
+      >
+        - 
+        Filter Applied
+      </span>
+    </span>
+    <svg
+      aria-hidden="true"
+      class="filter-chip__trailing icon icon--12"
+      focusable="false"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <use
+        xlink:href="#icon-chevron-down-12"
+      />
+    </svg>
+  </button>
+</div>
+`;
+
 exports[`<EbayFilterChip /> rendering > renders menu story correctly 1`] = `
 <div>
   <button
     aria-expanded="false"
-    aria-pressed="false"
     class="filter-chip filter-chip--animated"
     type="button"
   >

--- a/packages/ebayui-core-react/src/ebay-filter-chip/__tests__/index.spec.tsx
+++ b/packages/ebayui-core-react/src/ebay-filter-chip/__tests__/index.spec.tsx
@@ -109,6 +109,32 @@ describe("<EbayFilterChip />", () => {
 
             expect(container.querySelector(".filter-chip__trailing")).toBeInTheDocument();
         });
+
+        it("should not render aria-pressed", () => {
+            const { getByRole } = render(<EbayFilterChip variant="menu">Menu Filter</EbayFilterChip>);
+
+            expect(getByRole("button")).not.toHaveAttribute("aria-pressed");
+        });
+
+        it("should add filter-chip--selected class when selected", () => {
+            const { container } = render(
+                <EbayFilterChip variant="menu" selected>
+                    Menu Filter
+                </EbayFilterChip>,
+            );
+
+            expect(container.querySelector(".filter-chip")).toHaveClass("filter-chip--selected");
+        });
+
+        it("should show clipped text when selected", () => {
+            const { container } = render(
+                <EbayFilterChip variant="menu" selected>
+                    Menu Filter
+                </EbayFilterChip>,
+            );
+
+            expect(container.querySelector(".clipped")).toHaveTextContent("- Filter Applied");
+        });
     });
 
     describe("anchor variant", () => {

--- a/packages/ebayui-core-react/src/ebay-filter-chip/__tests__/index.stories.tsx
+++ b/packages/ebayui-core-react/src/ebay-filter-chip/__tests__/index.stories.tsx
@@ -171,6 +171,12 @@ export const Menu: StoryFn<typeof EbayFilterChip> = (args) => (
     </EbayFilterChip>
 );
 
+export const MenuSelected: StoryFn<typeof EbayFilterChip> = (args) => (
+    <EbayFilterChip {...args} variant="menu" selected>
+        Menu Selected
+    </EbayFilterChip>
+);
+
 export const MenuExpanded: StoryFn<typeof EbayFilterChip> = (args) => (
     <EbayFilterChip {...args} variant="menu" expanded>
         Menu Expanded

--- a/packages/ebayui-core-react/src/ebay-filter-chip/__tests__/render.spec.tsx
+++ b/packages/ebayui-core-react/src/ebay-filter-chip/__tests__/render.spec.tsx
@@ -11,6 +11,7 @@ const {
     Expressive,
     ExpressiveSelected,
     Menu,
+    MenuSelected,
     MenuExpanded,
     Anchor,
     AnchorSelected,
@@ -46,6 +47,11 @@ describe("<EbayFilterChip /> rendering", () => {
 
     it("renders menu story correctly", () => {
         const { container } = render(<Menu />);
+        expect(container).toMatchSnapshot();
+    });
+
+    it("renders menu selected story correctly", () => {
+        const { container } = render(<MenuSelected />);
         expect(container).toMatchSnapshot();
     });
 

--- a/packages/ebayui-core-react/src/ebay-filter-chip/filter-chip.tsx
+++ b/packages/ebayui-core-react/src/ebay-filter-chip/filter-chip.tsx
@@ -81,11 +81,13 @@ const EbayFilterChip: FC<EbayFilterChipProps> = ({
         }
     };
 
+    const isMenu = variant === "menu";
+
     const classNames = classnames(
         "filter-chip",
         {
             "filter-chip--expressive": variant === "expressive",
-            "filter-chip--selected": isAnchor && selected,
+            "filter-chip--selected": (isAnchor || isMenu) && selected,
         },
         className,
     );
@@ -100,8 +102,8 @@ const EbayFilterChip: FC<EbayFilterChipProps> = ({
             onClick={handleClick}
             href={!disabled ? href : undefined}
             type={!isAnchor ? "button" : undefined}
-            aria-pressed={!isAnchor ? (selected ? "true" : "false") : undefined}
-            aria-expanded={variant === "menu" ? (expanded ? "true" : "false") : undefined}
+            aria-pressed={!isAnchor && !isMenu ? (selected ? "true" : "false") : undefined}
+            aria-expanded={isMenu ? (expanded ? "true" : "false") : undefined}
             disabled={!isAnchor ? disabled : undefined}
         >
             {variant === "expressive" ? <span className="filter-chip__media">{image}</span> : null}
@@ -110,7 +112,7 @@ const EbayFilterChip: FC<EbayFilterChipProps> = ({
 
             <span className="filter-chip__text">
                 {children}
-                {selected && isAnchor ? <span className="clipped">- {a11ySelectedText}</span> : null}
+                {selected && (isAnchor || isMenu) ? <span className="clipped">- {a11ySelectedText}</span> : null}
             </span>
 
             {variant === "menu" ? <EbayIconChevronDown12 className="filter-chip__trailing" /> : null}

--- a/packages/ebayui-core-react/src/ebay-filter-chip/filter-chip.tsx
+++ b/packages/ebayui-core-react/src/ebay-filter-chip/filter-chip.tsx
@@ -55,7 +55,8 @@ const EbayFilterChip: FC<EbayFilterChipProps> = ({
     const selected = selectedControlled !== undefined ? selectedControlled : uncontrolledSelected;
     const expanded = expandedControlled !== undefined ? expandedControlled : uncontrolledExpanded;
 
-    const isAnchor = !!href && variant !== "menu";
+    const isMenu = variant === "menu";
+    const isAnchor = !!href && !isMenu;
 
     useLayoutEffect(() => {
         containerRef.current?.classList?.add("filter-chip--animated");
@@ -66,7 +67,7 @@ const EbayFilterChip: FC<EbayFilterChipProps> = ({
             let newExpanded = expanded;
             let newSelected = selected;
 
-            if (variant === "menu") {
+            if (isMenu) {
                 newExpanded = !expanded;
                 setUncontrolledExpanded(newExpanded);
             } else {
@@ -80,8 +81,6 @@ const EbayFilterChip: FC<EbayFilterChipProps> = ({
             });
         }
     };
-
-    const isMenu = variant === "menu";
 
     const classNames = classnames(
         "filter-chip",

--- a/packages/ebayui-core/src/components/ebay-filter-chip/filter-chip.stories.ts
+++ b/packages/ebayui-core/src/components/ebay-filter-chip/filter-chip.stories.ts
@@ -56,7 +56,7 @@ export default {
         a11ySelectedText: {
             control: { type: "string" },
             description:
-                'Localized, for anchor variant: the clipped text to show when the filter is set. Defaults to "- filter applied"',
+                'Localized, for anchor variant: the clipped text to show when the filter is set. Defaults to "- Filter Applied"',
         },
         onClick: {
             action: "on-click",

--- a/packages/ebayui-core/src/components/ebay-filter-chip/index.marko
+++ b/packages/ebayui-core/src/components/ebay-filter-chip/index.marko
@@ -21,13 +21,13 @@ $ const rootTag = isAnchor ? "a" : "button";
         "filter-chip",
         state.mounted && "filter-chip--animated",
         variant === "expressive" && "filter-chip--expressive",
-        isAnchor && state.selected && "filter-chip--selected",
+        (isAnchor || variant === "menu") && state.selected && "filter-chip--selected",
         inputClass
     ]
     type=!isAnchor && "button"
     href=!disabled ? href : undefined
     disabled=!isAnchor ? disabled : undefined
-    aria-pressed=!isAnchor && (state.selected ? "true" : "false")
+    aria-pressed=!isAnchor && variant !== "menu" && (state.selected ? "true" : "false")
     aria-expanded=variant === "menu" && (state.expanded ? "true" : "false")
     on-click("handleButtonClick")
 >
@@ -43,7 +43,7 @@ $ const rootTag = isAnchor ? "a" : "button";
 
     <span class="filter-chip__text">
         <${renderBody}/>
-        <if(state.selected && isAnchor)>
+        <if(state.selected && (isAnchor || variant === "menu"))>
             <span class="clipped">
                 - ${a11ySelectedText}
             </span>

--- a/packages/ebayui-core/src/components/ebay-filter-chip/test/__snapshots__/test.server.js.snap
+++ b/packages/ebayui-core/src/components/ebay-filter-chip/test/__snapshots__/test.server.js.snap
@@ -116,7 +116,6 @@ exports[`ebay-filter-chip > renders menu button 1`] = `
 "[36m<DocumentFragment>[39m
   [36m<button[39m
     [33maria-expanded[39m=[32m"false"[39m
-    [33maria-pressed[39m=[32m"false"[39m
     [33mclass[39m=[32m"filter-chip"[39m
     [33mtype[39m=[32m"button"[39m
   [36m>[39m
@@ -154,7 +153,6 @@ exports[`ebay-filter-chip > renders menu button expanded 1`] = `
 "[36m<DocumentFragment>[39m
   [36m<button[39m
     [33maria-expanded[39m=[32m"true"[39m
-    [33maria-pressed[39m=[32m"false"[39m
     [33mclass[39m=[32m"filter-chip"[39m
     [33mtype[39m=[32m"button"[39m
   [36m>[39m
@@ -192,14 +190,18 @@ exports[`ebay-filter-chip > renders menu button expanded and selected 1`] = `
 "[36m<DocumentFragment>[39m
   [36m<button[39m
     [33maria-expanded[39m=[32m"true"[39m
-    [33maria-pressed[39m=[32m"true"[39m
-    [33mclass[39m=[32m"filter-chip"[39m
+    [33mclass[39m=[32m"filter-chip filter-chip--selected"[39m
     [33mtype[39m=[32m"button"[39m
   [36m>[39m
     [36m<span[39m
       [33mclass[39m=[32m"filter-chip__text"[39m
     [36m>[39m
       [0mFilter[0m
+      [36m<span[39m
+        [33mclass[39m=[32m"clipped"[39m
+      [36m>[39m
+        [0m- Filter Applied[0m
+      [36m</span>[39m
     [36m</span>[39m
     [36m<svg[39m
       [33maria-hidden[39m=[32m"true"[39m
@@ -230,14 +232,18 @@ exports[`ebay-filter-chip > renders menu button selected 1`] = `
 "[36m<DocumentFragment>[39m
   [36m<button[39m
     [33maria-expanded[39m=[32m"false"[39m
-    [33maria-pressed[39m=[32m"true"[39m
-    [33mclass[39m=[32m"filter-chip"[39m
+    [33mclass[39m=[32m"filter-chip filter-chip--selected"[39m
     [33mtype[39m=[32m"button"[39m
   [36m>[39m
     [36m<span[39m
       [33mclass[39m=[32m"filter-chip__text"[39m
     [36m>[39m
       [0mFilter[0m
+      [36m<span[39m
+        [33mclass[39m=[32m"clipped"[39m
+      [36m>[39m
+        [0m- Filter Applied[0m
+      [36m</span>[39m
     [36m</span>[39m
     [36m<svg[39m
       [33maria-hidden[39m=[32m"true"[39m

--- a/packages/ebayui-core/src/components/ebay-menu-button/test/__snapshots__/test.server.js.snap
+++ b/packages/ebayui-core/src/components/ebay-menu-button/test/__snapshots__/test.server.js.snap
@@ -920,7 +920,6 @@ exports[`menu-button > renders with filter 1`] = `
     [36m<button[39m
       [33maria-expanded[39m=[32m"false"[39m
       [33maria-haspopup[39m=[32m"true"[39m
-      [33maria-pressed[39m=[32m"false"[39m
       [33mclass[39m=[32m"filter-chip menu-button__button"[39m
       [33mtype[39m=[32m"button"[39m
     [36m>[39m
@@ -1307,7 +1306,6 @@ exports[`menu-button > renders with footer 1`] = `
     [36m<button[39m
       [33maria-expanded[39m=[32m"false"[39m
       [33maria-haspopup[39m=[32m"true"[39m
-      [33maria-pressed[39m=[32m"false"[39m
       [33mclass[39m=[32m"filter-chip menu-button__button"[39m
       [33mtype[39m=[32m"button"[39m
     [36m>[39m
@@ -2331,7 +2329,6 @@ exports[`menu-button > renders with type=checkbox and checked=false and as filte
     [36m<button[39m
       [33maria-expanded[39m=[32m"false"[39m
       [33maria-haspopup[39m=[32m"true"[39m
-      [33maria-pressed[39m=[32m"false"[39m
       [33mclass[39m=[32m"filter-chip menu-button__button"[39m
       [33mtype[39m=[32m"button"[39m
     [36m>[39m
@@ -2568,7 +2565,6 @@ exports[`menu-button > renders with type=checkbox and checked=true and as filter
     [36m<button[39m
       [33maria-expanded[39m=[32m"false"[39m
       [33maria-haspopup[39m=[32m"true"[39m
-      [33maria-pressed[39m=[32m"false"[39m
       [33mclass[39m=[32m"filter-chip menu-button__button"[39m
       [33mtype[39m=[32m"button"[39m
     [36m>[39m
@@ -2805,7 +2801,6 @@ exports[`menu-button > renders with type=radio and checked=false and as filter 1
     [36m<button[39m
       [33maria-expanded[39m=[32m"false"[39m
       [33maria-haspopup[39m=[32m"true"[39m
-      [33maria-pressed[39m=[32m"false"[39m
       [33mclass[39m=[32m"filter-chip menu-button__button"[39m
       [33mtype[39m=[32m"button"[39m
     [36m>[39m
@@ -3046,7 +3041,6 @@ exports[`menu-button > renders with type=radio and checked=true and as filter 1`
     [36m<button[39m
       [33maria-expanded[39m=[32m"false"[39m
       [33maria-haspopup[39m=[32m"true"[39m
-      [33maria-pressed[39m=[32m"false"[39m
       [33mclass[39m=[32m"filter-chip menu-button__button"[39m
       [33mtype[39m=[32m"button"[39m
     [36m>[39m

--- a/packages/evo-marko/src/tags/evo-filter-chip/examples/anchor.marko
+++ b/packages/evo-marko/src/tags/evo-filter-chip/examples/anchor.marko
@@ -1,4 +1,4 @@
-<evo-filter-chip href="https://www.ebay.com" a11ySelectedText="Filter applied" ...input>
+<evo-filter-chip href="https://www.ebay.com" a11ySelectedText="Filter Applied" ...input>
     <@icon>
         <evo-icon-sneaker-16/>
     </@icon>

--- a/packages/evo-marko/src/tags/evo-filter-chip/index.marko
+++ b/packages/evo-marko/src/tags/evo-filter-chip/index.marko
@@ -44,7 +44,7 @@ export interface Input
             ...input as Marko.HTML.Button
             disabled=disabled
             type="button"
-            aria-selected=(selected ? "true" : "false")/>
+            aria-selected=!isMenu && (selected ? "true" : "false")/>
     </else>
 </define>
 
@@ -54,6 +54,7 @@ export interface Input
         "filter-chip",
         mounted && "filter-chip--animated",
         variant === "expressive" && "filter-chip--expressive",
+        (isAnchor || isMenu) && selected && "filter-chip--selected",
         inputClass,
     ]
     href=(!disabled ? href : undefined)
@@ -80,7 +81,7 @@ export interface Input
 
     <span class="filter-chip__text">
         <${content}/>
-        <if=selected && isAnchor>
+        <if=selected && (isAnchor || isMenu)>
             <span class="clipped">
                 ${" "}- ${a11ySelectedText}
             </span>

--- a/packages/skin/dist/filter-chip/filter-chip.css
+++ b/packages/skin/dist/filter-chip/filter-chip.css
@@ -144,6 +144,7 @@ button.filter-chip--expressive {
 }
 
 a.filter-chip--selected,
+button.filter-chip.filter-chip--selected,
 button.filter-chip[aria-pressed="true"] {
     animation: fill-horizontal-background 0s var(--motion-easing-quick-enter)
         forwards;
@@ -158,6 +159,7 @@ button.filter-chip[aria-pressed="true"] {
 }
 
 a.filter-chip--selected:after,
+button.filter-chip.filter-chip--selected:after,
 button.filter-chip[aria-pressed="true"]:after {
     background-color: var(--color-state-layer-neutral-on-strong);
     content: "";
@@ -168,6 +170,11 @@ button.filter-chip[aria-pressed="true"]:after {
 
 a.filter-chip--selected:not([disabled], [aria-disabled="true"]):hover:after,
 a.filter-chip--selected[href]:hover:after,
+button.filter-chip.filter-chip--selected:not(
+        [disabled],
+        [aria-disabled="true"]
+    ):hover:after,
+button.filter-chip.filter-chip--selected[href]:hover:after,
 button.filter-chip[aria-pressed="true"]:not(
         [disabled],
         [aria-disabled="true"]
@@ -181,6 +188,11 @@ a.filter-chip--selected:not(
         [aria-disabled="true"]
     ):focus-visible:after,
 a.filter-chip--selected[href]:focus-visible:after,
+button.filter-chip.filter-chip--selected:not(
+        [disabled],
+        [aria-disabled="true"]
+    ):focus-visible:after,
+button.filter-chip.filter-chip--selected[href]:focus-visible:after,
 button.filter-chip[aria-pressed="true"]:not(
         [disabled],
         [aria-disabled="true"]
@@ -191,6 +203,11 @@ button.filter-chip[aria-pressed="true"][href]:focus-visible:after {
 
 a.filter-chip--selected:not([disabled], [aria-disabled="true"]):active:after,
 a.filter-chip--selected[href]:active:after,
+button.filter-chip.filter-chip--selected:not(
+        [disabled],
+        [aria-disabled="true"]
+    ):active:after,
+button.filter-chip.filter-chip--selected[href]:active:after,
 button.filter-chip[aria-pressed="true"]:not(
         [disabled],
         [aria-disabled="true"]
@@ -199,6 +216,7 @@ button.filter-chip[aria-pressed="true"][href]:active:after {
     background-color: var(--color-state-layer-pressed-on-strong);
 }
 
+button.filter-chip--animated.filter-chip--selected,
 button.filter-chip--animated[aria-pressed="true"] {
     animation-duration: var(--motion-duration-medium-2);
     transition: color var(--motion-duration-instant)

--- a/packages/skin/src/sass/filter-chip/filter-chip.scss
+++ b/packages/skin/src/sass/filter-chip/filter-chip.scss
@@ -35,12 +35,14 @@ a.filter-chip--expressive {
 }
 
 button.filter-chip[aria-pressed="true"],
+button.filter-chip.filter-chip--selected,
 a.filter-chip--selected {
     @include chip-mixins.selected;
     @include state-layer.strong;
 }
 
-button.filter-chip--animated[aria-pressed="true"] {
+button.filter-chip--animated[aria-pressed="true"],
+button.filter-chip--animated.filter-chip--selected {
     @include chip-mixins.selected-animation;
 }
 

--- a/packages/skin/src/sass/filter-chip/stories/menu-button-chip.stories.js
+++ b/packages/skin/src/sass/filter-chip/stories/menu-button-chip.stories.js
@@ -1,7 +1,7 @@
 export default { title: "Skin/Filter Chip/Menu" };
 
 export const collapsed = () => `
-<button class="filter-chip" aria-expanded="false" aria-pressed="false">
+<button class="filter-chip" aria-expanded="false">
     <span class="filter-chip__text">Football</span>
     <svg class="icon icon--12 filter-chip__trailing" width="13" height="12" aria-hidden="true">
         <use href="#icon-chevron-down-12"/>
@@ -10,7 +10,7 @@ export const collapsed = () => `
 `;
 
 export const expanded = () => `
-<button class="filter-chip" aria-expanded="true" aria-pressed="false">
+<button class="filter-chip" aria-expanded="true">
     <span class="filter-chip__text">Football</span>
     <svg class="icon icon--12 filter-chip__trailing" width="13" height="12" aria-hidden="true">
         <use href="#icon-chevron-down-12"/>
@@ -19,26 +19,28 @@ export const expanded = () => `
 `;
 
 export const collapsedSelected = () => `
-<button class="filter-chip" aria-expanded="false" aria-pressed="true">
+<button class="filter-chip filter-chip--selected" aria-expanded="false">
     <span class="filter-chip__text">Football</span>
     <svg class="icon icon--12 filter-chip__trailing" width="13" height="12" aria-hidden="true">
         <use href="#icon-chevron-down-12"/>
     </svg>
+    <span class="clipped">filter applied</span>
 </button>
 `;
 
 export const expandedSelected = () => `
-<button class="filter-chip" aria-expanded="true" aria-pressed="true">
+<button class="filter-chip filter-chip--selected" aria-expanded="true">
     <span class="filter-chip__text">Football</span>
     <svg class="icon icon--12 filter-chip__trailing" width="13" height="12" aria-hidden="true">
         <use href="#icon-chevron-down-12"/>
     </svg>
+    <span class="clipped">filter applied</span>
 </button>
 `;
 
 export const RTL = () => `
 <div dir="rtl">
-    <button class="filter-chip" aria-expanded="false" aria-pressed="false">
+    <button class="filter-chip" aria-expanded="false">
         <span class="filter-chip__text">Football</span>
         <svg class="icon icon--12 filter-chip__trailing" width="13" height="12" aria-hidden="true">
             <use href="#icon-chevron-down-12"/>
@@ -48,7 +50,7 @@ export const RTL = () => `
 `;
 
 export const textSpacing = () => `
-<button class="filter-chip demo-a11y-text-spacing" aria-expanded="false" aria-pressed="false">
+<button class="filter-chip demo-a11y-text-spacing" aria-expanded="false">
     <span class="filter-chip__text">Football</span>
     <svg class="icon icon--12 filter-chip__trailing" width="13" height="12" aria-hidden="true">
         <use href="#icon-chevron-down-12"/>

--- a/packages/skin/src/sass/filter-chip/stories/menu-button-chip.stories.js
+++ b/packages/skin/src/sass/filter-chip/stories/menu-button-chip.stories.js
@@ -24,7 +24,7 @@ export const collapsedSelected = () => `
     <svg class="icon icon--12 filter-chip__trailing" width="13" height="12" aria-hidden="true">
         <use href="#icon-chevron-down-12"/>
     </svg>
-    <span class="clipped">filter applied</span>
+    <span class="clipped">Filter Applied</span>
 </button>
 `;
 
@@ -34,7 +34,7 @@ export const expandedSelected = () => `
     <svg class="icon icon--12 filter-chip__trailing" width="13" height="12" aria-hidden="true">
         <use href="#icon-chevron-down-12"/>
     </svg>
-    <span class="clipped">filter applied</span>
+    <span class="clipped">Filter Applied</span>
 </button>
 `;
 
@@ -76,7 +76,7 @@ export const expressiveCollapsedSelected = () => `
     <svg class="icon icon--12 filter-chip__trailing" width="13" height="12" aria-hidden="true">
         <use href="#icon-chevron-down-12"/>
     </svg>
-    <span class="clipped">filter applied</span>
+    <span class="clipped">Filter Applied</span>
 </button>
 `;
 

--- a/packages/skin/src/sass/filter-chip/stories/menu-button-chip.stories.js
+++ b/packages/skin/src/sass/filter-chip/stories/menu-button-chip.stories.js
@@ -1,7 +1,7 @@
 export default { title: "Skin/Filter Chip/Menu" };
 
 export const collapsed = () => `
-<button class="filter-chip" aria-expanded="false">
+<button class="filter-chip" type="button" aria-expanded="false">
     <span class="filter-chip__text">Football</span>
     <svg class="icon icon--12 filter-chip__trailing" width="13" height="12" aria-hidden="true">
         <use href="#icon-chevron-down-12"/>
@@ -10,7 +10,7 @@ export const collapsed = () => `
 `;
 
 export const expanded = () => `
-<button class="filter-chip" aria-expanded="true">
+<button class="filter-chip" type="button" aria-expanded="true">
     <span class="filter-chip__text">Football</span>
     <svg class="icon icon--12 filter-chip__trailing" width="13" height="12" aria-hidden="true">
         <use href="#icon-chevron-down-12"/>
@@ -19,7 +19,7 @@ export const expanded = () => `
 `;
 
 export const collapsedSelected = () => `
-<button class="filter-chip filter-chip--selected" aria-expanded="false">
+<button class="filter-chip filter-chip--selected" type="button" aria-expanded="false">
     <span class="filter-chip__text">Football</span>
     <svg class="icon icon--12 filter-chip__trailing" width="13" height="12" aria-hidden="true">
         <use href="#icon-chevron-down-12"/>
@@ -29,7 +29,7 @@ export const collapsedSelected = () => `
 `;
 
 export const expandedSelected = () => `
-<button class="filter-chip filter-chip--selected" aria-expanded="true">
+<button class="filter-chip filter-chip--selected" type="button" aria-expanded="true">
     <span class="filter-chip__text">Football</span>
     <svg class="icon icon--12 filter-chip__trailing" width="13" height="12" aria-hidden="true">
         <use href="#icon-chevron-down-12"/>
@@ -40,7 +40,7 @@ export const expandedSelected = () => `
 
 export const RTL = () => `
 <div dir="rtl">
-    <button class="filter-chip" aria-expanded="false">
+    <button class="filter-chip" type="button" aria-expanded="false">
         <span class="filter-chip__text">Football</span>
         <svg class="icon icon--12 filter-chip__trailing" width="13" height="12" aria-hidden="true">
             <use href="#icon-chevron-down-12"/>
@@ -49,8 +49,39 @@ export const RTL = () => `
 </div>
 `;
 
+export const expressiveCollapsed = () => `
+<button class="filter-chip filter-chip--expressive" type="button" aria-expanded="false">
+    <span class="filter-chip__media">
+        <img
+            src="https://ir.ebaystatic.com/cr/v/c01/skin/docs/dog_profile_optimized.jpg"
+            alt=""
+        >
+    </span>
+    <span class="filter-chip__text">Football</span>
+    <svg class="icon icon--12 filter-chip__trailing" width="13" height="12" aria-hidden="true">
+        <use href="#icon-chevron-down-12"/>
+    </svg>
+</button>
+`;
+
+export const expressiveCollapsedSelected = () => `
+<button class="filter-chip filter-chip--expressive filter-chip--selected" type="button" aria-expanded="false">
+    <span class="filter-chip__media">
+        <img
+            src="https://ir.ebaystatic.com/cr/v/c01/skin/docs/dog_profile_optimized.jpg"
+            alt=""
+        >
+    </span>
+    <span class="filter-chip__text">Football</span>
+    <svg class="icon icon--12 filter-chip__trailing" width="13" height="12" aria-hidden="true">
+        <use href="#icon-chevron-down-12"/>
+    </svg>
+    <span class="clipped">filter applied</span>
+</button>
+`;
+
 export const textSpacing = () => `
-<button class="filter-chip demo-a11y-text-spacing" aria-expanded="false">
+<button class="filter-chip demo-a11y-text-spacing" type="button" aria-expanded="false">
     <span class="filter-chip__text">Football</span>
     <svg class="icon icon--12 filter-chip__trailing" width="13" height="12" aria-hidden="true">
         <use href="#icon-chevron-down-12"/>

--- a/src/routes/_index/components/filter-chip/css+page.marko
+++ b/src/routes/_index/components/filter-chip/css+page.marko
@@ -85,7 +85,7 @@
         <span class="filter-chip__text">
           Football
           <span class="clipped">
-            - filter applied
+            - Filter Applied
           </span>
         </span>
       </a>
@@ -109,7 +109,7 @@
       <span class="filter-chip__text">
         Football
         <span class="clipped">
-          - filter applied
+          - Filter Applied
         </span>
       </span>
     </a>
@@ -213,7 +213,7 @@
         <span class="filter-chip__text">
           Pet Supplies
           <span class="clipped">
-            - filter applied
+            - Filter Applied
           </span>
         </span>
       </a>
@@ -246,7 +246,7 @@
       <span class="filter-chip__text">
         Football
         <span class="clipped">
-          - filter applied
+          - Filter Applied
         </span>
       </span>
     </a>
@@ -301,7 +301,7 @@
           <icon-symbol name="chevron-down-16"/>
         </svg>
         <span class="clipped">
-          filter applied
+          Filter Applied
         </span>
       </button>
     </div>
@@ -319,7 +319,7 @@
         <use href="#icon-chevron-down-16"/>
       </svg>
       <span class="clipped">
-        filter applied
+        Filter Applied
       </span>
     </button>
   </highlight-code>

--- a/src/routes/_index/components/filter-chip/css+page.marko
+++ b/src/routes/_index/components/filter-chip/css+page.marko
@@ -261,7 +261,7 @@
 
   <div class="demo">
     <div class="demo__inner">
-      <button class="filter-chip" aria-pressed="false" aria-expanded="false">
+      <button class="filter-chip" type="button" aria-expanded="false">
         <span class="filter-chip__text">
           Sport: -
         </span>
@@ -273,7 +273,7 @@
   </div>
 
   <highlight-code type="html">
-    <button class="filter-chip" aria-pressed="false" aria-expanded="false">
+    <button class="filter-chip" type="button" aria-expanded="false">
       <span class="filter-chip__text">
         Sport: -
       </span>
@@ -290,7 +290,7 @@
 
   <div class="demo">
     <div class="demo__inner">
-      <button class="filter-chip" aria-pressed="true" aria-expanded="false">
+      <button class="filter-chip filter-chip--selected" type="button" aria-expanded="false">
         <span class="filter-chip__text">
           Sport: Football
           <span class="filter-chip__count">
@@ -300,12 +300,15 @@
         <svg class="filter-chip__trailing icon icon--12" width="12" height="12">
           <icon-symbol name="chevron-down-16"/>
         </svg>
+        <span class="clipped">
+          filter applied
+        </span>
       </button>
     </div>
   </div>
 
   <highlight-code type="html">
-    <button class="filter-chip" aria-pressed="true" aria-expanded="false">
+    <button class="filter-chip filter-chip--selected" type="button" aria-expanded="false">
       <span class="filter-chip__text">
         Sport: Football
         <span class="filter-chip__count">
@@ -315,6 +318,9 @@
       <svg class="filter-chip__trailing icon icon--12" width="12" height="12">
         <use href="#icon-chevron-down-16"/>
       </svg>
+      <span class="clipped">
+        filter applied
+      </span>
     </button>
   </highlight-code>
 </div>


### PR DESCRIPTION
<!-- Insert GitHub issue number below. An issue is required for all PRs -->

- Fixes #452

## Description

<!-- Briefly describe the proposed changes -->

## Notes

Menu filter-chips used `aria-pressed` to show selected state. That's the wrong attribute here - `aria-pressed` is for buttons that toggle their own state on/off, but a menu chip reflects a selection made inside another UI element. Screen readers were announcing a pressed state that had nothing to do with the button itself.

Two changes:

1. CSS — added `filter-chip--selected` class as a selector for selected state and animation, alongside the existing `aria-pressed="true"`. Menu chips can now drop `aria-pressed` without losing visual feedback.
2. Stories — removed `aria-pressed` from all menu button chip examples, added `filter-chip--selected` class and `<span class="clipped">filter applied</span>` so screen readers announce filter state correctly.

Non-menu chips (no `aria-expanded`) still use `aria-pressed` as before.

**As-Is**
`<button class="filter-chip" aria-pressed="true">`
**To-Be**
`<button class="filter-chip filter-chip--selected">` + `<span class="clipped">filter applied</span>`

## Screenshots

<!-- Upload screenshots of UI before & after these changes -->

## Checklist

## Checklist
- [x] I verify all changes are within scope of the linked issue
- [ ] I added/updated/removed testing (Storybook in Skin) coverage as appropriate
- [x] I tested the UI in all supported browsers
- [ ] I tested the UI in dark mode and RTL mode
