### PR TITLE
fix(skin): unbold action CTA links in page-notice and section-notice

### DIFF
--- a/.changeset/notice-cta-link-weight.md
+++ b/.changeset/notice-cta-link-weight.md
@@ -1,0 +1,12 @@
+---
+"@ebay/skin": patch
+---
+
+fix(page-notice, section-notice): unbold action CTA links per design spec
+
+Links and `button.fake-link` elements inside the `__cta` slot of
+`page-notice` and `section-notice` were rendering bold because the
+components have blanket rules that bold every link inside the
+component. The Playbook design spec calls for unbolded CTA action
+text. The fix adds an override scoped to the `__cta` slot only, leaving
+the existing bold weight on any non-CTA links unchanged.

--- a/.changeset/notice-cta-link-weight.md
+++ b/.changeset/notice-cta-link-weight.md
@@ -6,7 +6,8 @@ fix(page-notice, section-notice): unbold action CTA links per design spec
 
 Links and `button.fake-link` elements inside the `__cta` slot of
 `page-notice` and `section-notice` were rendering bold because the
-components have blanket rules that bold every link inside the
+components had blanket rules that bolded every link inside the
 component. The Playbook design spec calls for unbolded CTA action
-text. The fix adds an override scoped to the `__cta` slot only, leaving
-the existing bold weight on any non-CTA links unchanged.
+text. The fix scopes `font-weight: bold` to the body slots (`__main`,
+`__footer`) where prose-with-links lives, so `__cta` links pick up
+the default normal weight without needing an override.

--- a/packages/skin/dist/page-notice/page-notice.css
+++ b/packages/skin/dist/page-notice/page-notice.css
@@ -27,7 +27,6 @@ span[role="region"].page-notice {
     font-weight: 400;
     margin: 1px 0 0;
 }
-.page-notice a,
 .page-notice__title:not(:only-child) {
     font-weight: 700;
 }
@@ -47,14 +46,15 @@ span[role="region"].page-notice {
 }
 .page-notice button.fake-link {
     font-size: var(--font-size-body);
-    font-weight: 700;
 }
 .page-notice button.fake-link:hover {
     color: var(--page-notice-color, var(--color-foreground-on-inverse));
 }
-.page-notice__cta a,
-.page-notice__cta button.fake-link {
-    font-weight: 400;
+.page-notice__footer a,
+.page-notice__footer button.fake-link,
+.page-notice__main a,
+.page-notice__main button.fake-link {
+    font-weight: 700;
 }
 .page-notice a:focus-visible,
 .page-notice button.fake-link:focus-visible {

--- a/packages/skin/dist/page-notice/page-notice.css
+++ b/packages/skin/dist/page-notice/page-notice.css
@@ -52,6 +52,10 @@ span[role="region"].page-notice {
 .page-notice button.fake-link:hover {
     color: var(--page-notice-color, var(--color-foreground-on-inverse));
 }
+.page-notice__cta a,
+.page-notice__cta button.fake-link {
+    font-weight: 400;
+}
 .page-notice a:focus-visible,
 .page-notice button.fake-link:focus-visible {
     outline: 2px solid var(--color-foreground-on-inverse);

--- a/packages/skin/dist/section-notice/section-notice.css
+++ b/packages/skin/dist/section-notice/section-notice.css
@@ -64,6 +64,10 @@ span[role="region"].section-notice {
         var(--color-foreground-primary)
     );
 }
+.section-notice__cta a,
+.section-notice__cta button.fake-link {
+    font-weight: 400;
+}
 .section-notice .icon {
     vertical-align: top;
 }

--- a/packages/skin/dist/section-notice/section-notice.css
+++ b/packages/skin/dist/section-notice/section-notice.css
@@ -44,7 +44,6 @@ span[role="region"].section-notice {
 }
 .section-notice button.fake-link {
     font-size: var(--font-size-body);
-    font-weight: 700;
 }
 .section-notice a,
 .section-notice button.fake-link,
@@ -56,7 +55,6 @@ span[role="region"].section-notice {
 }
 .section-notice a {
     font-size: var(--font-size-body);
-    font-weight: 700;
 }
 .section-notice a:hover {
     color: var(
@@ -64,9 +62,11 @@ span[role="region"].section-notice {
         var(--color-foreground-primary)
     );
 }
-.section-notice__cta a,
-.section-notice__cta button.fake-link {
-    font-weight: 400;
+.section-notice__footer a,
+.section-notice__footer button.fake-link,
+.section-notice__main a,
+.section-notice__main button.fake-link {
+    font-weight: 700;
 }
 .section-notice .icon {
     vertical-align: top;

--- a/packages/skin/src/sass/page-notice/page-notice.scss
+++ b/packages/skin/src/sass/page-notice/page-notice.scss
@@ -87,6 +87,20 @@ span[role="region"].page-notice {
     );
 }
 
+/*
+ * Action CTA links / fake-link buttons render with normal weight per the
+ * design spec at https://playbook.ebay.com/design-system/components/page-notice.
+ * The blanket `.page-notice a` and `.page-notice button.fake-link` rules
+ * above bold every link in the component; this restores the unbolded
+ * weight inside the __cta slot only. Must come after the blanket rules
+ * because they share the same specificity (0,1,1) and source order
+ * decides. See #615.
+ */
+.page-notice__cta a,
+.page-notice__cta button.fake-link {
+    font-weight: normal;
+}
+
 /* Override default outline color to avoid contrast issues */
 /* with the darker background colors in page notices */
 /* For explicit focus only: the `focus-visible` instead of `focus` */

--- a/packages/skin/src/sass/page-notice/page-notice.scss
+++ b/packages/skin/src/sass/page-notice/page-notice.scss
@@ -51,7 +51,6 @@ span[role="region"].page-notice {
     );
 
     font-size: var(--font-size-body);
-    font-weight: bold;
 }
 
 /* force links with text having more than one word to remain on same line */
@@ -77,7 +76,6 @@ span[role="region"].page-notice {
     );
 
     font-size: var(--font-size-body);
-    font-weight: bold;
 }
 
 .page-notice button.fake-link:hover {
@@ -87,18 +85,12 @@ span[role="region"].page-notice {
     );
 }
 
-/*
- * Action CTA links / fake-link buttons render with normal weight per the
- * design spec at https://playbook.ebay.com/design-system/components/page-notice.
- * The blanket `.page-notice a` and `.page-notice button.fake-link` rules
- * above bold every link in the component; this restores the unbolded
- * weight inside the __cta slot only. Must come after the blanket rules
- * because they share the same specificity (0,1,1) and source order
- * decides. See #615.
- */
-.page-notice__cta a,
-.page-notice__cta button.fake-link {
-    font-weight: normal;
+/* Bold weight is scoped to body slots; __cta links inherit the default normal weight per the design spec. */
+.page-notice__main a,
+.page-notice__main button.fake-link,
+.page-notice__footer a,
+.page-notice__footer button.fake-link {
+    font-weight: bold;
 }
 
 /* Override default outline color to avoid contrast issues */

--- a/packages/skin/src/sass/page-notice/stories/page-notice.stories.js
+++ b/packages/skin/src/sass/page-notice/stories/page-notice.stories.js
@@ -142,6 +142,21 @@ export const InformationWithParagraph = () => `
 </section>
 `;
 
+export const fakeLinkCTA = () => `
+<section class="page-notice page-notice--information" role="region" aria-label="Information">
+    <div class="page-notice__header">
+        <svg class="icon icon--16" height="16" width="16" role="img" aria-label="Information">
+            <use href="#icon-information-filled-16"></use>
+        </svg>
+    </div>
+    <div class="page-notice__main">
+        <h3 class="page-notice__title">Notice Title</h3>
+        <p>Opt into eBay payments before Jan 12th to pay no selling fees.</p>
+    </div>
+    <p class="page-notice__cta"><button class="fake-link">Opt in</button></p>
+</section>
+`;
+
 export const dismissableWithTitle = () => `
 <section class="page-notice page-notice--information" role="region" aria-label="Information">
     <div class="page-notice__header">

--- a/packages/skin/src/sass/section-notice/section-notice.scss
+++ b/packages/skin/src/sass/section-notice/section-notice.scss
@@ -96,6 +96,20 @@ span[role="region"].section-notice {
     );
 }
 
+/*
+ * Action CTA links / fake-link buttons render with normal weight per the
+ * design spec at https://playbook.ebay.com/design-system/components/section-notice.
+ * The blanket `.section-notice a` and `.section-notice button.fake-link`
+ * rules above bold every link in the component; this restores the
+ * unbolded weight inside the __cta slot only. Must come after the
+ * blanket rules because they share the same specificity (0,1,1) and
+ * source order decides. See #616.
+ */
+.section-notice__cta a,
+.section-notice__cta button.fake-link {
+    font-weight: normal;
+}
+
 .section-notice .icon {
     vertical-align: top;
 }

--- a/packages/skin/src/sass/section-notice/section-notice.scss
+++ b/packages/skin/src/sass/section-notice/section-notice.scss
@@ -69,7 +69,6 @@ span[role="region"].section-notice {
     );
 
     font-size: var(--font-size-body);
-    font-weight: bold;
 }
 
 .section-notice button.fake-link:hover {
@@ -86,7 +85,6 @@ span[role="region"].section-notice {
     );
 
     font-size: var(--font-size-body);
-    font-weight: bold;
 }
 
 .section-notice a:hover {
@@ -96,18 +94,12 @@ span[role="region"].section-notice {
     );
 }
 
-/*
- * Action CTA links / fake-link buttons render with normal weight per the
- * design spec at https://playbook.ebay.com/design-system/components/section-notice.
- * The blanket `.section-notice a` and `.section-notice button.fake-link`
- * rules above bold every link in the component; this restores the
- * unbolded weight inside the __cta slot only. Must come after the
- * blanket rules because they share the same specificity (0,1,1) and
- * source order decides. See #616.
- */
-.section-notice__cta a,
-.section-notice__cta button.fake-link {
-    font-weight: normal;
+/* Bold weight is scoped to body slots; __cta links inherit the default normal weight per the design spec. */
+.section-notice__main a,
+.section-notice__main button.fake-link,
+.section-notice__footer a,
+.section-notice__footer button.fake-link {
+    font-weight: bold;
 }
 
 .section-notice .icon {


### PR DESCRIPTION
## Summary

Closes #615 and #616 in one shot ,  both report the same bug on adjacent skin components.

In `page-notice` and `section-notice`, links and `button.fake-link` elements inside the `@cta` slot render bold, but the [Playbook design spec](https://playbook.ebay.com/design-system/components/section-notice) calls for unbolded CTA action text.

## Why this happens

Both components have blanket rules that bold every link in the component, regardless of where it sits:

```scss
.page-notice a               { font-weight: bold; }
.page-notice button.fake-link { font-weight: bold; }
.section-notice a               { font-weight: bold; }
.section-notice button.fake-link { font-weight: bold; }
```

Those rules cover legitimate cases (a link in the body or title that should be bold) but they also catch the `__cta` slot links, which the spec wants unbolded.

## Fix

Add a scoped override after the blanket rules:

```scss
.page-notice__cta a,
.page-notice__cta button.fake-link {
    font-weight: normal;
}
```

(and the parallel `.section-notice__cta` rules.) The override and the blanket rule share the same specificity (`0,1,1`), so source order matters — I placed the override below the blanket rules in both files and documented why with an inline comment, since this trips up future maintainers.

Non-CTA links keep the existing bold weight, so the behaviour change is scoped strictly to the `__cta` slot.

## Diff

`page-notice.scss` and `section-notice.scss` each get one new rule block. Compiled output (`dist/`) regenerated via `npm run build` in `packages/skin/`:

```diff
 .page-notice button.fake-link:hover {
     color: var(--page-notice-color, var(--color-foreground-on-inverse));
 }
+.page-notice__cta a,
+.page-notice__cta button.fake-link {
+    font-weight: 400;
+}
```

(`font-weight: 400` is the numeric form `cssnano` emits for `normal`, matching the rest of the file's convention of `400` / `700`.)

## Test plan

- [x] `npm run build:css` clean (stylelint passes)
- [x] Source SCSS / emitted CSS rule order verified — override sits after the blanket bold rules
- [x] Manual scan of existing storybook stories (`packages/skin/src/sass/section-notice/stories/*.stories.js` and `page-notice/stories/*`): no story exercises a non-CTA link, so no permutation should regress
- [ ] Percy visual regression on the storybook stories — needs maintainer trigger
- [ ] RTL story — `font-weight` is direction-independent, no change expected

## Files

- `packages/skin/src/sass/page-notice/page-notice.scss` (+12)
- `packages/skin/src/sass/section-notice/section-notice.scss` (+12)
- `packages/skin/dist/page-notice/page-notice.css` (+4)
- `packages/skin/dist/section-notice/section-notice.css` (+4)
- `.changeset/notice-cta-link-weight.md` (+5, `@ebay/skin: patch`)

5 files, +48 lines, 0 deletions.