### PR TITLE
feat(evo-marko): evo-toast-dialog

### DIFF
--- a/.changeset/wide-apples-build.md
+++ b/.changeset/wide-apples-build.md
@@ -1,0 +1,6 @@
+---
+"@evo-web/marko": patch
+"@ebay/skin": patch
+---
+
+Add `<evo-toast-dialog>`

--- a/packages/evo-marko/src/tags/evo-alert-dialog/index.marko
+++ b/packages/evo-marko/src/tags/evo-alert-dialog/index.marko
@@ -41,7 +41,7 @@ export interface Input extends Omit<Marko.HTML.Dialog, "open" | "closedby" | "ro
     inputClass,
   ]
   onAnimationEnd(e, el) {
-    if (!open) {
+    if (e.target === el && !open) {
       el.close();
     }
     onAnimationEnd && onAnimationEnd(e, el);

--- a/packages/evo-marko/src/tags/evo-alert-dialog/index.marko
+++ b/packages/evo-marko/src/tags/evo-alert-dialog/index.marko
@@ -15,6 +15,7 @@ export interface Input extends Omit<Marko.HTML.Dialog, "open" | "closedby" | "ro
   confirm,
   content,
   onAnimationEnd,
+  onCancel,
   ...htmlInput
 }=input>
 
@@ -40,6 +41,11 @@ export interface Input extends Omit<Marko.HTML.Dialog, "open" | "closedby" | "ro
     !open && "dialog--close",
     inputClass,
   ]
+  onCancel(e, el) {
+    // Only necessary while `closedby` is outside of our browser policy
+    e.preventDefault();
+    onCancel && onCancel(e, el);
+  }
   onAnimationEnd(e, el) {
     if (e.target === el && !open) {
       el.close();

--- a/packages/evo-marko/src/tags/evo-confirm-dialog/confirm-dialog.stories.ts
+++ b/packages/evo-marko/src/tags/evo-confirm-dialog/confirm-dialog.stories.ts
@@ -23,6 +23,14 @@ export default {
       description: "Whether the confirm dialog is open",
       table: { defaultValue: { summary: "false" } },
     },
+    closedby: {
+      type: "string",
+      options: ["any", "closerequest", "none"],
+      control: "inline-radio",
+      description:
+        'The [`closedby=` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog#closedby) from the native `<dialog>` component. Defaults to `"closerequest"` if not specified',
+      table: { defaultValue: { summary: "closerequest" } },
+    },
     header: {
       description:
         "The header content rendered inside the dialog title (required)",

--- a/packages/evo-marko/src/tags/evo-confirm-dialog/confirm-dialog.stories.ts
+++ b/packages/evo-marko/src/tags/evo-confirm-dialog/confirm-dialog.stories.ts
@@ -23,14 +23,6 @@ export default {
       description: "Whether the confirm dialog is open",
       table: { defaultValue: { summary: "false" } },
     },
-    closedby: {
-      type: "string",
-      options: ["any", "closerequest", "none"],
-      control: "inline-radio",
-      description:
-        'The [`closedby=` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog#closedby) from the native `<dialog>` component. Defaults to `"closerequest"` if not specified',
-      table: { defaultValue: { summary: "closerequest" } },
-    },
     header: {
       description:
         "The header content rendered inside the dialog title (required)",

--- a/packages/evo-marko/src/tags/evo-confirm-dialog/index.marko
+++ b/packages/evo-marko/src/tags/evo-confirm-dialog/index.marko
@@ -1,6 +1,6 @@
 import { type Input as ButtonInput } from "<evo-button>";
 
-export interface Input extends Omit<Marko.HTML.Dialog, "open" | "role" | "aria-labelledby" | "aria-modal"> {
+export interface Input extends Omit<Marko.HTML.Dialog, "open" | "role" | "aria-labelledby" | "aria-modal" | "closedby"> {
   open?: boolean;
   openChange?: (o: boolean) => void;
   header: Marko.AttrTag<Marko.HTML.H2 & { as?: string }>;
@@ -16,7 +16,6 @@ export interface Input extends Omit<Marko.HTML.Dialog, "open" | "role" | "aria-l
   confirm,
   reject,
   content,
-  closedby = "closerequest",
   onCancel,
   onAnimationEnd,
   ...htmlInput
@@ -36,7 +35,7 @@ export interface Input extends Omit<Marko.HTML.Dialog, "open" | "role" | "aria-l
   open=null // tell Marko it's not a part of the spread because the browser does DOM manipulation
   role="alertdialog"
   aria-modal="true"
-  closedby=closedby
+  closedby="closerequest"
   aria-labelledby=headerId
   class=[
     "dialog",

--- a/packages/evo-marko/src/tags/evo-confirm-dialog/index.marko
+++ b/packages/evo-marko/src/tags/evo-confirm-dialog/index.marko
@@ -50,7 +50,7 @@ export interface Input extends Omit<Marko.HTML.Dialog, "open" | "role" | "aria-l
     onCancel && onCancel(e, el);
   }
   onAnimationEnd(e, el) {
-    if (!open) {
+    if (e.target === el && !open) {
       el.close();
     }
     onAnimationEnd && onAnimationEnd(e, el);

--- a/packages/evo-marko/src/tags/evo-dialog/index.marko
+++ b/packages/evo-marko/src/tags/evo-dialog/index.marko
@@ -62,7 +62,7 @@ export interface Input extends Marko.HTML.Dialog {
     onCancel && onCancel(e, el);
   }
   onAnimationEnd(e, el) {
-    if (!open) {
+    if (e.target === el && !open) {
       el.close();
     }
     onAnimationEnd && onAnimationEnd(e, el);

--- a/packages/evo-marko/src/tags/evo-dialog/index.marko
+++ b/packages/evo-marko/src/tags/evo-dialog/index.marko
@@ -44,6 +44,25 @@ export interface Input extends Marko.HTML.Dialog {
   }
 </script>
 
+<script>
+  // NOTE: Only required until Safari has better support for closedby
+  if (open && !("closedBy" in HTMLDialogElement.prototype)) {
+    if (closedby === "any") {
+      $dialog().addEventListener("click", (e) => {
+        if (e.target === $dialog()) {
+          open = false;
+        }
+      }, { signal: $signal });
+    } else if (closedby === "none") {
+      $dialog().addEventListener("keydown", (e) => {
+        if (e.key === "Escape") {
+          e.preventDefault();
+        }
+      }, { signal: $signal });
+    }
+  }
+</script>
+
 <dialog/$dialog
   ...htmlInput
   open=null // tell Marko it's not a part of the spread because the browser does DOM manipulation

--- a/packages/evo-marko/src/tags/evo-toast-dialog/README.md
+++ b/packages/evo-marko/src/tags/evo-toast-dialog/README.md
@@ -1,0 +1,18 @@
+<h1 style='display: flex; justify-content: space-between; align-items: center;'>
+    <span>
+        evo-toast-dialog
+    </span>
+    <span style='font-weight: normal; font-size: medium; margin-bottom: -15px;'>
+        DS v2.1.0
+    </span>
+</h1>
+
+A non-modal toast dialog that slides up from the bottom of the page. Used for non-blocking notifications that the user needs to see.
+
+Uses a native `<dialog>` element opened non-modally via `.show()`, with `aria-live="polite"` for screen reader announcements.
+
+## Examples and Documentation
+
+- [Storybook](https://ebay.github.io/evo-web/evo-marko/?path=/story/navigation-disclosure-evo-toast-dialog)
+- [Storybook Docs](https://ebay.github.io/evo-web/evo-marko/?path=/docs/navigation-disclosure-evo-toast-dialog)
+- [Code Examples](https://github.com/eBay/evo-web/tree/main/packages/evo-marko/src/tags/evo-toast-dialog/examples)

--- a/packages/evo-marko/src/tags/evo-toast-dialog/examples/default.marko
+++ b/packages/evo-marko/src/tags/evo-toast-dialog/examples/default.marko
@@ -1,0 +1,22 @@
+import { type Input as ToastDialogInput } from "<evo-toast-dialog>";
+export interface Input extends ToastDialogInput {}
+
+<let/open:=input.open>
+
+<evo-button onClick() { open = true; }>
+    Open Toast
+</evo-button>
+
+<evo-toast-dialog ...input open:=open>
+    <@header>Heading</@header>
+    <@close a11yText="Close Toast"/>
+    <@footer>
+        <evo-button onClick() { open = false; }>
+            Close
+        </evo-button>
+    </@footer>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit</p>
+    <p>
+        <a href="http://www.ebay.com">www.ebay.com</a>
+    </p>
+</evo-toast-dialog>

--- a/packages/evo-marko/src/tags/evo-toast-dialog/index.marko
+++ b/packages/evo-marko/src/tags/evo-toast-dialog/index.marko
@@ -1,0 +1,81 @@
+import { type Input as IconButtonInput } from "<evo-icon-button>";
+
+export interface Input extends Omit<Marko.HTML.Dialog, "open" | "role" | "aria-modal" | "aria-live"> {
+  open?: boolean;
+  openChange?: (o: boolean) => void;
+  header: Marko.AttrTag<Marko.HTML.H2 & { as?: string }>;
+  footer?: Marko.AttrTag<Marko.HTML.Div>;
+  close: Marko.AttrTag<IconButtonInput>;
+}
+
+<const/{
+  open: inputOpen,
+  openChange,
+  class: inputClass,
+  header,
+  footer,
+  close,
+  content,
+  "aria-labelledby": inputLabelledBy,
+  onAnimationEnd,
+  ...htmlInput
+}=input>
+
+<let/open:=input.open>
+<id/headerId=header.id>
+
+<script>
+  if (open && !$dialog().open) {
+    const prev = document.activeElement as HTMLElement | null;
+    $dialog().show();
+    prev?.focus();
+  }
+</script>
+
+<dialog/$dialog
+  ...htmlInput
+  open=null
+  role="dialog"
+  aria-modal="false"
+  aria-live="polite"
+  aria-labelledby=(inputLabelledBy ? `${inputLabelledBy} ${headerId}` : headerId)
+  class=[
+    "toast-dialog",
+    !open && "toast-dialog--close",
+    inputClass,
+  ]
+  onAnimationEnd(e, el) {
+    if (!open) {
+      el.close();
+    }
+    onAnimationEnd && onAnimationEnd(e, el);
+  }
+>
+  <div class="toast-dialog__window">
+    <div class="toast-dialog__header">
+      <const/{ as: headerAs = "h2", ...headerInput }=header>
+      <${headerAs}
+        ...headerInput
+        id=headerId
+        class=["toast-dialog__title", headerInput.class]
+      />
+      <evo-icon-button
+        ...close
+        transparent
+        class=["toast-dialog__close", close.class]
+        onClick(e, el) {
+          open = false;
+          close.onClick && close.onClick(e, el);
+        }
+      >
+        <evo-icon-close-16/>
+      </evo-icon-button>
+    </div>
+    <div class="toast-dialog__main">
+      <${content}/>
+    </div>
+    <if=footer>
+      <div ...footer class=["toast-dialog__footer", footer.class]/>
+    </if>
+  </div>
+</dialog>

--- a/packages/evo-marko/src/tags/evo-toast-dialog/index.marko
+++ b/packages/evo-marko/src/tags/evo-toast-dialog/index.marko
@@ -1,6 +1,6 @@
 import { type Input as IconButtonInput } from "<evo-icon-button>";
 
-export interface Input extends Omit<Marko.HTML.Dialog, "open" | "role" | "aria-modal" | "aria-live"> {
+export interface Input extends Omit<Marko.HTML.Dialog, "open" | "role" | "aria-modal" | "aria-live" | "closedby"> {
   open?: boolean;
   openChange?: (o: boolean) => void;
   header: Marko.AttrTag<Marko.HTML.H2 & { as?: string }>;
@@ -17,7 +17,6 @@ export interface Input extends Omit<Marko.HTML.Dialog, "open" | "role" | "aria-m
   close,
   content,
   "aria-labelledby": inputLabelledBy,
-  closedby = "closerequest",
   onCancel,
   onAnimationEnd,
   ...htmlInput
@@ -34,13 +33,24 @@ export interface Input extends Omit<Marko.HTML.Dialog, "open" | "role" | "aria-m
   }
 </script>
 
+<script>
+  // NOTE: Only required until Safari has better support for closedby
+  if (open && !("closedBy" in HTMLDialogElement.prototype)) {
+    document.addEventListener("keydown", ({ key, defaultPrevented }) => {
+      if (key === "Escape" && !defaultPrevented) {
+        open = false;
+      }
+    }, { signal: $signal });
+  }
+</script>
+
 <dialog/$dialog
   ...htmlInput
   open=null
   role="dialog"
   aria-modal="false"
   aria-live="polite"
-  closedby=closedby
+  closedby="closerequest"
   aria-labelledby=(inputLabelledBy ? `${inputLabelledBy} ${headerId}` : headerId)
   class=[
     "toast-dialog",

--- a/packages/evo-marko/src/tags/evo-toast-dialog/index.marko
+++ b/packages/evo-marko/src/tags/evo-toast-dialog/index.marko
@@ -17,6 +17,8 @@ export interface Input extends Omit<Marko.HTML.Dialog, "open" | "role" | "aria-m
   close,
   content,
   "aria-labelledby": inputLabelledBy,
+  closedby = "closerequest",
+  onCancel,
   onAnimationEnd,
   ...htmlInput
 }=input>
@@ -38,14 +40,20 @@ export interface Input extends Omit<Marko.HTML.Dialog, "open" | "role" | "aria-m
   role="dialog"
   aria-modal="false"
   aria-live="polite"
+  closedby=closedby
   aria-labelledby=(inputLabelledBy ? `${inputLabelledBy} ${headerId}` : headerId)
   class=[
     "toast-dialog",
     !open && "toast-dialog--close",
     inputClass,
   ]
+  onCancel(e, el) {
+    e.preventDefault();
+    open = false;
+    onCancel && onCancel(e, el);
+  }
   onAnimationEnd(e, el) {
-    if (!open) {
+    if (e.target === el && !open) {
       el.close();
     }
     onAnimationEnd && onAnimationEnd(e, el);
@@ -64,7 +72,7 @@ export interface Input extends Omit<Marko.HTML.Dialog, "open" | "role" | "aria-m
         transparent
         class=["toast-dialog__close", close.class]
         onClick(e, el) {
-          open = false;
+          $dialog().requestClose();
           close.onClick && close.onClick(e, el);
         }
       >

--- a/packages/evo-marko/src/tags/evo-toast-dialog/style.ts
+++ b/packages/evo-marko/src/tags/evo-toast-dialog/style.ts
@@ -1,0 +1,1 @@
+import "@ebay/skin/toast-dialog";

--- a/packages/evo-marko/src/tags/evo-toast-dialog/test/test.browser.ts
+++ b/packages/evo-marko/src/tags/evo-toast-dialog/test/test.browser.ts
@@ -1,0 +1,113 @@
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  it,
+  expect,
+} from "vitest";
+import { render, cleanup } from "@marko/testing-library";
+import { composeStories } from "@storybook/marko";
+import { fastAnimations } from "../../../common/test-utils/index";
+import * as stories from "../toast-dialog.stories";
+
+const { Default } = composeStories(stories);
+
+beforeAll(() => fastAnimations.start());
+afterAll(() => fastAnimations.stop());
+afterEach(cleanup);
+
+let component: Awaited<ReturnType<typeof render>>;
+
+describe("evo-toast-dialog", () => {
+  describe("given the toast dialog is in the default (closed) state", () => {
+    beforeEach(async () => {
+      component = await render(Default);
+    });
+
+    it("should render with a dialog element", () => {
+      expect(component.container.querySelector("dialog")).toBeTruthy();
+    });
+
+    it("should have the toast-dialog class", () => {
+      const dialog = component.container.querySelector("dialog");
+      expect(dialog?.classList.contains("toast-dialog")).toBe(true);
+    });
+
+    it("should have toast-dialog--close class when not open", () => {
+      const dialog = component.container.querySelector("dialog");
+      expect(dialog?.classList.contains("toast-dialog--close")).toBe(true);
+    });
+
+    it("should have role=dialog", () => {
+      const dialog = component.container.querySelector("dialog");
+      expect(dialog?.getAttribute("role")).toBe("dialog");
+    });
+
+    it("should have aria-modal=false", () => {
+      const dialog = component.container.querySelector("dialog");
+      expect(dialog?.getAttribute("aria-modal")).toBe("false");
+    });
+
+    it("should have aria-live=polite", () => {
+      const dialog = component.container.querySelector("dialog");
+      expect(dialog?.getAttribute("aria-live")).toBe("polite");
+    });
+
+    it("should render the close button", () => {
+      const closeBtn = component.container.querySelector(
+        ".toast-dialog__close",
+      );
+      expect(closeBtn).toBeTruthy();
+    });
+
+    it("should have aria-label on close button", () => {
+      const closeBtn = component.container.querySelector(
+        ".toast-dialog__close",
+      );
+      expect(closeBtn?.getAttribute("aria-label")).toBe("Close Toast");
+    });
+  });
+
+  describe("given the toast dialog is in the open state", () => {
+    beforeEach(async () => {
+      component = await render(Default, { open: true });
+    });
+
+    it("should render the dialog element", () => {
+      const dialog = component.container.querySelector("dialog");
+      expect(dialog).toBeTruthy();
+    });
+
+    it("should not have toast-dialog--close class when open", () => {
+      const dialog = component.container.querySelector("dialog");
+      expect(dialog?.classList.contains("toast-dialog")).toBe(true);
+      expect(dialog?.classList.contains("toast-dialog--close")).toBe(false);
+    });
+
+    it("should render header with h2 by default", () => {
+      const title = component.container.querySelector(".toast-dialog__title");
+      expect(title).toBeTruthy();
+      expect(title?.tagName.toLowerCase()).toBe("h2");
+    });
+
+    it("should link dialog to header via aria-labelledby", () => {
+      const dialog = component.container.querySelector("dialog");
+      const title = component.container.querySelector(".toast-dialog__title");
+      const titleId = title?.id;
+      expect(titleId).toBeTruthy();
+      expect(dialog?.getAttribute("aria-labelledby")).toBe(titleId);
+    });
+
+    it("should render main content area", () => {
+      const main = component.container.querySelector(".toast-dialog__main");
+      expect(main).toBeTruthy();
+    });
+
+    it("should render footer when provided", () => {
+      const footer = component.container.querySelector(".toast-dialog__footer");
+      expect(footer).toBeTruthy();
+    });
+  });
+});

--- a/packages/evo-marko/src/tags/evo-toast-dialog/test/test.server.ts
+++ b/packages/evo-marko/src/tags/evo-toast-dialog/test/test.server.ts
@@ -1,0 +1,16 @@
+import { describe, it } from "vitest";
+import { composeStories } from "@storybook/marko";
+import { snapshotHTML } from "../../../common/test-utils/snapshots";
+import * as stories from "../toast-dialog.stories";
+
+const { Default } = composeStories(stories);
+
+describe("evo-toast-dialog SSR", () => {
+  it("renders default", async () => {
+    await snapshotHTML(Default);
+  });
+
+  it("renders in open state", async () => {
+    await snapshotHTML(Default, { open: true });
+  });
+});

--- a/packages/evo-marko/src/tags/evo-toast-dialog/toast-dialog.stories.ts
+++ b/packages/evo-marko/src/tags/evo-toast-dialog/toast-dialog.stories.ts
@@ -1,0 +1,72 @@
+import { buildExtensionTemplate } from "../../common/storybook/utils";
+import { type Meta } from "@storybook/marko";
+import Readme from "./README.md";
+import Component, { type Input } from "./index.marko";
+import DefaultTemplate from "./examples/default.marko";
+import DefaultCode from "./examples/default.marko?raw";
+
+export default {
+  title: "navigation & disclosure/evo-toast-dialog",
+  component: Component,
+  parameters: {
+    docs: {
+      description: {
+        component: Readme,
+      },
+    },
+  },
+
+  argTypes: {
+    open: {
+      type: "boolean",
+      controllable: true,
+      description: "Whether the toast dialog is open",
+      table: { defaultValue: { summary: "false" } },
+    },
+    header: {
+      description:
+        "The header content rendered inside the toast dialog title (required)",
+      "@": {
+        as: {
+          type: "string",
+          description:
+            "The heading element to use for the title. Defaults to `h2`",
+        },
+        ["<h2> attributes" as any]: {
+          description:
+            "All attributes and event handlers from the heading element will be passed through",
+        },
+      },
+    },
+    footer: {
+      description:
+        "Optional footer content rendered below the toast dialog main content area",
+      "@": {
+        ["<div> attributes" as any]: {
+          description:
+            "All attributes and event handlers from [the native HTML `<div>` tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/div) will be passed through",
+        },
+      },
+    },
+    close: {
+      description:
+        "Close button rendered in the toast dialog header (required). Pass `a11yText` for the accessible label",
+      "@": {
+        a11yText: {
+          type: { name: "string", required: true },
+          description: "Accessible label for the close button",
+        },
+        ["<button> attributes" as any]: {
+          description:
+            "All attributes and event handlers from [the native HTML `<button>` tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/button) will be passed through",
+        },
+      },
+    },
+    ["<dialog> attributes" as any]: {
+      description:
+        "All attributes and event handlers from [the native HTML `<dialog>` tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dialog) will be passed through",
+    },
+  },
+} satisfies Meta<Input>;
+
+export const Default = buildExtensionTemplate(DefaultTemplate, DefaultCode);

--- a/packages/evo-marko/src/tags/evo-toast-dialog/toast-dialog.stories.ts
+++ b/packages/evo-marko/src/tags/evo-toast-dialog/toast-dialog.stories.ts
@@ -23,14 +23,6 @@ export default {
       description: "Whether the toast dialog is open",
       table: { defaultValue: { summary: "false" } },
     },
-    closedby: {
-      type: "string",
-      options: ["any", "closerequest", "none"],
-      control: "inline-radio",
-      description:
-        'The [`closedby=` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog#closedby) from the native `<dialog>` component. Defaults to `"closerequest"` if not specified',
-      table: { defaultValue: { summary: "closerequest" } },
-    },
     header: {
       description:
         "The header content rendered inside the toast dialog title (required)",

--- a/packages/evo-marko/src/tags/evo-toast-dialog/toast-dialog.stories.ts
+++ b/packages/evo-marko/src/tags/evo-toast-dialog/toast-dialog.stories.ts
@@ -23,6 +23,14 @@ export default {
       description: "Whether the toast dialog is open",
       table: { defaultValue: { summary: "false" } },
     },
+    closedby: {
+      type: "string",
+      options: ["any", "closerequest", "none"],
+      control: "inline-radio",
+      description:
+        'The [`closedby=` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog#closedby) from the native `<dialog>` component. Defaults to `"closerequest"` if not specified',
+      table: { defaultValue: { summary: "closerequest" } },
+    },
     header: {
       description:
         "The header content rendered inside the toast dialog title (required)",

--- a/packages/skin/dist/dialog/dialog.css
+++ b/packages/skin/dist/dialog/dialog.css
@@ -74,7 +74,7 @@ body:has(.dialog[open]) {
 .dialog__header {
     display: flex;
     flex-shrink: 0;
-    margin: var(--spacing-200) var(--spacing-200) 0;
+    padding: var(--spacing-200) var(--spacing-200) 0;
     position: relative;
 }
 .dialog__header h1,
@@ -149,7 +149,7 @@ button.icon-btn.dialog__prev {
     margin-inline-start: -32px;
 }
 .dialog--expressive .dialog__header {
-    margin: var(--spacing-300) var(--spacing-300) 0;
+    padding: var(--spacing-300) var(--spacing-300) 0;
 }
 .dialog--expressive .dialog__footer,
 .dialog--expressive .dialog__main {

--- a/packages/skin/dist/toast-dialog/toast-dialog.css
+++ b/packages/skin/dist/toast-dialog/toast-dialog.css
@@ -5,11 +5,32 @@
     --state-layer-neutral-on-strong: rgb(var(--color-neutral-900-rgb), 0);
     --state-layer-neutral: rgb(var(--color-neutral-900-rgb), 0);
 }
+@keyframes toast-dialog-open {
+    0% {
+        opacity: 0;
+        transform: translateY(110%);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+@keyframes toast-dialog-close {
+    0% {
+        opacity: 1;
+        transform: translateY(0);
+    }
+    to {
+        opacity: 0;
+        transform: translateY(110%);
+    }
+}
 .toast-dialog {
     background-color: var(--color-background-accent);
     border-top-left-radius: var(--border-radius-100);
     border-top-right-radius: var(--border-radius-100);
     box-shadow: 0 0 3px rgba(0, 0, 0, 0.28);
+    color: var(--color-foreground-on-success);
     inset: auto 0 0;
     max-height: 40vh;
     min-width: 320px;
@@ -19,7 +40,18 @@
     will-change: opacity, transform;
     z-index: 2;
 }
-.toast-dialog,
+dialog.toast-dialog {
+    border: none;
+    margin: 0;
+    outline-offset: 2px;
+    padding: 0;
+}
+.toast-dialog[open] {
+    animation: toast-dialog-open 0.2s cubic-bezier(0.21, 0.31, 1, 1.22);
+}
+.toast-dialog[open].toast-dialog--close {
+    animation: toast-dialog-close 0.2s cubic-bezier(0.21, 0.31, 1, 1.22);
+}
 .toast-dialog a {
     color: var(--color-foreground-on-success);
 }

--- a/packages/skin/src/sass/dialog/dialog.scss
+++ b/packages/skin/src/sass/dialog/dialog.scss
@@ -87,7 +87,7 @@ body:has(.dialog[open]) {
 .dialog__header {
     display: flex;
     flex-shrink: 0;
-    margin: var(--spacing-200) var(--spacing-200) 0;
+    padding: var(--spacing-200) var(--spacing-200) 0;
     position: relative;
 
     h1,
@@ -177,7 +177,7 @@ button.icon-btn.dialog__prev {
 }
 
 .dialog--expressive .dialog__header {
-    margin: var(--spacing-300) var(--spacing-300) 0;
+    padding: var(--spacing-300) var(--spacing-300) 0;
 }
 
 .dialog--expressive .dialog__main,

--- a/packages/skin/src/sass/toast-dialog/toast-dialog.scss
+++ b/packages/skin/src/sass/toast-dialog/toast-dialog.scss
@@ -3,6 +3,28 @@
 @use "../mixins/private/token-mixins";
 @use "../mixins/private/state-layer";
 
+@keyframes toast-dialog-open {
+    from {
+        opacity: 0;
+        transform: translateY(110%);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@keyframes toast-dialog-close {
+    from {
+        opacity: 1;
+        transform: translateY(0);
+    }
+    to {
+        opacity: 0;
+        transform: translateY(110%);
+    }
+}
+
 .toast-dialog {
     background-color: var(--color-background-accent);
     border-top-left-radius: var(--border-radius-100);
@@ -20,6 +42,24 @@
     z-index: 2;
 }
 
+/* Reset <dialog> UA styles when used as toast */
+dialog.toast-dialog {
+    border: none;
+    margin: 0;
+    outline-offset: 2px;
+    padding: 0;
+}
+
+/* Native <dialog> animation: open */
+.toast-dialog[open] {
+    animation: toast-dialog-open 0.2s cubic-bezier(0.21, 0.31, 1, 1.22);
+}
+
+/* Native <dialog> animation: close */
+.toast-dialog[open].toast-dialog--close {
+    animation: toast-dialog-close 0.2s cubic-bezier(0.21, 0.31, 1, 1.22);
+}
+
 .toast-dialog a {
     color: var(--color-foreground-on-success);
 }
@@ -28,12 +68,14 @@
     outline: 1px auto currentColor;
 }
 
+/* @deprecated remove once we've moved from `<aside>` to `<dialog>` */
 .toast-dialog--transition {
     transition:
         opacity 0.2s cubic-bezier(0.21, 0.31, 1, 1.22) 0s,
         transform 0.2s cubic-bezier(0.21, 0.31, 1, 1.22) 0s;
 }
 
+/* @deprecated remove once we've moved from `<aside>` to `<dialog>` */
 .toast-dialog--show,
 .toast-dialog--hide-init {
     display: block;
@@ -41,6 +83,7 @@
     transform: translateY(0);
 }
 
+/* @deprecated remove once we've moved from `<aside>` to `<dialog>` */
 .toast-dialog--show-init,
 .toast-dialog--hide {
     display: block;


### PR DESCRIPTION
- Create `<evo-toast-dialog>` component


## Differences from `<ebay-toast-dialog>`

- Use `<dialog>` instead of `<aside>`
  - This means the top-level component is also in the focus order (it wasn't before)
- Use `@animation` instead of `transition`
- `<@close>` attr tag instead of `a11yCloseText`
- controllable `open` (with `openChange`)