### PR TITLE
fix(ebay-star-rating-select): do not select star on focus (React, port of #394)

### DIFF
--- a/.changeset/star-rating-select-react-no-focus-select.md
+++ b/.changeset/star-rating-select-react-no-focus-select.md
@@ -1,0 +1,10 @@
+---
+"@ebay/ebayui-core-react": patch
+---
+
+fix(ebay-star-rating-select): do not select star on focus
+
+Tabbing to the first star auto-selected it because `handleFocus` (and
+`handleKeyDown`) called `setChecked` unconditionally. Selection now only
+happens on click (or the click event browsers synthesize from keyboard
+activation of native radio inputs), matching the Marko fix from #394.

--- a/packages/ebayui-core-react/src/ebay-star-rating-select/__tests__/index.spec.tsx
+++ b/packages/ebayui-core-react/src/ebay-star-rating-select/__tests__/index.spec.tsx
@@ -82,13 +82,22 @@ describe("star-rating-select", () => {
     describe("when native focus event is fired on star", () => {
         beforeEach(async () => {
             onFocusSpy.mockReset();
-            component = await render(<Isolated onFocus={onFocusSpy} />);
+            onChangeSpy.mockReset();
+            component = await render(<Isolated onFocus={onFocusSpy} onChange={onChangeSpy} />);
             await fireEvent.focus(component.getByLabelText("2 stars"));
         });
 
         it("should emit the focus event", () => {
             expect(onFocusSpy).toHaveBeenCalledTimes(1);
             expect(onFocusSpy).toHaveBeenCalledWith(eventOfType("focus"), { value: 2 });
+        });
+
+        it("should NOT select the star (issue #393)", () => {
+            // Tabbing to a star must not trigger a selection. The user must
+            // actively click or keyboard-activate the star.
+            expect(onChangeSpy).not.toHaveBeenCalled();
+            const input = component.getByLabelText("2 stars") as HTMLInputElement;
+            expect(input.classList.contains("star-rating-select__control--filled")).toBe(false);
         });
     });
 

--- a/packages/ebayui-core-react/src/ebay-star-rating-select/star-rating-select.tsx
+++ b/packages/ebayui-core-react/src/ebay-star-rating-select/star-rating-select.tsx
@@ -44,19 +44,21 @@ const EbayStarRatingSelect: FC<Props> = ({
     }, [value]);
     const handleKeyDown = (i: number) => (e) => {
         if (!disabled) {
-            setChecked(getValue(i));
             onKeyDown(e, { value: i });
         }
     };
     const handleClick = (i: number) => (e) => {
         if (!disabled) {
+            // Selection only happens on click (or keyboard activation that
+            // browsers translate to a click for native radio inputs). Tab
+            // navigation and synthetic focus must not implicitly select a
+            // star. See #393.
             setChecked(getValue(i));
             onChange(e, { value: i });
         }
     };
     const handleFocus = (i: number) => (e) => {
         if (!disabled) {
-            setChecked(getValue(i));
             onFocus(e, { value: i });
         }
     };

--- a/packages/ebayui-core-react/src/ebay-star-rating-select/star-rating-select.tsx
+++ b/packages/ebayui-core-react/src/ebay-star-rating-select/star-rating-select.tsx
@@ -49,10 +49,6 @@ const EbayStarRatingSelect: FC<Props> = ({
     };
     const handleClick = (i: number) => (e) => {
         if (!disabled) {
-            // Selection only happens on click (or keyboard activation that
-            // browsers translate to a click for native radio inputs). Tab
-            // navigation and synthetic focus must not implicitly select a
-            // star. See #393.
             setChecked(getValue(i));
             onChange(e, { value: i });
         }


### PR DESCRIPTION
## Summary

Closes #393. React port of the Marko fix shipped in [#394](https://github.com/eBay/evo-web/pull/394) (which closed the parent issue [#392](https://github.com/eBay/evo-web/issues/392)).

## What was wrong

In [`star-rating-select.tsx`](packages/ebayui-core-react/src/ebay-star-rating-select/star-rating-select.tsx), `handleFocus` (and `handleKeyDown`) called `setChecked(getValue(i))` unconditionally — selection and focus were the same code path. Tabbing to the first star therefore auto-selected it, contradicting the documented expectation:

> Pressing the Tab key should place the focus on the first star, but no selection will occur. The user must actively select the icon button.

## Fix (mirrors the Marko fix in #394)

```diff
 const handleKeyDown = (i: number) => (e) => {
     if (!disabled) {
-        setChecked(getValue(i));
         onKeyDown(e, { value: i });
     }
 };
 const handleClick = (i: number) => (e) => {
     if (!disabled) {
         setChecked(getValue(i));
         onChange(e, { value: i });
     }
 };
 const handleFocus = (i: number) => (e) => {
     if (!disabled) {
-        setChecked(getValue(i));
         onFocus(e, { value: i });
     }
 };
```

`handleClick` is the only selection path. Native radio inputs already synthesize a `click` event when arrow keys are used to move within a radio group, so keyboard arrow navigation continues to update the selection correctly through the existing `handleClick`.

## Test plan

- [x] Existing 10 tests still pass (focus event still emitted, change still emitted on click, disabled still gates everything, snapshots unchanged)
- [x] New regression test: focusing the 2nd star
  - asserts `onChange` is NOT called
  - asserts the input does not receive the `--filled` modifier class
- [x] Manual verification via Storybook (`Tab` to first star, no selection visible until click)
- [x] `npm run build` (smoke tests pass on React 16, 18, 19)

11 / 11 tests pass.

## Additional context

The Marko component (#394) was fixed in December. The React component still had the original buggy behavior. This PR brings them into parity.

Changeset: `@ebay/ebayui-core-react: patch`.