### PR TITLE
feat(evo-marko): alert & confirm dialog

### DIFF
--- a/.changeset/funky-pears-occur.md
+++ b/.changeset/funky-pears-occur.md
@@ -1,0 +1,5 @@
+---
+"@evo-web/marko": patch
+---
+
+Confirm & Alert Dialog

--- a/.claude/skills/evo-migrate-marko/SKILL.md
+++ b/.claude/skills/evo-migrate-marko/SKILL.md
@@ -132,6 +132,7 @@ Key changes:
 - **Remove `Omit<..., 'on${string}'>`** -- Marko 6 handles events natively via spread.
 - **Remove custom `on-*` event props** from the interface -- consumers bind native DOM events directly or use two-way binding callbacks (e.g., `valueChange`, `openChange`, `indexChange`).
 - **Use camelCase** for all prop names (not kebab-case).
+- **Use `Marko.HTML.*`** for element types -- e.g., `Marko.HTML.H2`, `Marko.HTML.Div`, `Marko.HTML.Button`. Do **not** use `Marko.Input<"h2">` or `Marko.Input<"div">`.
 - **Omit only props the component hardcodes** (e.g., `Omit<Marko.HTML.Input, "type" | "role">`).
 
 ### HTML attribute pass-through

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,10 @@ HTML Semantic Structure → @ebay/skin (CSS/BEM) → Framework Components → In
 - ✅ Attribute values containing `>` MUST be wrapped in parentheses: `<const/x=(a > b ? 1 : 0)>`
 - ❌ Never: `<const/x=a > b ? 1 : 0>` (the `>` is parsed as the tag close)
 
+**Marko 6 Tag Variable Locality:**
+
+Declare `<const/>`, `<let/>`, `<id/>`, and other tag variables close to where they are first used, not grouped at the top. Exception is variables needed in multiple distant locations.
+
 **React Package Differences:**
 
 - `ebayui-core-react`: Requires `React.forwardRef` wrapper

--- a/packages/evo-marko/src/tags/evo-alert-dialog/README.md
+++ b/packages/evo-marko/src/tags/evo-alert-dialog/README.md
@@ -1,0 +1,18 @@
+<h1 style='display: flex; justify-content: space-between; align-items: center;'>
+    <span>
+        evo-alert-dialog
+    </span>
+    <span style='font-weight: normal; font-size: medium; margin-bottom: -15px;'>
+        DS vBETA
+    </span>
+</h1>
+
+An alert dialog that forces the user to acknowledge a message before continuing. The dialog can only be dismissed by clicking the confirm button -- Escape and backdrop clicks are blocked.
+
+Uses a native `<dialog>` element with `role="alertdialog"` and `closedby="none"`.
+
+## Examples and Documentation
+
+- [Storybook](https://ebay.github.io/evo-web/evo-marko/?path=/story/navigation-disclosure-evo-alert-dialog)
+- [Storybook Docs](https://ebay.github.io/evo-web/evo-marko/?path=/docs/navigation-disclosure-evo-alert-dialog)
+- [Code Examples](https://github.com/eBay/evo-web/tree/main/packages/evo-marko/src/tags/evo-alert-dialog/examples)

--- a/packages/evo-marko/src/tags/evo-alert-dialog/alert-dialog.stories.ts
+++ b/packages/evo-marko/src/tags/evo-alert-dialog/alert-dialog.stories.ts
@@ -1,0 +1,58 @@
+import { buildExtensionTemplate } from "../../common/storybook/utils";
+import { type Meta } from "@storybook/marko";
+import Readme from "./README.md";
+import Component, { type Input } from "./index.marko";
+import DefaultTemplate from "./examples/default.marko";
+import DefaultCode from "./examples/default.marko?raw";
+
+export default {
+  title: "navigation & disclosure/evo-alert-dialog",
+  component: Component,
+  parameters: {
+    docs: {
+      description: {
+        component: Readme,
+      },
+    },
+  },
+
+  argTypes: {
+    open: {
+      type: "boolean",
+      controllable: true,
+      description: "Whether the alert dialog is open",
+      table: { defaultValue: { summary: "false" } },
+    },
+    header: {
+      description:
+        "The header content rendered inside the dialog title (required)",
+      "@": {
+        as: {
+          type: "string",
+          description:
+            "The heading element to use for the title. Defaults to `h2`",
+        },
+        ["<h2> attributes" as any]: {
+          description:
+            "All attributes and event handlers from the heading element will be passed through",
+        },
+      },
+    },
+    confirm: {
+      description:
+        "The confirm/acknowledge button (required). Render body is the button label text",
+      "@": {
+        ["<button> attributes" as any]: {
+          description:
+            "All attributes and event handlers from [the native HTML `<button>` tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/button) will be passed through",
+        },
+      },
+    },
+    ["<dialog> attributes" as any]: {
+      description:
+        "All attributes and event handlers from [the native HTML `<dialog>` tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dialog) will be passed through",
+    },
+  },
+} satisfies Meta<Input>;
+
+export const Default = buildExtensionTemplate(DefaultTemplate, DefaultCode);

--- a/packages/evo-marko/src/tags/evo-alert-dialog/examples/default.marko
+++ b/packages/evo-marko/src/tags/evo-alert-dialog/examples/default.marko
@@ -1,0 +1,14 @@
+import { type Input as AlertDialogInput } from "<evo-alert-dialog>";
+export interface Input extends AlertDialogInput {}
+
+<let/open:=input.open>
+
+<evo-button onClick() { open = true; }>
+    Open Alert Dialog
+</evo-button>
+
+<evo-alert-dialog ...input open:=open>
+    <@header>Alert!</@header>
+    <@confirm>OK</@confirm>
+    <p>You must acknowledge this alert to continue.</p>
+</evo-alert-dialog>

--- a/packages/evo-marko/src/tags/evo-alert-dialog/index.marko
+++ b/packages/evo-marko/src/tags/evo-alert-dialog/index.marko
@@ -1,0 +1,79 @@
+import { type Input as ButtonInput } from "<evo-button>";
+
+export interface Input extends Omit<Marko.HTML.Dialog, "open" | "closedby" | "role" | "aria-labelledby"> {
+  open?: boolean;
+  openChange?: (o: boolean) => void;
+  header: Marko.AttrTag<Marko.HTML.H2 & { as?: string }>;
+  confirm: Marko.AttrTag<ButtonInput>;
+}
+
+<const/{
+  open: inputOpen,
+  openChange,
+  class: inputClass,
+  header,
+  confirm,
+  content,
+  onCancel,
+  onAnimationEnd,
+  ...htmlInput
+}=input>
+
+<let/open:=input.open>
+<id/headerId=header.id>
+
+<script>
+  if (open && !$dialog().open) {
+    $dialog().showModal();
+  }
+</script>
+
+<dialog/$dialog
+  ...htmlInput
+  open=null // tell Marko it's not a part of the spread because the browser does DOM manipulation
+  role="alertdialog"
+  closedby="none"
+  aria-labelledby=headerId
+  class=[
+    "dialog",
+    "dialog--narrow",
+    !open && "dialog--close",
+    inputClass,
+  ]
+  onCancel(e, el) {
+    e.preventDefault();
+    onCancel && onCancel(e, el);
+  }
+  onAnimationEnd(e, el) {
+    if (!open) {
+      el.close();
+    }
+    onAnimationEnd && onAnimationEnd(e, el);
+  }
+>
+  <div class="dialog__header">
+    <const/{ as: headerAs = "h2", ...headerInput }=header>
+    <${headerAs}
+      ...headerInput
+      id=headerId
+      class=["dialog__title", headerInput.class]
+    />
+  </div>
+  <id/mainId>
+  <div id=mainId class="dialog__main">
+    <${content}/>
+  </div>
+  <div class="dialog__footer">
+    <const/{ onClick: confirmOnClick, ...confirmInput }=confirm>
+    <evo-button
+      ...confirmInput
+      priority="primary"
+      autofocus
+      aria-describedby=mainId
+      onClick(e, el) {
+        open = false;
+        confirmOnClick && confirmOnClick(e, el);
+      }
+    />
+  </div>
+</dialog>

--- a/packages/evo-marko/src/tags/evo-alert-dialog/index.marko
+++ b/packages/evo-marko/src/tags/evo-alert-dialog/index.marko
@@ -1,6 +1,6 @@
 import { type Input as ButtonInput } from "<evo-button>";
 
-export interface Input extends Omit<Marko.HTML.Dialog, "open" | "closedby" | "role" | "aria-labelledby"> {
+export interface Input extends Omit<Marko.HTML.Dialog, "open" | "closedby" | "role" | "aria-labelledby" | "aria-modal"> {
   open?: boolean;
   openChange?: (o: boolean) => void;
   header: Marko.AttrTag<Marko.HTML.H2 & { as?: string }>;
@@ -32,6 +32,7 @@ export interface Input extends Omit<Marko.HTML.Dialog, "open" | "closedby" | "ro
   ...htmlInput
   open=null // tell Marko it's not a part of the spread because the browser does DOM manipulation
   role="alertdialog"
+  aria-modal="true"
   closedby="none"
   aria-labelledby=headerId
   class=[

--- a/packages/evo-marko/src/tags/evo-alert-dialog/index.marko
+++ b/packages/evo-marko/src/tags/evo-alert-dialog/index.marko
@@ -14,7 +14,6 @@ export interface Input extends Omit<Marko.HTML.Dialog, "open" | "closedby" | "ro
   header,
   confirm,
   content,
-  onCancel,
   onAnimationEnd,
   ...htmlInput
 }=input>
@@ -41,10 +40,6 @@ export interface Input extends Omit<Marko.HTML.Dialog, "open" | "closedby" | "ro
     !open && "dialog--close",
     inputClass,
   ]
-  onCancel(e, el) {
-    e.preventDefault();
-    onCancel && onCancel(e, el);
-  }
   onAnimationEnd(e, el) {
     if (!open) {
       el.close();

--- a/packages/evo-marko/src/tags/evo-alert-dialog/style.ts
+++ b/packages/evo-marko/src/tags/evo-alert-dialog/style.ts
@@ -1,0 +1,1 @@
+import "@ebay/skin/dialog";

--- a/packages/evo-marko/src/tags/evo-alert-dialog/test/test.browser.ts
+++ b/packages/evo-marko/src/tags/evo-alert-dialog/test/test.browser.ts
@@ -1,0 +1,137 @@
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  it,
+  expect,
+} from "vitest";
+import { render, fireEvent, waitFor, cleanup } from "@marko/testing-library";
+import { userEvent } from "vitest/browser";
+import { composeStories } from "@storybook/marko";
+import { fastAnimations } from "../../../common/test-utils/index";
+import * as stories from "../alert-dialog.stories";
+
+const { Default } = composeStories(stories);
+
+beforeAll(() => fastAnimations.start());
+afterAll(() => fastAnimations.stop());
+afterEach(cleanup);
+
+let component: Awaited<ReturnType<typeof render>>;
+
+describe("evo-alert-dialog", () => {
+  describe("given the dialog is in the default (closed) state", () => {
+    beforeEach(async () => {
+      component = await render(Default);
+    });
+
+    it("should render with a dialog element", () => {
+      expect(component.container.querySelector("dialog")).toBeTruthy();
+    });
+
+    it("should have the dialog class", () => {
+      const dialog = component.container.querySelector("dialog");
+      expect(dialog?.classList.contains("dialog")).toBe(true);
+    });
+
+    it("should have dialog--close class when not open", () => {
+      const dialog = component.container.querySelector("dialog");
+      expect(dialog?.classList.contains("dialog--close")).toBe(true);
+    });
+
+    it("should have dialog--narrow class", () => {
+      const dialog = component.container.querySelector("dialog");
+      expect(dialog?.classList.contains("dialog--narrow")).toBe(true);
+    });
+  });
+
+  describe("given the dialog is in the open state", () => {
+    beforeEach(async () => {
+      component = await render(Default, { open: true });
+    });
+
+    it("should render the dialog element", () => {
+      const dialog = component.container.querySelector("dialog");
+      expect(dialog).toBeTruthy();
+    });
+
+    it("should not have dialog--close class when open", () => {
+      const dialog = component.container.querySelector("dialog");
+      expect(dialog?.classList.contains("dialog")).toBe(true);
+      expect(dialog?.classList.contains("dialog--close")).toBe(false);
+    });
+
+    it("should have role alertdialog", () => {
+      const dialog = component.container.querySelector("dialog");
+      expect(dialog?.getAttribute("role")).toBe("alertdialog");
+    });
+
+    it("should have aria-modal set to true", () => {
+      const dialog = component.container.querySelector("dialog");
+      expect(dialog?.getAttribute("aria-modal")).toBe("true");
+    });
+
+    it("should have closedby set to none", () => {
+      const dialog = component.container.querySelector("dialog");
+      expect(dialog?.getAttribute("closedby")).toBe("none");
+    });
+
+    it("should render header with h2 by default", () => {
+      const title = component.container.querySelector(".dialog__title");
+      expect(title).toBeTruthy();
+      expect(title?.tagName.toLowerCase()).toBe("h2");
+    });
+
+    it("should link dialog to header via aria-labelledby", () => {
+      const dialog = component.container.querySelector("dialog");
+      const title = component.container.querySelector(".dialog__title");
+      const titleId = title?.id;
+      expect(titleId).toBeTruthy();
+      expect(dialog?.getAttribute("aria-labelledby")).toBe(titleId);
+    });
+
+    it("should render the confirm button", () => {
+      const button = component.getByRole("button", { name: "OK" });
+      expect(button).toBeTruthy();
+    });
+
+    it("should have aria-describedby on the confirm button referencing main content", () => {
+      const button = component.getByRole("button", { name: "OK" });
+      const describedBy = button.getAttribute("aria-describedby");
+      expect(describedBy).toBeTruthy();
+      const mainEl = document.getElementById(describedBy!);
+      expect(mainEl).toBeTruthy();
+      expect(mainEl?.textContent).toContain(
+        "You must acknowledge this alert to continue.",
+      );
+    });
+
+    it("should render main content area", () => {
+      const main = component.container.querySelector(".dialog__main");
+      expect(main).toBeTruthy();
+    });
+
+    describe("when the confirm button is clicked", () => {
+      it("should close the dialog", async () => {
+        await fireEvent.click(
+          component.getByRole("button", { name: "OK" }),
+        );
+        const dialog = component.container.querySelector("dialog");
+        expect(dialog?.classList.contains("dialog--close")).toBe(true);
+      });
+    });
+
+    describe("when Escape key is pressed", () => {
+      it("should not close the dialog", async () => {
+        const user = userEvent.setup();
+        const button = component.getByRole("button", { name: "OK" });
+        button.focus();
+        await user.keyboard("{Escape}");
+        const dialog = component.container.querySelector("dialog");
+        expect(dialog?.classList.contains("dialog--close")).toBe(false);
+      });
+    });
+  });
+});

--- a/packages/evo-marko/src/tags/evo-alert-dialog/test/test.browser.ts
+++ b/packages/evo-marko/src/tags/evo-alert-dialog/test/test.browser.ts
@@ -7,7 +7,7 @@ import {
   it,
   expect,
 } from "vitest";
-import { render, fireEvent, waitFor, cleanup } from "@marko/testing-library";
+import { render, fireEvent, cleanup } from "@marko/testing-library";
 import { userEvent } from "vitest/browser";
 import { composeStories } from "@storybook/marko";
 import { fastAnimations } from "../../../common/test-utils/index";

--- a/packages/evo-marko/src/tags/evo-alert-dialog/test/test.server.ts
+++ b/packages/evo-marko/src/tags/evo-alert-dialog/test/test.server.ts
@@ -1,0 +1,16 @@
+import { describe, it } from "vitest";
+import { composeStories } from "@storybook/marko";
+import { snapshotHTML } from "../../../common/test-utils/snapshots";
+import * as stories from "../alert-dialog.stories";
+
+const { Default } = composeStories(stories);
+
+describe("evo-alert-dialog SSR", () => {
+  it("renders default (closed)", async () => {
+    await snapshotHTML(Default);
+  });
+
+  it("renders in open state", async () => {
+    await snapshotHTML(Default, { open: true });
+  });
+});

--- a/packages/evo-marko/src/tags/evo-confirm-dialog/README.md
+++ b/packages/evo-marko/src/tags/evo-confirm-dialog/README.md
@@ -7,9 +7,9 @@
     </span>
 </h1>
 
-A confirm dialog that forces the user to make a choice to either confirm or reject. The dialog can only be dismissed by clicking one of the two buttons. Pressing Escape triggers the reject action.
+A confirm dialog that forces the user to make a choice to either confirm or reject. The dialog can be dismissed by clicking one of the two buttons, and pressing Escape triggers the reject action.
 
-Uses a native `<dialog>` element with `role="alertdialog"` and `closedby="none"`.
+Uses a native `<dialog>` element with `role="alertdialog"` and `closedby="closerequest"`.
 
 ## Examples and Documentation
 

--- a/packages/evo-marko/src/tags/evo-confirm-dialog/README.md
+++ b/packages/evo-marko/src/tags/evo-confirm-dialog/README.md
@@ -1,0 +1,18 @@
+<h1 style='display: flex; justify-content: space-between; align-items: center;'>
+    <span>
+        evo-confirm-dialog
+    </span>
+    <span style='font-weight: normal; font-size: medium; margin-bottom: -15px;'>
+        DS vBETA
+    </span>
+</h1>
+
+A confirm dialog that forces the user to make a choice to either confirm or reject. The dialog can only be dismissed by clicking one of the two buttons. Pressing Escape triggers the reject action.
+
+Uses a native `<dialog>` element with `role="alertdialog"` and `closedby="none"`.
+
+## Examples and Documentation
+
+- [Storybook](https://ebay.github.io/evo-web/evo-marko/?path=/story/navigation-disclosure-evo-confirm-dialog)
+- [Storybook Docs](https://ebay.github.io/evo-web/evo-marko/?path=/docs/navigation-disclosure-evo-confirm-dialog)
+- [Code Examples](https://github.com/eBay/evo-web/tree/main/packages/evo-marko/src/tags/evo-confirm-dialog/examples)

--- a/packages/evo-marko/src/tags/evo-confirm-dialog/confirm-dialog.stories.ts
+++ b/packages/evo-marko/src/tags/evo-confirm-dialog/confirm-dialog.stories.ts
@@ -62,6 +62,12 @@ export default {
       description:
         "All attributes and event handlers from [the native HTML `<dialog>` tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dialog) will be passed through",
     },
+    onCancel: {
+      action: "onCancel",
+      description:
+        "Triggered when the dialog's cancel event fires, via `esc` or the cancel button",
+      table: { category: "Events" },
+    },
   },
 } satisfies Meta<Input>;
 

--- a/packages/evo-marko/src/tags/evo-confirm-dialog/confirm-dialog.stories.ts
+++ b/packages/evo-marko/src/tags/evo-confirm-dialog/confirm-dialog.stories.ts
@@ -1,0 +1,68 @@
+import { buildExtensionTemplate } from "../../common/storybook/utils";
+import { type Meta } from "@storybook/marko";
+import Readme from "./README.md";
+import Component, { type Input } from "./index.marko";
+import DefaultTemplate from "./examples/default.marko";
+import DefaultCode from "./examples/default.marko?raw";
+
+export default {
+  title: "navigation & disclosure/evo-confirm-dialog",
+  component: Component,
+  parameters: {
+    docs: {
+      description: {
+        component: Readme,
+      },
+    },
+  },
+
+  argTypes: {
+    open: {
+      type: "boolean",
+      controllable: true,
+      description: "Whether the confirm dialog is open",
+      table: { defaultValue: { summary: "false" } },
+    },
+    header: {
+      description:
+        "The header content rendered inside the dialog title (required)",
+      "@": {
+        as: {
+          type: "string",
+          description:
+            "The heading element to use for the title. Defaults to `h2`",
+        },
+        ["<h2> attributes" as any]: {
+          description:
+            "All attributes and event handlers from the heading element will be passed through",
+        },
+      },
+    },
+    confirm: {
+      description:
+        "The confirm button (required). Render body is the button label text",
+      "@": {
+        ["<button> attributes" as any]: {
+          description:
+            "All attributes and event handlers from [the native HTML `<button>` tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/button) will be passed through",
+        },
+      },
+    },
+    reject: {
+      description:
+        "The reject/cancel button (required). Render body is the button label text. Also triggered by Escape key",
+      "@": {
+        ["<button> attributes" as any]: {
+          description:
+            "All attributes and event handlers from [the native HTML `<button>` tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/button) will be passed through",
+        },
+      },
+    },
+    ["<dialog> attributes" as any]: {
+      description:
+        "All attributes and event handlers from [the native HTML `<dialog>` tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dialog) will be passed through",
+    },
+  },
+} satisfies Meta<Input>;
+
+export const Default = buildExtensionTemplate(DefaultTemplate, DefaultCode);

--- a/packages/evo-marko/src/tags/evo-confirm-dialog/examples/default.marko
+++ b/packages/evo-marko/src/tags/evo-confirm-dialog/examples/default.marko
@@ -1,0 +1,15 @@
+import { type Input as ConfirmDialogInput } from "<evo-confirm-dialog>";
+export interface Input extends ConfirmDialogInput {}
+
+<let/open:=input.open>
+
+<evo-button onClick() { open = true; }>
+    Open Confirm Dialog
+</evo-button>
+
+<evo-confirm-dialog ...input open:=open>
+    <@header>Delete Address?</@header>
+    <@reject>Cancel</@reject>
+    <@confirm>Delete</@confirm>
+    <p>You will permanently lose this address.</p>
+</evo-confirm-dialog>

--- a/packages/evo-marko/src/tags/evo-confirm-dialog/index.marko
+++ b/packages/evo-marko/src/tags/evo-confirm-dialog/index.marko
@@ -1,6 +1,6 @@
 import { type Input as ButtonInput } from "<evo-button>";
 
-export interface Input extends Omit<Marko.HTML.Dialog, "open" | "role" | "aria-labelledby"> {
+export interface Input extends Omit<Marko.HTML.Dialog, "open" | "role" | "aria-labelledby" | "aria-modal"> {
   open?: boolean;
   openChange?: (o: boolean) => void;
   header: Marko.AttrTag<Marko.HTML.H2 & { as?: string }>;
@@ -35,6 +35,7 @@ export interface Input extends Omit<Marko.HTML.Dialog, "open" | "role" | "aria-l
   ...htmlInput
   open=null // tell Marko it's not a part of the spread because the browser does DOM manipulation
   role="alertdialog"
+  aria-modal="true"
   closedby=closedby
   aria-labelledby=headerId
   class=[
@@ -46,7 +47,6 @@ export interface Input extends Omit<Marko.HTML.Dialog, "open" | "role" | "aria-l
   onCancel(e, el) {
     e.preventDefault();
     open = false;
-    reject.onClick && reject.onClick(e as any, el as any);
     onCancel && onCancel(e, el);
   }
   onAnimationEnd(e, el) {

--- a/packages/evo-marko/src/tags/evo-confirm-dialog/index.marko
+++ b/packages/evo-marko/src/tags/evo-confirm-dialog/index.marko
@@ -1,0 +1,92 @@
+import { type Input as ButtonInput } from "<evo-button>";
+
+export interface Input extends Omit<Marko.HTML.Dialog, "open" | "role" | "aria-labelledby"> {
+  open?: boolean;
+  openChange?: (o: boolean) => void;
+  header: Marko.AttrTag<Marko.HTML.H2 & { as?: string }>;
+  confirm: Marko.AttrTag<ButtonInput>;
+  reject: Marko.AttrTag<ButtonInput>;
+}
+
+<const/{
+  open: inputOpen,
+  openChange,
+  class: inputClass,
+  header,
+  confirm,
+  reject,
+  content,
+  closedby = "closerequest",
+  onCancel,
+  onAnimationEnd,
+  ...htmlInput
+}=input>
+
+<let/open:=input.open>
+<id/headerId=header.id>
+
+<script>
+  if (open && !$dialog().open) {
+    $dialog().showModal();
+  }
+</script>
+
+<dialog/$dialog
+  ...htmlInput
+  open=null // tell Marko it's not a part of the spread because the browser does DOM manipulation
+  role="alertdialog"
+  closedby=closedby
+  aria-labelledby=headerId
+  class=[
+    "dialog",
+    "dialog--narrow",
+    !open && "dialog--close",
+    inputClass,
+  ]
+  onCancel(e, el) {
+    e.preventDefault();
+    open = false;
+    reject.onClick && reject.onClick(e as any, el as any);
+    onCancel && onCancel(e, el);
+  }
+  onAnimationEnd(e, el) {
+    if (!open) {
+      el.close();
+    }
+    onAnimationEnd && onAnimationEnd(e, el);
+  }
+>
+  <div class="dialog__header">
+    <const/{ as: headerAs = "h2", ...headerInput }=header>
+    <${headerAs}
+      ...headerInput
+      id=headerId
+      class=["dialog__title", headerInput.class]
+    />
+  </div>
+  <id/mainId>
+  <div id=mainId class="dialog__main">
+    <${content}/>
+  </div>
+  <div class="dialog__footer">
+    <const/{ onClick: rejectOnClick, ...rejectInput }=reject>
+    <evo-button
+      ...rejectInput
+      onClick(e, el) {
+        open = false;
+        rejectOnClick && rejectOnClick(e, el);
+      }
+    />
+    <const/{ onClick: confirmOnClick, ...confirmInput }=confirm>
+    <evo-button
+      ...confirmInput
+      priority="primary"
+      autofocus
+      aria-describedby=mainId
+      onClick(e, el) {
+        open = false;
+        confirmOnClick && confirmOnClick(e, el);
+      }
+    />
+  </div>
+</dialog>

--- a/packages/evo-marko/src/tags/evo-confirm-dialog/index.marko
+++ b/packages/evo-marko/src/tags/evo-confirm-dialog/index.marko
@@ -73,7 +73,7 @@ export interface Input extends Omit<Marko.HTML.Dialog, "open" | "role" | "aria-l
     <evo-button
       ...rejectInput
       onClick(e, el) {
-        open = false;
+        $dialog().requestClose();
         rejectOnClick && rejectOnClick(e, el);
       }
     />

--- a/packages/evo-marko/src/tags/evo-confirm-dialog/style.ts
+++ b/packages/evo-marko/src/tags/evo-confirm-dialog/style.ts
@@ -1,0 +1,1 @@
+import "@ebay/skin/dialog";

--- a/packages/evo-marko/src/tags/evo-confirm-dialog/test/test.browser.ts
+++ b/packages/evo-marko/src/tags/evo-confirm-dialog/test/test.browser.ts
@@ -1,0 +1,152 @@
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  it,
+  expect,
+} from "vitest";
+import { render, fireEvent, cleanup } from "@marko/testing-library";
+import { userEvent } from "vitest/browser";
+import { composeStories } from "@storybook/marko";
+import { fastAnimations } from "../../../common/test-utils/index";
+import * as stories from "../confirm-dialog.stories";
+
+const { Default } = composeStories(stories);
+
+beforeAll(() => fastAnimations.start());
+afterAll(() => fastAnimations.stop());
+afterEach(cleanup);
+
+let component: Awaited<ReturnType<typeof render>>;
+
+describe("evo-confirm-dialog", () => {
+  describe("given the dialog is in the default (closed) state", () => {
+    beforeEach(async () => {
+      component = await render(Default);
+    });
+
+    it("should render with a dialog element", () => {
+      expect(component.container.querySelector("dialog")).toBeTruthy();
+    });
+
+    it("should have the dialog class", () => {
+      const dialog = component.container.querySelector("dialog");
+      expect(dialog?.classList.contains("dialog")).toBe(true);
+    });
+
+    it("should have dialog--close class when not open", () => {
+      const dialog = component.container.querySelector("dialog");
+      expect(dialog?.classList.contains("dialog--close")).toBe(true);
+    });
+
+    it("should have dialog--narrow class", () => {
+      const dialog = component.container.querySelector("dialog");
+      expect(dialog?.classList.contains("dialog--narrow")).toBe(true);
+    });
+  });
+
+  describe("given the dialog is in the open state", () => {
+    beforeEach(async () => {
+      component = await render(Default, { open: true });
+    });
+
+    it("should render the dialog element", () => {
+      const dialog = component.container.querySelector("dialog");
+      expect(dialog).toBeTruthy();
+    });
+
+    it("should not have dialog--close class when open", () => {
+      const dialog = component.container.querySelector("dialog");
+      expect(dialog?.classList.contains("dialog")).toBe(true);
+      expect(dialog?.classList.contains("dialog--close")).toBe(false);
+    });
+
+    it("should have role alertdialog", () => {
+      const dialog = component.container.querySelector("dialog");
+      expect(dialog?.getAttribute("role")).toBe("alertdialog");
+    });
+
+    it("should have aria-modal set to true", () => {
+      const dialog = component.container.querySelector("dialog");
+      expect(dialog?.getAttribute("aria-modal")).toBe("true");
+    });
+
+    it("should have closedby set to none", () => {
+      const dialog = component.container.querySelector("dialog");
+      expect(dialog?.getAttribute("closedby")).toBe("none");
+    });
+
+    it("should render header with h2 by default", () => {
+      const title = component.container.querySelector(".dialog__title");
+      expect(title).toBeTruthy();
+      expect(title?.tagName.toLowerCase()).toBe("h2");
+    });
+
+    it("should link dialog to header via aria-labelledby", () => {
+      const dialog = component.container.querySelector("dialog");
+      const title = component.container.querySelector(".dialog__title");
+      const titleId = title?.id;
+      expect(titleId).toBeTruthy();
+      expect(dialog?.getAttribute("aria-labelledby")).toBe(titleId);
+    });
+
+    it("should render the confirm button", () => {
+      const button = component.getByRole("button", { name: "Delete" });
+      expect(button).toBeTruthy();
+    });
+
+    it("should render the reject button", () => {
+      const button = component.getByRole("button", { name: "Cancel" });
+      expect(button).toBeTruthy();
+    });
+
+    it("should have aria-describedby on the confirm button referencing main content", () => {
+      const button = component.getByRole("button", { name: "Delete" });
+      const describedBy = button.getAttribute("aria-describedby");
+      expect(describedBy).toBeTruthy();
+      const mainEl = document.getElementById(describedBy!);
+      expect(mainEl).toBeTruthy();
+      expect(mainEl?.textContent).toContain(
+        "You will permanently lose this address.",
+      );
+    });
+
+    it("should render main content area", () => {
+      const main = component.container.querySelector(".dialog__main");
+      expect(main).toBeTruthy();
+    });
+
+    describe("when the confirm button is clicked", () => {
+      it("should close the dialog", async () => {
+        await fireEvent.click(
+          component.getByRole("button", { name: "Delete" }),
+        );
+        const dialog = component.container.querySelector("dialog");
+        expect(dialog?.classList.contains("dialog--close")).toBe(true);
+      });
+    });
+
+    describe("when the reject button is clicked", () => {
+      it("should close the dialog", async () => {
+        await fireEvent.click(
+          component.getByRole("button", { name: "Cancel" }),
+        );
+        const dialog = component.container.querySelector("dialog");
+        expect(dialog?.classList.contains("dialog--close")).toBe(true);
+      });
+    });
+
+    describe("when Escape key is pressed", () => {
+      it("should close the dialog (triggers reject)", async () => {
+        const user = userEvent.setup();
+        const button = component.getByRole("button", { name: "Delete" });
+        button.focus();
+        await user.keyboard("{Escape}");
+        const dialog = component.container.querySelector("dialog");
+        expect(dialog?.classList.contains("dialog--close")).toBe(true);
+      });
+    });
+  });
+});

--- a/packages/evo-marko/src/tags/evo-confirm-dialog/test/test.browser.ts
+++ b/packages/evo-marko/src/tags/evo-confirm-dialog/test/test.browser.ts
@@ -73,9 +73,9 @@ describe("evo-confirm-dialog", () => {
       expect(dialog?.getAttribute("aria-modal")).toBe("true");
     });
 
-    it("should have closedby set to none", () => {
+    it('should have closedby set to "closerequest" by default', () => {
       const dialog = component.container.querySelector("dialog");
-      expect(dialog?.getAttribute("closedby")).toBe("none");
+      expect(dialog?.getAttribute("closedby")).toBe("closerequest");
     });
 
     it("should render header with h2 by default", () => {

--- a/packages/evo-marko/src/tags/evo-confirm-dialog/test/test.server.ts
+++ b/packages/evo-marko/src/tags/evo-confirm-dialog/test/test.server.ts
@@ -1,0 +1,16 @@
+import { describe, it } from "vitest";
+import { composeStories } from "@storybook/marko";
+import { snapshotHTML } from "../../../common/test-utils/snapshots";
+import * as stories from "../confirm-dialog.stories";
+
+const { Default } = composeStories(stories);
+
+describe("evo-confirm-dialog SSR", () => {
+  it("renders default (closed)", async () => {
+    await snapshotHTML(Default);
+  });
+
+  it("renders in open state", async () => {
+    await snapshotHTML(Default, { open: true });
+  });
+});

--- a/packages/evo-marko/src/tags/evo-dialog/dialog.stories.ts
+++ b/packages/evo-marko/src/tags/evo-dialog/dialog.stories.ts
@@ -70,6 +70,10 @@ export default {
       description:
         "Close button rendered in the dialog header (required). Pass `a11yText` for the accessible label",
       "@": {
+        a11yText: {
+          type: { name: "string", required: true },
+          description: "Accessible label for the close button",
+        },
         ["<button> attributes" as any]: {
           description:
             "All attributes and event handlers from [the native HTML `<button>` tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/button) will be passed through",
@@ -80,7 +84,7 @@ export default {
       description: "Optional previous/back button rendered in the header",
       "@": {
         a11yText: {
-          type: "string",
+          type: { name: "string", required: true },
           description: "Accessible label for the previous button",
         },
         ["<button> attributes" as any]: {


### PR DESCRIPTION
## Description

- Add `<evo-alert-dialog>` and `<evo-confirm-dialog>`

## Notes

- The real question here is should these be separate components? Since they are so common and there is slightly different behavior for each of them I think there's value in keeping them apart, but this is up for debate.
- I also modified some AI instructions to make sure code follows best practices moving forward

## Screenshots

<img width="378" height="208" alt="image" src="https://github.com/user-attachments/assets/b974e135-74bc-4637-b78f-cef84a5ac209" />
<img width="1031" height="865" alt="image" src="https://github.com/user-attachments/assets/a5652b5d-dfc8-43bc-b896-fb4bd6330f75" />
