### PR TITLE
fix(skin): remove arbitrary 75% max-width on section-title title container

### DIFF
--- a/.changeset/section-title-width.md
+++ b/.changeset/section-title-width.md
@@ -1,0 +1,14 @@
+---
+"@ebay/skin": patch
+---
+
+fix(section-title): remove arbitrary 75% max-width on title container
+
+The `.section-title__title-container` was capped at `max-width: 75%`, which
+caused unnecessary text wrapping on narrow viewports and on titles without
+a trailing CTA. The Playbook spec is to let the title flow naturally and
+rely on margin to maintain separation from a trailing CTA / overflow / info
+element.
+
+The `max-width` cap is replaced with `margin-inline-end: var(--spacing-300)`,
+matching the spacing token used by sibling elements.

--- a/packages/skin/dist/section-title/section-title.css
+++ b/packages/skin/dist/section-title/section-title.css
@@ -4,7 +4,7 @@
     margin: 30px 0 10px;
 }
 .section-title__title-container {
-    max-width: 75%;
+    margin-inline-end: var(--spacing-300);
 }
 .section-title__title {
     font-size: var(--font-size-large-1);

--- a/packages/skin/src/sass/section-title/section-title.scss
+++ b/packages/skin/src/sass/section-title/section-title.scss
@@ -9,7 +9,12 @@
 }
 
 .section-title__title-container {
-    max-width: 75%;
+    /*
+     * Separation from any trailing CTA / overflow / info element. We rely on
+     * the flex container to grow the title naturally and use this margin to
+     * preserve spacing instead of an arbitrary max-width cap. See #562.
+     */
+    margin-inline-end: var(--spacing-300);
 }
 
 .section-title__title {


### PR DESCRIPTION
## Summary

Closes #562. Implements [@ArtBlue's dev notes](https://github.com/eBay/evo-web/issues/562#issuecomment) from the issue triage.

## What was wrong

`.section-title__title-container` was capped at `max-width: 75%`:

```css
.section-title__title-container {
    max-width: 75%;
}
```

That cap had two visible side-effects:
- Titles wrapped onto a second line on narrow viewports even when there was no trailing CTA forcing them to (the issue's first screenshot).
- The wrapped layout did not match the [Playbook spec](https://playbook.ebay.com/design-system/components/section-header#specs), which expects the title to fill the available width and rely on margin to keep clear of any trailing element.

## Fix

Per the maintainer's dev notes:

> 1. simply remove the arbitrary width limit
> 2. as specified in Playbook, to avoid element collision with the elements on the other side, add the necessary margin to the container using the correct spacing token.

Replaced the `max-width: 75%` cap with `margin-inline-end: var(--spacing-300)`, matching the spacing token already used by `.section-title__info` and `.section-title__overflow`. The flex container handles the title's natural growth, and the margin maintains a 24px gap from any trailing CTA, overflow, or info element. Logical-property usage means RTL layouts get the equivalent inline-start margin automatically.

## Diff

```diff
 .section-title__title-container {
-    max-width: 75%;
+    margin-inline-end: var(--spacing-300);
 }
```

`dist/section-title/section-title.css` regenerated via `npm run build` in `packages/skin/`.

## Test plan

- [x] `npm run build:css` clean (stylelint passes)
- [x] Source SCSS and emitted CSS match
- [x] Manual: existing `section-title` Storybook stories still render at all breakpoints (320 / 512 / 768 / 1024 / 1280 / 1440 / 1920)
- [ ] Percy visual regression review for the storybook stories listed in `packages/skin/src/sass/section-title/stories/`
- [ ] RTL story (`stories/rtl.stories.js`) — `margin-inline-end` automatically maps to `margin-left` in RTL, so the visual should mirror the LTR result

## Notes for reviewers

- Existing `.section-title__title-container + button.icon-btn` rule still applies and adds an extra `margin-left: var(--spacing-100)` when an icon button is the immediate sibling — that behavior is unchanged.
- I left the SCSS comment in the source explaining why the margin replaces the cap, with a back-pointer to #562, since `_spacing` decisions are easy to lose track of when scanning a stylesheet later.
- Changeset included as `.changeset/section-title-width.md` (`@ebay/skin`: patch).