### PR TITLE
fix(eek): refactored EEK to use role img instead of figure

### DIFF
--- a/packages/ebayui-core-react/src/ebay-eek/__tests__/index.spec.tsx
+++ b/packages/ebayui-core-react/src/ebay-eek/__tests__/index.spec.tsx
@@ -9,8 +9,8 @@ async function ratingCheck(max, min, rating, number) {
 
     wrapper = render(<EbayEek max={max} min={min} rating={rating} />);
 
-    wrapper.getAllByRole("figure").forEach((figure) => {
-        expect(figure).toHaveClass(eekClass);
+    wrapper.getAllByRole("img").forEach((eekRoot) => {
+        expect(eekRoot).toHaveClass(eekClass);
     });
 }
 
@@ -26,7 +26,7 @@ describe("<EbayEek>", () => {
         expect(wrapper.getByText("A+++")).toHaveProperty("nextElementSibling");
         expect(wrapper.getByText("D")).toHaveProperty("previousElementSibling");
         expect(wrapper.getByText("B")).toHaveClass("eek__rating");
-        expect(wrapper.getByRole("figure")).toHaveClass("eek--rating-5");
+        expect(wrapper.getByRole("img")).toHaveClass("eek--rating-5");
     });
 
     it("renders invalid eek", async () => {
@@ -40,7 +40,7 @@ describe("<EbayEek>", () => {
         expect(wrapper.getByText("A")).toHaveProperty("nextElementSibling");
         expect(wrapper.getByText("D")).toHaveProperty("previousElementSibling");
         expect(wrapper.getByText("B")).toHaveClass("eek__rating");
-        expect(wrapper.getByRole("figure")).toHaveClass("eek");
+        expect(wrapper.getByRole("img")).toHaveClass("eek");
     });
 
     it("renders the correct eek if rating is outside", async () => {

--- a/packages/ebayui-core-react/src/ebay-eek/__tests__/index.stories.tsx
+++ b/packages/ebayui-core-react/src/ebay-eek/__tests__/index.stories.tsx
@@ -44,7 +44,7 @@ or import styles using SCSS/CSS
         rating: { description: "The energy rating", control: "text" },
         max: { description: "The maximum range", control: "text" },
         min: { description: "The minimum range", control: "text" },
-        a11yText: { description: "Accessible label for the energy rating figure", control: "text" },
+        a11yText: { description: "Accessible label for the energy rating graphic", control: "text" },
     },
 };
 

--- a/packages/ebayui-core-react/src/ebay-eek/eek-rating.tsx
+++ b/packages/ebayui-core-react/src/ebay-eek/eek-rating.tsx
@@ -17,7 +17,7 @@ const EbayEek: FC<EbayEekProps> = ({ min = "", max = "", rating, a11yText, class
     const className = classNames(extraClasses, "eek", { [`eek--rating-${parsedRating}`]: !!parsedRating });
     const backupA11yText = `Energy Rating: ${rating}. Range: ${max} - ${min}.`;
     return (
-        <div className={className} role="figure" aria-label={a11yText || backupA11yText}>
+        <div className={className} role="img" aria-label={a11yText || backupA11yText}>
             <div className="eek__container" aria-hidden>
                 <span className="eek__rating-range">
                     <span>{max}</span>

--- a/packages/ebayui-core/src/components/ebay-eek/index.marko
+++ b/packages/ebayui-core/src/components/ebay-eek/index.marko
@@ -16,7 +16,7 @@ $ (input as any).toJSON = noop;
 $ const eekRating = eekUtil(input);
 <div
     ...processHtmlAttributes(htmlInput)
-    role="figure"
+    role="img"
     style=style
     aria-label=a11yText ||
     `Energy Rating: ${rating}. Range: ${max} - ${min}.`

--- a/packages/ebayui-core/src/components/ebay-eek/test/__snapshots__/test.server.js.snap
+++ b/packages/ebayui-core/src/components/ebay-eek/test/__snapshots__/test.server.js.snap
@@ -6,7 +6,7 @@ exports[`eek > passes through additional html attributes 1`] = `
   class="eek class1"
   data-passed-through="true"
   data-testid="AttributePassthrough"
-  role="figure"
+  role="img"
   style="color:red"
   type="number"
 >
@@ -86,7 +86,7 @@ exports[`eek > passes through additional html attributes 2`] = `
   class="eek class1"
   data-passed-through="true"
   data-testid="AttributePassthrough"
-  role="figure"
+  role="img"
   style="color:red"
   type="number"
 >
@@ -184,7 +184,7 @@ exports[`eek > renders default eek 4`] = `
 <div
   aria-label="Energy Rating: B. Range: A+++ - D."
   class="eek eek--rating-5"
-  role="figure"
+  role="img"
 >
   <div
     aria-hidden="true"
@@ -286,7 +286,7 @@ exports[`eek > renders invalid eek 4`] = `
 <div
   aria-label="Energy Rating: B. Range: A - D."
   class="eek"
-  role="figure"
+  role="img"
 >
   <div
     aria-hidden="true"
@@ -388,7 +388,7 @@ exports[`eek > renders large eek 4`] = `
 <div
   aria-label="Energy Rating: B. Range: A+++ - D."
   class="eek eek--rating-5 eek--large"
-  role="figure"
+  role="img"
 >
   <div
     aria-hidden="true"
@@ -470,7 +470,7 @@ exports[`eek > renders rating 1 1`] = `
 <div
   aria-label="Energy Rating: A++. Range: A++ - E."
   class="eek eek--rating-1"
-  role="figure"
+  role="img"
 >
   <div
     aria-hidden="true"
@@ -552,7 +552,7 @@ exports[`eek > renders rating 2 1`] = `
 <div
   aria-label="Energy Rating: A+. Range: A++ - E."
   class="eek eek--rating-2"
-  role="figure"
+  role="img"
 >
   <div
     aria-hidden="true"
@@ -634,7 +634,7 @@ exports[`eek > renders rating 3 1`] = `
 <div
   aria-label="Energy Rating: A. Range: A++ - E."
   class="eek eek--rating-3"
-  role="figure"
+  role="img"
 >
   <div
     aria-hidden="true"
@@ -716,7 +716,7 @@ exports[`eek > renders rating 4 1`] = `
 <div
   aria-label="Energy Rating: B. Range: A++ - E."
   class="eek eek--rating-4"
-  role="figure"
+  role="img"
 >
   <div
     aria-hidden="true"
@@ -798,7 +798,7 @@ exports[`eek > renders rating 5 1`] = `
 <div
   aria-label="Energy Rating: C. Range: A++ - E."
   class="eek eek--rating-5"
-  role="figure"
+  role="img"
 >
   <div
     aria-hidden="true"
@@ -880,7 +880,7 @@ exports[`eek > renders rating 6 1`] = `
 <div
   aria-label="Energy Rating: D. Range: A++ - E."
   class="eek eek--rating-6"
-  role="figure"
+  role="img"
 >
   <div
     aria-hidden="true"
@@ -962,7 +962,7 @@ exports[`eek > renders rating 7 (not 8) 1`] = `
 <div
   aria-label="Energy Rating: F. Range: A++ - G."
   class="eek eek--rating-7"
-  role="figure"
+  role="img"
 >
   <div
     aria-hidden="true"
@@ -1044,7 +1044,7 @@ exports[`eek > renders rating 7 (not 8) 2`] = `
 <div
   aria-label="Energy Rating: G. Range: A++ - G."
   class="eek eek--rating-7"
-  role="figure"
+  role="img"
 >
   <div
     aria-hidden="true"
@@ -1126,7 +1126,7 @@ exports[`eek > renders rating 7 1`] = `
 <div
   aria-label="Energy Rating: E. Range: A++ - E."
   class="eek eek--rating-7"
-  role="figure"
+  role="img"
 >
   <div
     aria-hidden="true"
@@ -1208,7 +1208,7 @@ exports[`eek > renders the correct eek if rating is outside 1`] = `
 <div
   aria-label="Energy Rating: A++. Range: A+ - D."
   class="eek"
-  role="figure"
+  role="img"
 >
   <div
     aria-hidden="true"

--- a/packages/ebayui-core/src/components/ebay-eek/test/test.server.js
+++ b/packages/ebayui-core/src/components/ebay-eek/test/test.server.js
@@ -7,7 +7,7 @@ import template from "../index.marko";
 describe("eek", () => {
     async function ratingCheck(max, min, rating) {
         const { getByRole } = await render(template, { max, min, rating });
-        expect(getByRole("figure")).toMatchSnapshot();
+        expect(getByRole("img")).toMatchSnapshot();
     }
 
     it("renders default eek", async () => {
@@ -19,7 +19,7 @@ describe("eek", () => {
         expect(getByText("A+++")).toMatchSnapshot();
         expect(getByText("D")).toMatchSnapshot();
         expect(getByText("B")).toMatchSnapshot();
-        expect(getByRole("figure")).toMatchSnapshot();
+        expect(getByRole("img")).toMatchSnapshot();
     });
 
     it("renders large eek", async () => {
@@ -32,7 +32,7 @@ describe("eek", () => {
         expect(getByText("A+++")).toMatchSnapshot();
         expect(getByText("D")).toMatchSnapshot();
         expect(getByText("B")).toMatchSnapshot();
-        expect(getByRole("figure")).toMatchSnapshot();
+        expect(getByRole("img")).toMatchSnapshot();
     });
 
     it("renders invalid eek", async () => {
@@ -44,7 +44,7 @@ describe("eek", () => {
         expect(getByText("A")).toMatchSnapshot();
         expect(getByText("D")).toMatchSnapshot();
         expect(getByText("B")).toMatchSnapshot();
-        expect(getByRole("figure")).toMatchSnapshot();
+        expect(getByRole("img")).toMatchSnapshot();
     });
 
     it("renders the correct eek if rating is outside", async () => {

--- a/packages/evo-marko/src/tags/evo-eek/index.marko
+++ b/packages/evo-marko/src/tags/evo-eek/index.marko
@@ -58,7 +58,7 @@ static function eekUtil(max:string, min:string, rating:string) {
 <div
   ...htmlInput
   aria-label=a11yText
-  role="figure"
+  role="img"
   class=[
     "eek",
     eekRating ? `eek--rating-${eekRating}` : null,

--- a/packages/evo-marko/src/tags/evo-eek/test/test.server.ts
+++ b/packages/evo-marko/src/tags/evo-eek/test/test.server.ts
@@ -25,7 +25,7 @@ describe("eek", () => {
     expect(getByText("A+++")).toMatchSnapshot();
     expect(getByText("D")).toMatchSnapshot();
     expect(getByText("B")).toMatchSnapshot();
-    expect(getByRole("figure")).toMatchSnapshot();
+    expect(getByRole("img")).toMatchSnapshot();
   });
 
   it("renders large eek", async () => {
@@ -39,7 +39,7 @@ describe("eek", () => {
     expect(getByText("A+++")).toMatchSnapshot();
     expect(getByText("D")).toMatchSnapshot();
     expect(getByText("B")).toMatchSnapshot();
-    expect(getByRole("figure")).toMatchSnapshot();
+    expect(getByRole("img")).toMatchSnapshot();
   });
 
   it("renders invalid eek", async () => {
@@ -52,7 +52,7 @@ describe("eek", () => {
     expect(getByText("A")).toMatchSnapshot();
     expect(getByText("D")).toMatchSnapshot();
     expect(getByText("B")).toMatchSnapshot();
-    expect(getByRole("figure")).toMatchSnapshot();
+    expect(getByRole("img")).toMatchSnapshot();
   });
 
   it("renders the correct eek if rating is outside", async () => {

--- a/packages/skin/src/sass/eek/stories/eek.stories.js
+++ b/packages/skin/src/sass/eek/stories/eek.stories.js
@@ -1,7 +1,7 @@
 export default { title: "Skin/EEK" };
 
 export const typical = () => `
-    <div class="eek eek--rating-4" role="figure" aria-label="Energy Rating: B. Range: A++ - E">
+    <div class="eek eek--rating-4" role="img" aria-label="Energy Rating: B. Range: A++ - E">
         <div class="eek__container">
             <span class="eek__rating-range">
                 <span aria-hidden="true">A++</span>
@@ -21,7 +21,7 @@ export const typical = () => `
 `;
 
 export const large = () => `
-    <div class="eek eek--large eek--rating-1" role="figure" aria-label="Energy Rating: A+++. Range: A+++ - D">
+    <div class="eek eek--large eek--rating-1" role="img" aria-label="Energy Rating: A+++. Range: A+++ - D">
         <div class="eek__container">
             <span class="eek__rating-range">
                 <span aria-hidden="true">A+++</span>
@@ -42,7 +42,7 @@ export const large = () => `
 
 export const RTL = () => `
 <div dir="rtl">
-    <div class="eek eek--rating-4" role="figure" aria-label="Energy Rating: B. Range: A++ - E">
+    <div class="eek eek--rating-4" role="img" aria-label="Energy Rating: B. Range: A++ - E">
         <div class="eek__container">
             <span class="eek__rating-range">
                 <span aria-hidden="true">A++</span>
@@ -64,7 +64,7 @@ export const RTL = () => `
 
 export const RTLLarge = () => `
 <div dir="rtl">
-    <div class="eek eek--large eek--rating-1" role="figure" aria-label="Energy Rating: A+++. Range: A+++ - D">
+    <div class="eek eek--large eek--rating-1" role="img" aria-label="Energy Rating: A+++. Range: A+++ - D">
         <div class="eek__container">
             <span class="eek__rating-range">
                 <span aria-hidden="true">A+++</span>

--- a/src/routes/_index/components/eek/accessibility+meta.json
+++ b/src/routes/_index/components/eek/accessibility+meta.json
@@ -1,4 +1,4 @@
 {
   "pageTitle": "EEK Accessibility Guidelines — Creating Inclusive Energy Efficiency Labels",
-  "pageDescription": "Learn how to make EEK (Energy Efficiency Class) components fully accessible with proper figure semantics and ARIA labels. Follow these guidelines to ensure energy rating information is clear and accessible to all users, including those using assistive technologies."
+  "pageDescription": "Learn how to make EEK (Energy Efficiency Class) components fully accessible using role=img and ARIA labels. Follow these guidelines to ensure energy rating information is clear and accessible to all users, including those using assistive technologies."
 }

--- a/src/routes/_index/components/eek/accessibility+page.marko
+++ b/src/routes/_index/components/eek/accessibility+page.marko
@@ -27,7 +27,7 @@ import { urls } from "../../../../data";
     <h3>Screen Reader</h3>
     <p>
         A screen reader <strong>must</strong> announce the label content,
-        including the energy rating and range. The figure role provides semantic context.
+        including the energy rating and range. The image role provides semantic context.
     </p>
     <h3>Pointer</h3>
     <p>
@@ -48,16 +48,16 @@ import { urls } from "../../../../data";
         </thead>
         <tbody>
             <tr>
-                <td><strong>role="figure"</strong></td>
+                <td><strong>role="img"</strong></td>
                 <td>
-                    Identifies the EEK as a figure element, providing semantic meaning
-                    for the graphical representation of the energy rating.
+                    Identifies the EEK as a labeled graphic so the accessible name is announced
+                    reliably across assistive technologies.
                 </td>
             </tr>
             <tr>
                 <td><strong>aria-label</strong></td>
                 <td>
-                    Provides the accessible name for the figure. (e.g., "Energy Rating: A+++. Range: A+++ - D").
+                    Provides the accessible name for the graphic. (e.g., "Energy Rating: A+++. Range: A+++ - D").
                 </td>
             </tr>
             <tr>
@@ -82,8 +82,8 @@ import { urls } from "../../../../data";
             </a>
         </li>
         <li>
-            <a href="https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/figure_role">
-                MDN: ARIA figure role
+            <a href="https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/img_role">
+                MDN: ARIA img role
             </a>
         </li>
         <li>

--- a/src/routes/_index/components/eek/css+page.marko
+++ b/src/routes/_index/components/eek/css+page.marko
@@ -146,7 +146,7 @@ import { table } from "../../../../sass/table.module.scss";
     <div class="demo__inner">
       <div
         class="eek eek--rating-1"
-        role="figure"
+        role="img"
         aria-label="Energy Rating: A+++. Range: A+++ - D">
         <div class="eek__container" aria-hidden="true">
           <span class="eek__rating-range">
@@ -170,7 +170,7 @@ import { table } from "../../../../sass/table.module.scss";
       </div>
       <div
         class="eek eek--rating-4"
-        role="figure"
+        role="img"
         aria-label="Energy Rating: B. Range: A++ - E">
         <div class="eek__container" aria-hidden="true">
           <span class="eek__rating-range">
@@ -194,7 +194,7 @@ import { table } from "../../../../sass/table.module.scss";
       </div>
       <div
         class="eek eek--rating-7"
-        role="figure"
+        role="img"
         aria-label="Energy Rating: G. Range: A+ - G">
         <div class="eek__container" aria-hidden="true">
           <span class="eek__rating-range">
@@ -221,7 +221,7 @@ import { table } from "../../../../sass/table.module.scss";
   <highlight-code type="html">
     <div
       class="eek eek--rating-1"
-      role="figure"
+      role="img"
       aria-label="Energy Rating: A+++. Range: A+++ - D">
       <div class="eek__container" aria-hidden="true">
         <span class="eek__rating-range">
@@ -245,7 +245,7 @@ import { table } from "../../../../sass/table.module.scss";
     </div>
     <div
       class="eek eek--rating-4"
-      role="figure"
+      role="img"
       aria-label="Energy Rating: B. Range: A++ - E">
       <div class="eek__container" aria-hidden="true">
         <span class="eek__rating-range">
@@ -269,7 +269,7 @@ import { table } from "../../../../sass/table.module.scss";
     </div>
     <div
       class="eek eek--rating-7"
-      role="figure"
+      role="img"
       aria-label="Energy Rating: G. Range: A+ - G">
       <div class="eek__container" aria-hidden="true">
         <span class="eek__rating-range">
@@ -305,7 +305,7 @@ import { table } from "../../../../sass/table.module.scss";
     <div class="demo__inner">
       <div
         class="eek eek--large eek--rating-1"
-        role="figure"
+        role="img"
         aria-label="Energy Rating: A+++. Range: A+++ - D">
         <div class="eek__container" aria-hidden="true">
           <span class="eek__rating-range">
@@ -329,7 +329,7 @@ import { table } from "../../../../sass/table.module.scss";
       </div>
       <div
         class="eek eek--large eek--rating-4"
-        role="figure"
+        role="img"
         aria-label="Energy Rating: B. Range: A++ - E">
         <div class="eek__container" aria-hidden="true">
           <span class="eek__rating-range">
@@ -353,7 +353,7 @@ import { table } from "../../../../sass/table.module.scss";
       </div>
       <div
         class="eek eek--large eek--rating-7"
-        role="figure"
+        role="img"
         aria-label="Energy Rating: G. Range: A+ - G">
         <div class="eek__container" aria-hidden="true">
           <span class="eek__rating-range">
@@ -380,7 +380,7 @@ import { table } from "../../../../sass/table.module.scss";
   <highlight-code type="html">
     <div
       class="eek eek--large eek--rating-1"
-      role="figure"
+      role="img"
       aria-label="Energy Rating: A+++. Range: A+++ - D">
       <div class="eek__container" aria-hidden="true">
         <span class="eek__rating-range">
@@ -404,7 +404,7 @@ import { table } from "../../../../sass/table.module.scss";
     </div>
     <div
       class="eek eek--large eek--rating-4"
-      role="figure"
+      role="img"
       aria-label="Energy Rating: B. Range: A++ - E">
       <div class="eek__container" aria-hidden="true">
         <span class="eek__rating-range">
@@ -428,7 +428,7 @@ import { table } from "../../../../sass/table.module.scss";
     </div>
     <div
       class="eek eek--large eek--rating-7"
-      role="figure"
+      role="img"
       aria-label="Energy Rating: G. Range: A+ - G">
       <div class="eek__container" aria-hidden="true">
         <span class="eek__rating-range">


### PR DESCRIPTION
<!-- Insert GitHub issue number below. An issue is required for all PRs -->

- Fixes #619

## Description

<!-- Briefly describe the proposed changes -->
Swapped role `figure` to `img`. With `role:figure` AT is not announcing the label consistently because the descendants are hidden.


## Checklist

<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->

- [x] I verify the linked issue has been triaged ("Needs Triage" label removed)
- [x] I verify all changes are within scope of the linked issue
- [x] I added/updated/removed testing (Storybook in Skin) coverage as appropriate

<!-- For CSS changes -->

- [ ] I tested the UI in all supported browsers
- [ ] I tested the UI in dark mode and RTL mode
