### PR TITLE
docs(evo-marko): add color scheme selector to storybook

### DIFF
--- a/packages/evo-marko/.storybook/manager.ts
+++ b/packages/evo-marko/.storybook/manager.ts
@@ -1,4 +1,0 @@
-import { addons } from "storybook/manager-api";
-import theme from "./theme";
-
-addons.setConfig({ theme });

--- a/packages/evo-marko/.storybook/manager.tsx
+++ b/packages/evo-marko/.storybook/manager.tsx
@@ -1,0 +1,78 @@
+import React from "react";
+import { addons, types, useGlobals } from "storybook/manager-api";
+import { Select } from "storybook/internal/components";
+import { MoonIcon, SunIcon } from "@storybook/icons";
+import theme from "./theme";
+
+addons.setConfig({ theme });
+
+const ADDON_ID = "evo/color-scheme-toggle";
+const GLOBAL_KEY = "colorScheme";
+
+const options = [
+  { title: "Light", value: "light" },
+  { title: "Dark", value: "dark" },
+];
+
+// Module-level so the MutationObserver can read the current value outside React.
+let currentScheme: string | undefined;
+
+function applyToIframe() {
+  const iframe = document.getElementById(
+    "storybook-preview-iframe",
+  ) as HTMLIFrameElement | null;
+  if (!iframe) return;
+  const desired = currentScheme ?? "light dark";
+  if (iframe.style.colorScheme !== desired) {
+    iframe.style.colorScheme = desired;
+  }
+}
+
+// Re-apply on any DOM mutation. getElementById + a string comparison is
+// essentially free, and this catches every edge case: iframe recreation,
+// React reconciliation resetting styles, deferred attribute setting, etc.
+new MutationObserver(applyToIframe).observe(document.documentElement, {
+  childList: true,
+  subtree: true,
+});
+
+const ColorSchemeTool = () => {
+  const [globals, updateGlobals] = useGlobals();
+  const current: string | undefined = globals[GLOBAL_KEY];
+
+  // Sync persisted globals → module variable on every render.
+  // Skip undefined during view-mode transitions to avoid clobbering
+  // an active selection. The onReset callback handles intentional resets.
+  if (current !== undefined) {
+    currentScheme = current;
+  }
+  applyToIframe();
+
+  return (
+    <Select
+      icon={current === "dark" ? <MoonIcon /> : <SunIcon />}
+      ariaLabel="Color scheme"
+      tooltip="Change color scheme"
+      resetLabel="System"
+      onReset={() => {
+        currentScheme = undefined;
+        updateGlobals({ [GLOBAL_KEY]: undefined });
+      }}
+      defaultOptions={current}
+      options={options}
+      onSelect={(value) => {
+        currentScheme = value;
+        updateGlobals({ [GLOBAL_KEY]: value });
+      }}
+    />
+  );
+};
+
+addons.register(ADDON_ID, () => {
+  addons.add(ADDON_ID, {
+    type: types.TOOL,
+    title: "Color scheme",
+    match: ({ viewMode }) => viewMode === "story" || viewMode === "docs",
+    render: () => <ColorSchemeTool />,
+  });
+});

--- a/packages/evo-marko/.storybook/preview.ts
+++ b/packages/evo-marko/.storybook/preview.ts
@@ -11,6 +11,9 @@ import theme from "./theme";
 
 export default {
   tags: ["autodocs"],
+  globalTypes: {
+    colorScheme: {},
+  },
   parameters: {
     layout: "centered",
     controls: { expanded: true, sort: "requiredFirst" },


### PR DESCRIPTION
<img width="281" height="174" alt="image" src="https://github.com/user-attachments/assets/99ce2578-5a5b-4e9c-9f07-b5616656dc89" />
<img width="282" height="168" alt="image" src="https://github.com/user-attachments/assets/5fd83f3c-d9b6-46bf-ba5d-739eb7574239" />

---

- Add a color scheme selector to the evo-marko storybook
- Apparently storybook doesn't have this built in, so I needed to make a custom plugin. There's some hacky stuff to prevent FOUC, but it does the job and it's fairly minimal so since this doesn't impact anybody downstream I think it's safe to keep