### PR TITLE
fix(ebay-combobox): apply combobox--fluid class when fluid prop is set

### DIFF
--- a/.changeset/fix-combobox-fluid-class.md
+++ b/.changeset/fix-combobox-fluid-class.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ui-core-react": patch
+---
+
+fix(ebay-combobox): apply combobox--fluid class when fluid prop is set

--- a/packages/ebayui-core-react/src/ebay-combobox/__tests__/index.spec.tsx
+++ b/packages/ebayui-core-react/src/ebay-combobox/__tests__/index.spec.tsx
@@ -15,6 +15,11 @@ const renderCombobox = (props?) =>
     );
 
 describe("<EbayCombobox />", () => {
+    it("should apply combobox--fluid class when fluid prop is set", () => {
+        const { container } = renderCombobox({ fluid: true });
+        expect(container.firstChild).toHaveClass("combobox", "combobox--fluid");
+    });
+
     it("should update input value on arrow down", async () => {
         renderCombobox();
         const input = screen.getByRole("combobox");

--- a/packages/ebayui-core-react/src/ebay-combobox/combobox.tsx
+++ b/packages/ebayui-core-react/src/ebay-combobox/combobox.tsx
@@ -264,7 +264,7 @@ const EbayCombobox: FC<EbayComboboxProps> = ({
     };
 
     return (
-        <Container ref={containerRef} className={classNames(`combobox`, className)}>
+        <Container ref={containerRef} className={classNames("combobox", { "combobox--fluid": fluid }, className)}>
             <floatingLabel.Label htmlFor={rest.id} />
 
             <span


### PR DESCRIPTION
## Summary

- Fixes missing `combobox--fluid` CSS class on `EbayCombobox` when `fluid={true}` is passed
- The `fluid` prop already switched the container tag from `span` to `div`, but never added the CSS modifier that applies `width: 100%`
- Matches the behavior of the Marko 5 (`ebayui-core`) implementation

Fixes #628