### PR TITLE
fix(ebay-menu-button): remove broken expand restoration logic

### DIFF
--- a/.changeset/goofy-jars-throw.md
+++ b/.changeset/goofy-jars-throw.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ebayui-core": patch
+---
+
+Fix bug with makeup-expander

--- a/packages/ebayui-core/src/components/ebay-menu-button/component.ts
+++ b/packages/ebayui-core/src/components/ebay-menu-button/component.ts
@@ -63,7 +63,6 @@ export interface Input extends WithNormalizedProps<MenuButtonInput> {}
 
 export default class extends MenuUtils<Input, MenuState> {
     declare expander: any;
-    declare isExpanded?: boolean;
     declare dropdownUtil: DropdownUtil;
 
     onCreate() {
@@ -242,9 +241,6 @@ export default class extends MenuUtils<Input, MenuState> {
             collapseOnHostReFocus: true,
         });
 
-        this.expander.expanded = this.isExpanded || false;
-        delete this.isExpanded;
-
         this.dropdownUtil = new DropdownUtil(
             this.getEl("button"),
             this.getEl("content"),
@@ -259,7 +255,6 @@ export default class extends MenuUtils<Input, MenuState> {
     _cleanupMakeup() {
         if (this.expander) {
             this.expander.destroy();
-            this.isExpanded = this.expander.expanded;
         }
 
         this.dropdownUtil?.cleanup?.();

--- a/packages/ebayui-core/src/components/ebay-menu-button/test/test.browser.js
+++ b/packages/ebayui-core/src/components/ebay-menu-button/test/test.browser.js
@@ -169,6 +169,27 @@ describe("given the menu is in the expanded state", () => {
         });
     });
 
+    describe("when aria-expanded is set directly on the DOM and a re-render is triggered", () => {
+        beforeEach(async () => {
+            // Simulate external consumer bypassing expander API (e.g. m-dialog on-select handler)
+            const button = component.getByRole("button");
+            button.setAttribute("aria-expanded", "false");
+            // Trigger a re-render (simulates setStateDirty from a parent component)
+            await component.rerender(
+                Object.assign({}, Default.args, {
+                    item: addRenderBodies([...items]),
+                }),
+            );
+        });
+
+        it("then the menu remains closed after re-render (no flash)", () => {
+            expect(component.getByRole("button")).toHaveAttribute(
+                "aria-expanded",
+                "false",
+            );
+        });
+    });
+
     describe("when an item is clicked", () => {
         beforeEach(async () => {
             await fireEvent.mouseDown(component.getByText(firstItemText));


### PR DESCRIPTION
Recent updates to `makeup-expander` changed its behavior and exposed faulty logic that attempts to store/restore expanded state. In certain cases where a re-render was happening during a state change, the component was locked into an "expanded" state.

Removing this logic fixes the issue.

https://github.com/user-attachments/assets/3148364b-d3d4-48a3-a94d-79a630d82214

