### PR TITLE
feat: added wrapText prop to Button

### DIFF
--- a/packages/ebayui-core-react/src/ebay-button/__tests__/index.stories.tsx
+++ b/packages/ebayui-core-react/src/ebay-button/__tests__/index.stories.tsx
@@ -106,6 +106,9 @@ or import styles using SCSS/CSS
         },
         borderless: { description: "shows button without border", control: "boolean" },
         fixedHeight: { description: "fixes the height based on `size`", control: "boolean" },
+        wrapText: {
+            description: "wraps each child in a `btn__text` span element",
+        },
         onClick: {
             description: "click or action key pressed (`Space` / `Enter`)",
             action: "onClick",

--- a/packages/ebayui-core-react/src/ebay-button/button.tsx
+++ b/packages/ebayui-core-react/src/ebay-button/button.tsx
@@ -14,6 +14,7 @@ import { Priority, Size, BodyState, Variant, Split } from "./types";
 import { EbayIcon } from "../ebay-icon";
 import EbayButtonLoading from "./button-loading";
 import EbayButtonExpand from "./button-expand";
+import EbayButtonText from "./button-text";
 
 export type EbayButtonProps = {
     fluid?: boolean;
@@ -31,6 +32,7 @@ export type EbayButtonProps = {
     forwardedRef?: RefObject<HTMLAnchorElement & HTMLButtonElement>;
     borderless?: boolean;
     fixedHeight?: boolean;
+    wrapText?: boolean;
 };
 
 type Props = ComponentProps<"button"> & ComponentProps<"a"> & EbayButtonProps;
@@ -54,6 +56,7 @@ const EbayButton: FC<Props> = ({
     forwardedRef,
     borderless,
     fixedHeight,
+    wrapText = false,
     ...rest
 }) => {
     const classPrefix = href ? "fake-btn" : "btn";
@@ -99,7 +102,7 @@ const EbayButton: FC<Props> = ({
         }
     };
 
-    const bodyContent = getBodyContent(children, { isLoading, isExpand });
+    const bodyContent = getBodyContent(children, { isLoading, isExpand, wrapText });
     const ariaLive = isLoading ? `polite` : null;
 
     return href ? (
@@ -131,16 +134,17 @@ const EbayButton: FC<Props> = ({
 type bodyContentOptions = {
     isLoading: boolean;
     isExpand: boolean;
+    wrapText: boolean;
 };
 
-function getBodyContent(children: ReactNode, { isLoading, isExpand }: bodyContentOptions) {
+function getBodyContent(children: ReactNode, { isLoading, isExpand, wrapText }: bodyContentOptions) {
     switch (true) {
         case isLoading:
             return <EbayButtonLoading />;
         case isExpand:
             return <EbayButtonExpand>{children}</EbayButtonExpand>;
         default:
-            return children;
+            return wrapText ? Children.map(children, (child) => <EbayButtonText>{child}</EbayButtonText>) : children;
     }
 }
 


### PR DESCRIPTION
<!-- Insert GitHub issue number below. An issue is required for all PRs -->

## Description

This pull request adds a new `wrapText` feature to the `EbayButton` component, allowing each child element to be wrapped in a `btn__text` to resolve an eBay Live Google translate issue. The change is implemented in both the component logic and its Storybook documentation.

Enhancement: Button text wrapping

* Added a new `wrapText` prop to the `EbayButton` component's props and updated its TypeScript type definition to support this feature. [[1]](diffhunk://#diff-5689cf63018f6e4e1c57da379ffed30a6ed4de49ce7873da7b86470a334ffb12R35) [[2]](diffhunk://#diff-5689cf63018f6e4e1c57da379ffed30a6ed4de49ce7873da7b86470a334ffb12R59)
* Modified the `getBodyContent` function to wrap each child in an `EbayButtonText` component when `wrapText` is true, providing more granular control over button text rendering.
* Imported the new `EbayButtonText` component into `button.tsx` to support the wrapping functionality.

Documentation:

* Added a description for the new `wrapText` prop in the Storybook controls for `EbayButton`, making it visible and configurable in the component documentation.

Internal logic:

* Passed the `wrapText` option through to `getBodyContent` to ensure the new behavior is triggered when the prop is set.
- Fixes #


## Notes

<!-- Be sure to mention anything unusual, out-of-scope or new technical debt, etc -->

## Screenshots

<!-- Upload screenshots of UI before & after these changes -->

## Checklist

<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->

- [ ] I verify all changes are within scope of the linked issue
- [ ] I added/updated/removed testing (Storybook in Skin) coverage as appropriate

<!-- For CSS changes -->

- [ ] I tested the UI in all supported browsers
- [ ] I tested the UI in dark mode and RTL mode
