### PR TITLE
feat(evo-react): migrate ebay-avatar to evo-avatar

### DIFF
--- a/.changeset/silver-wolves-dance.md
+++ b/.changeset/silver-wolves-dance.md
@@ -1,0 +1,5 @@
+---
+"@evo-web/react": minor
+---
+
+feat(avatar): add EvoAvatar and EvoAvatarImage components

--- a/.claude/skills/evo-migrate-react/SKILL.md
+++ b/.claude/skills/evo-migrate-react/SKILL.md
@@ -293,6 +293,7 @@ describe("EvoButton SSR", () => {
 - **One story per component** unless the component tree itself must change between variations (e.g. different sub-components, optional children). Visual and prop variations (size, alignment, disabled, open…) must be handled through `args` and `argTypes` controls — not separate stories.
 - `title` must mirror the ebayui-core-react story title with `ebay` replaced by `evo`.
 - Description format: one-sentence summary followed by a `## Usage` section with the import snippet.
+- **`subcomponents`**: If the component has sub-components (e.g. `EvoAvatarImage` alongside `EvoAvatar`), declare them in the meta using the `subcomponents` field. This causes Storybook's autodocs to render a props table for each sub-component as a separate tab.
 
 ```tsx
 import type { Meta, StoryObj } from "@storybook/react-vite";
@@ -301,6 +302,8 @@ import { EvoButton } from "./button";
 const meta: Meta<typeof EvoButton> = {
   title: "buttons/evo-button",
   component: EvoButton,
+  // Include any exported sub-components so autodocs generates their prop tables:
+  // subcomponents: { EvoButtonCell },
   tags: ["autodocs"],
   parameters: {
     docs: {

--- a/packages/evo-react/src/avatar/README.md
+++ b/packages/evo-react/src/avatar/README.md
@@ -1,0 +1,5 @@
+# EvoAvatar
+
+## Documentation
+
+[Storybook](https://opensource.ebay.com/evo-web/react/main/?path=/docs/graphics-icons-evo-avatar--documentation)

--- a/packages/evo-react/src/avatar/avatar-image.tsx
+++ b/packages/evo-react/src/avatar/avatar-image.tsx
@@ -1,0 +1,19 @@
+import type { ComponentProps } from "react";
+import { useAvatarContext } from "./context";
+import { isFit } from "./utils";
+import type { EvoAvatarImageProps } from "./types";
+
+export function EvoAvatarImage({ onLoad, ...props }: EvoAvatarImageProps) {
+  const context = useAvatarContext();
+
+  const handleImageLoad: ComponentProps<"img">["onLoad"] = (event) => {
+    if (context) {
+      const element = event.target as HTMLImageElement;
+      const aspectRatio = element.naturalWidth / element.naturalHeight;
+      context.setImagePlacement(isFit(aspectRatio) ? "fit" : "cover");
+    }
+    onLoad?.(event);
+  };
+
+  return <img {...props} alt="" onLoad={handleImageLoad} />;
+}

--- a/packages/evo-react/src/avatar/avatar.stories.tsx
+++ b/packages/evo-react/src/avatar/avatar.stories.tsx
@@ -1,0 +1,135 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { EvoAvatar } from "./avatar";
+import { EvoAvatarImage } from "./avatar-image";
+
+const meta: Meta<typeof EvoAvatar> = {
+  title: "graphics & icons/evo-avatar",
+  component: EvoAvatar,
+  subcomponents: { EvoAvatarImage },
+  tags: ["autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component: `
+An avatar component that displays a user's profile picture, initials, or a signed-out placeholder icon.
+
+## Usage
+
+\`\`\`tsx
+import { EvoAvatar, EvoAvatarImage } from "@evo-web/react/avatar";
+\`\`\`
+        `,
+      },
+    },
+  },
+  argTypes: {
+    size: {
+      control: "select",
+      options: ["32", "40", "48", "56", "64", "96", "128"],
+      description: "The pixel size of the avatar. Only specific sizes are supported.",
+      table: { defaultValue: { summary: "48" } },
+    },
+    color: {
+      control: "select",
+      options: ["teal", "light-teal", "green", "lime", "yellow", "orange", "magenta", "pink"],
+      description:
+        "Background color override for the initials variant. When omitted, color is derived from the username hash.",
+    },
+    username: {
+      control: "text",
+      description:
+        "The username to display. Determines the background color (via hash) and shows the first letter when no image child is present. Omit to show the signed-out icon.",
+    },
+    knownAspectRatio: {
+      control: "number",
+      description:
+        "Optional pre-known image aspect ratio to prevent a flash of incorrectly styled content before the image loads.",
+    },
+    a11yText: {
+      type: { name: "string", required: true },
+      control: "text",
+      description:
+        'Accessible label for the avatar (`aria-label`). English default is `"avatar"`. Pass `null` explicitly only if alternative accessibility information is present.',
+    },
+  },
+  args: {
+    a11yText: "avatar",
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof EvoAvatar>;
+
+export const Default: Story = {
+  args: {
+    username: "Elizabeth",
+    a11yText: "Signed in as Elizabeth",
+  },
+};
+
+export const WithImage: Story = {
+  args: {
+    username: "Elizabeth",
+    a11yText: "Signed in as Elizabeth",
+  },
+  render: (args) => (
+    <EvoAvatar {...args}>
+      <EvoAvatarImage src="https://ir.ebaystatic.com/cr/v/c01/skin/docs/dog_profile.png" />
+    </EvoAvatar>
+  ),
+};
+
+export const SignedOut: Story = {
+  args: {
+    a11yText: "Signed out",
+  },
+};
+
+export const WithCustomBody: Story = {
+  args: {
+    username: "Elizabeth",
+    a11yText: "Signed in as Elizabeth",
+  },
+  render: (args) => (
+    <EvoAvatar {...args}>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          height: "100%",
+          width: "100%",
+          color: "white",
+          backgroundColor: "black",
+        }}
+      >
+        <span>EB</span>
+      </div>
+    </EvoAvatar>
+  ),
+};
+
+export const WithAutoPlacement: Story = {
+  args: {
+    a11yText: "Signed in as Doggy",
+  },
+  render: (args) => (
+    <>
+      <div>
+        <EvoAvatar {...args}>
+          <EvoAvatarImage src="https://ir.ebaystatic.com/cr/v/c01/skin/docs/dog_profile2.png" />
+        </EvoAvatar>
+      </div>
+      <div>
+        <EvoAvatar {...args}>
+          <EvoAvatarImage src="https://ir.ebaystatic.com/cr/v/c01/skin/docs/dog_profile3.png" />
+        </EvoAvatar>
+      </div>
+      <div>
+        <EvoAvatar {...args}>
+          <EvoAvatarImage src="https://ir.ebaystatic.com/cr/v/c01/skin/docs/dog_profile4.png" />
+        </EvoAvatar>
+      </div>
+    </>
+  ),
+};

--- a/packages/evo-react/src/avatar/avatar.tsx
+++ b/packages/evo-react/src/avatar/avatar.tsx
@@ -1,0 +1,41 @@
+import { useState } from "react";
+import classNames from "classnames";
+import type { EvoAvatarProps } from "./types";
+import { AvatarContext } from "./context";
+import { getColorForText, isFit } from "./utils";
+import { EvoIconAvatarSignedOut } from "../icon/icons/avatar-signed-out";
+import "@ebay/skin/avatar.mjs";
+
+export function EvoAvatar({
+  size,
+  color,
+  username,
+  children,
+  className,
+  knownAspectRatio,
+  a11yText = "avatar",
+  ...rest
+}: EvoAvatarProps) {
+  const [imagePlacement, setImagePlacement] = useState<"fit" | "cover">(
+    isFit(knownAspectRatio) ? "fit" : "cover",
+  );
+
+  return (
+    <AvatarContext value={{ setImagePlacement }}>
+      <div
+        {...rest}
+        role="img"
+        aria-label={a11yText ?? undefined}
+        className={classNames(
+          "avatar",
+          className,
+          size && `avatar--${size}`,
+          imagePlacement === "fit" && "avatar--fit",
+          username && !children && `avatar--${getColorForText(username, color)}`,
+        )}
+      >
+        {children || username?.charAt(0).toUpperCase() || <EvoIconAvatarSignedOut />}
+      </div>
+    </AvatarContext>
+  );
+}

--- a/packages/evo-react/src/avatar/context.ts
+++ b/packages/evo-react/src/avatar/context.ts
@@ -1,0 +1,11 @@
+import { createContext, useContext } from "react";
+
+export type AvatarContextValue = {
+  setImagePlacement: (value: "fit" | "cover") => void;
+};
+
+export const AvatarContext = createContext<AvatarContextValue | null>(null);
+
+export function useAvatarContext() {
+  return useContext(AvatarContext);
+}

--- a/packages/evo-react/src/avatar/index.ts
+++ b/packages/evo-react/src/avatar/index.ts
@@ -1,0 +1,3 @@
+export { EvoAvatar } from "./avatar";
+export { EvoAvatarImage } from "./avatar-image";
+export type { EvoAvatarProps, EvoAvatarImageProps, Size, Color } from "./types";

--- a/packages/evo-react/src/avatar/test/__snapshots__/test.server.tsx.snap
+++ b/packages/evo-react/src/avatar/test/__snapshots__/test.server.tsx.snap
@@ -1,0 +1,41 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`EvoAvatar SSR > should render avatar with color=green 1`] = `"<div role="img" aria-label="Joe" class="avatar avatar--green">J</div>"`;
+
+exports[`EvoAvatar SSR > should render avatar with color=light-teal 1`] = `"<div role="img" aria-label="Joe" class="avatar avatar--light-teal">J</div>"`;
+
+exports[`EvoAvatar SSR > should render avatar with color=lime 1`] = `"<div role="img" aria-label="Joe" class="avatar avatar--lime">J</div>"`;
+
+exports[`EvoAvatar SSR > should render avatar with color=magenta 1`] = `"<div role="img" aria-label="Joe" class="avatar avatar--magenta">J</div>"`;
+
+exports[`EvoAvatar SSR > should render avatar with color=orange 1`] = `"<div role="img" aria-label="Joe" class="avatar avatar--orange">J</div>"`;
+
+exports[`EvoAvatar SSR > should render avatar with color=pink 1`] = `"<div role="img" aria-label="Joe" class="avatar avatar--pink">J</div>"`;
+
+exports[`EvoAvatar SSR > should render avatar with color=teal 1`] = `"<div role="img" aria-label="Joe" class="avatar avatar--teal">J</div>"`;
+
+exports[`EvoAvatar SSR > should render avatar with color=yellow 1`] = `"<div role="img" aria-label="Joe" class="avatar avatar--yellow">J</div>"`;
+
+exports[`EvoAvatar SSR > should render avatar with fit placement when knownAspectRatio is portrait 1`] = `"<link rel="preload" as="image" href="https://example.com/pic.jpg"/><div role="img" aria-label="avatar" class="avatar avatar--fit"><img src="https://example.com/pic.jpg" alt=""/></div>"`;
+
+exports[`EvoAvatar SSR > should render avatar with image child 1`] = `"<link rel="preload" as="image" href="https://example.com/pic.jpg"/><div role="img" aria-label="Signed in as Elizabeth" class="avatar"><img src="https://example.com/pic.jpg" alt=""/></div>"`;
+
+exports[`EvoAvatar SSR > should render avatar with null a11yText (no aria-label) 1`] = `"<div aria-labelledby="some-id" role="img" class="avatar avatar--teal">J</div>"`;
+
+exports[`EvoAvatar SSR > should render avatar with size=32 1`] = `"<div role="img" aria-label="Joe" class="avatar avatar--32 avatar--teal">J</div>"`;
+
+exports[`EvoAvatar SSR > should render avatar with size=40 1`] = `"<div role="img" aria-label="Joe" class="avatar avatar--40 avatar--teal">J</div>"`;
+
+exports[`EvoAvatar SSR > should render avatar with size=48 1`] = `"<div role="img" aria-label="Joe" class="avatar avatar--48 avatar--teal">J</div>"`;
+
+exports[`EvoAvatar SSR > should render avatar with size=56 1`] = `"<div role="img" aria-label="Joe" class="avatar avatar--56 avatar--teal">J</div>"`;
+
+exports[`EvoAvatar SSR > should render avatar with size=64 1`] = `"<div role="img" aria-label="Joe" class="avatar avatar--64 avatar--teal">J</div>"`;
+
+exports[`EvoAvatar SSR > should render avatar with size=96 1`] = `"<div role="img" aria-label="Joe" class="avatar avatar--96 avatar--teal">J</div>"`;
+
+exports[`EvoAvatar SSR > should render avatar with size=128 1`] = `"<div role="img" aria-label="Joe" class="avatar avatar--128 avatar--teal">J</div>"`;
+
+exports[`EvoAvatar SSR > should render avatar with username initial 1`] = `"<div role="img" aria-label="Signed in as Elizabeth" class="avatar avatar--teal">E</div>"`;
+
+exports[`EvoAvatar SSR > should render signed-out avatar when no username or children 1`] = `"<div role="img" aria-label="Signed out" class="avatar"><svg class="icon icon--avatar-signed-out" xmlns="http://www.w3.org/2000/svg" focusable="false" aria-hidden="true"><use xlink:href="#icon-avatar-signed-out"></use><defs><symbol viewBox="0 0 40 40" id="icon-avatar-signed-out"><circle cx="20" cy="20" r="20" fill="var(--color-background-secondary, #F7F7F7)"/><circle cx="20" cy="17.5" r="8.333" fill="var(--color-foreground-secondary, #707070)"/><path d="M7.67 35.748c2-4.84 6.767-8.248 12.33-8.248s10.33 3.407 12.33 8.249A19.914 19.914 0 0 1 20 40a19.914 19.914 0 0 1-12.33-4.252Z" fill="var(--color-foreground-secondary, #707070)"/></symbol></defs></svg></div>"`;

--- a/packages/evo-react/src/avatar/test/test.browser.tsx
+++ b/packages/evo-react/src/avatar/test/test.browser.tsx
@@ -1,0 +1,138 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render } from "vitest-browser-react";
+import { userEvent } from "vitest/browser";
+import { EvoAvatar } from "../avatar";
+import { EvoAvatarImage } from "../avatar-image";
+
+describe("evo-avatar", () => {
+  let user: ReturnType<typeof userEvent.setup>;
+
+  beforeEach(() => {
+    user = userEvent.setup();
+  });
+
+  afterEach(() => {
+    user.cleanup();
+  });
+
+  it("renders with username initial when no children are provided", async () => {
+    const screen = await render(
+      <EvoAvatar username="Elizabeth" a11yText="Signed in as Elizabeth" />,
+    );
+    await expect.element(screen.getByText("E")).toBeInTheDocument();
+  });
+
+  it("renders signed-out icon when no username or children are provided", async () => {
+    const screen = await render(<EvoAvatar a11yText="Signed out" />);
+    const avatar = screen.getByRole("img", { name: "Signed out" });
+    await expect.element(avatar).toBeInTheDocument();
+    const svgEl = avatar.element().querySelector("svg");
+    expect(svgEl).toBeTruthy();
+  });
+
+  it("renders with the correct aria-label from a11yText", async () => {
+    const screen = await render(
+      <EvoAvatar username="Joe" a11yText="Signed in as Joe" />,
+    );
+    await expect
+      .element(screen.getByRole("img", { name: "Signed in as Joe" }))
+      .toBeInTheDocument();
+  });
+
+  it("does not render aria-label when a11yText is null", async () => {
+    const screen = await render(
+      <EvoAvatar username="Joe" a11yText={null} aria-labelledby="some-id" />,
+    );
+    // Query the avatar div directly — the SVG sprite also has role="img" so
+    // we use the container to find the .avatar element.
+    const avatarEl = screen.baseElement.querySelector<HTMLElement>(".avatar");
+    expect(avatarEl).toBeTruthy();
+    expect(avatarEl!.hasAttribute("aria-label")).toBe(false);
+  });
+
+  it("renders img child when EvoAvatarImage is used", async () => {
+    const screen = await render(
+      <EvoAvatar username="Elizabeth" a11yText="Signed in as Elizabeth">
+        <EvoAvatarImage src="https://example.com/pic.jpg" />
+      </EvoAvatar>,
+    );
+    const avatar = screen.getByRole("img", { name: "Signed in as Elizabeth" });
+    const imgEl = avatar.element().querySelector("img");
+    expect(imgEl).toBeTruthy();
+    expect(imgEl?.getAttribute("src")).toBe("https://example.com/pic.jpg");
+  });
+
+  it("applies size modifier class", async () => {
+    const screen = await render(
+      <EvoAvatar username="Joe" a11yText="Joe" size={64} />,
+    );
+    await expect
+      .element(screen.getByRole("img", { name: "Joe" }))
+      .toHaveClass("avatar--64");
+  });
+
+  it("applies color class derived from username", async () => {
+    const screen = await render(
+      <EvoAvatar username="Elizabeth" a11yText="Elizabeth" />,
+    );
+    const el = screen.getByRole("img", { name: "Elizabeth" }).element();
+    expect(el.className).toMatch(
+      /avatar--(?:teal|light-teal|green|lime|yellow|orange|magenta|pink)/,
+    );
+  });
+
+  it("applies explicit color override", async () => {
+    const screen = await render(
+      <EvoAvatar username="Joe" a11yText="Joe" color="magenta" />,
+    );
+    await expect
+      .element(screen.getByRole("img", { name: "Joe" }))
+      .toHaveClass("avatar--magenta");
+  });
+
+  it("applies avatar--fit class when knownAspectRatio is portrait", async () => {
+    const screen = await render(
+      <EvoAvatar a11yText="avatar" knownAspectRatio={0.5}>
+        <EvoAvatarImage src="https://example.com/pic.jpg" />
+      </EvoAvatar>,
+    );
+    await expect
+      .element(screen.getByRole("img", { name: "avatar" }))
+      .toHaveClass("avatar--fit");
+  });
+
+  it("updates image placement to fit on image load with portrait aspect ratio", async () => {
+    const screen = await render(
+      <EvoAvatar a11yText="avatar">
+        <EvoAvatarImage src="https://example.com/pic.jpg" />
+      </EvoAvatar>,
+    );
+
+    const avatarEl = screen.getByRole("img", { name: "avatar" }).element();
+    const img = avatarEl.querySelector("img") as HTMLImageElement;
+    Object.defineProperty(img, "naturalWidth", { value: 3, configurable: true });
+    Object.defineProperty(img, "naturalHeight", { value: 5, configurable: true });
+    img.dispatchEvent(new Event("load", { bubbles: true }));
+
+    await expect
+      .element(screen.getByRole("img", { name: "avatar" }))
+      .toHaveClass("avatar--fit");
+  });
+
+  it("calls custom onLoad handler from EvoAvatarImage", async () => {
+    const onLoad = vi.fn();
+    const screen = await render(
+      <EvoAvatar a11yText="avatar">
+        <EvoAvatarImage src="https://example.com/pic.jpg" onLoad={onLoad} />
+      </EvoAvatar>,
+    );
+
+    const avatarEl = screen.getByRole("img", { name: "avatar" }).element();
+    const img = avatarEl.querySelector("img") as HTMLImageElement;
+    Object.defineProperty(img, "naturalWidth", { value: 100, configurable: true });
+    Object.defineProperty(img, "naturalHeight", { value: 100, configurable: true });
+    img.dispatchEvent(new Event("load", { bubbles: true }));
+
+    expect(onLoad).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/evo-react/src/avatar/test/test.server.tsx
+++ b/packages/evo-react/src/avatar/test/test.server.tsx
@@ -1,0 +1,63 @@
+import { it, expect, describe } from "vitest";
+import { renderToString } from "react-dom/server";
+import { EvoAvatar } from "../avatar";
+import { EvoAvatarImage } from "../avatar-image";
+import type { Size, Color } from "../types";
+
+describe("EvoAvatar SSR", () => {
+  it.each<Size>([32, 40, 48, 56, 64, 96, 128])(
+    "should render avatar with size=%s",
+    (size) => {
+      expect(
+        renderToString(<EvoAvatar size={size} username="Joe" a11yText="Joe" />),
+      ).toMatchSnapshot();
+    },
+  );
+
+  it.each<Color>(["teal", "light-teal", "green", "lime", "yellow", "orange", "magenta", "pink"])(
+    "should render avatar with color=%s",
+    (color) => {
+      expect(
+        renderToString(<EvoAvatar color={color} username="Joe" a11yText="Joe" />),
+      ).toMatchSnapshot();
+    },
+  );
+
+  it("should render signed-out avatar when no username or children", () => {
+    expect(renderToString(<EvoAvatar a11yText="Signed out" />)).toMatchSnapshot();
+  });
+
+  it("should render avatar with username initial", () => {
+    expect(
+      renderToString(<EvoAvatar username="Elizabeth" a11yText="Signed in as Elizabeth" />),
+    ).toMatchSnapshot();
+  });
+
+  it("should render avatar with image child", () => {
+    expect(
+      renderToString(
+        <EvoAvatar username="Elizabeth" a11yText="Signed in as Elizabeth">
+          <EvoAvatarImage src="https://example.com/pic.jpg" />
+        </EvoAvatar>,
+      ),
+    ).toMatchSnapshot();
+  });
+
+  it("should render avatar with fit placement when knownAspectRatio is portrait", () => {
+    expect(
+      renderToString(
+        <EvoAvatar knownAspectRatio={0.5} a11yText="avatar">
+          <EvoAvatarImage src="https://example.com/pic.jpg" />
+        </EvoAvatar>,
+      ),
+    ).toMatchSnapshot();
+  });
+
+  it("should render avatar with null a11yText (no aria-label)", () => {
+    expect(
+      renderToString(
+        <EvoAvatar username="Joe" a11yText={null} aria-labelledby="some-id" />,
+      ),
+    ).toMatchSnapshot();
+  });
+});

--- a/packages/evo-react/src/avatar/types.ts
+++ b/packages/evo-react/src/avatar/types.ts
@@ -1,0 +1,29 @@
+import type { ComponentProps } from "react";
+
+export type Size = 32 | 40 | 48 | 56 | 64 | 96 | 128;
+export type Color =
+  | "teal"
+  | "light-teal"
+  | "green"
+  | "lime"
+  | "yellow"
+  | "orange"
+  | "magenta"
+  | "pink";
+
+export type EvoAvatarProps = Omit<ComponentProps<"div">, "role"> & {
+  size?: Size | `${Size}`;
+  color?: Color;
+  username?: string;
+  knownAspectRatio?: number;
+  /**
+   * The `aria-label` of the avatar.
+   *
+   * English default to be overridden is `"avatar"`
+   *
+   * Pass `null` explicitly _only_ if alternative accessibility information is present
+   */
+  a11yText?: string | null;
+};
+
+export type EvoAvatarImageProps = Omit<ComponentProps<"img">, "alt">;

--- a/packages/evo-react/src/avatar/utils.ts
+++ b/packages/evo-react/src/avatar/utils.ts
@@ -1,0 +1,35 @@
+import type { Color } from "./types";
+
+const backgroundColors: Color[] = [
+  "teal",
+  "light-teal",
+  "green",
+  "lime",
+  "yellow",
+  "orange",
+  "magenta",
+  "pink",
+];
+
+export function getColorForText(username?: string, color?: Color): Color {
+  if (color) return color;
+
+  let hash = 0,
+    chr: number,
+    i: number;
+  if (username && username.length > 0) {
+    for (i = 0; i < username.length; i++) {
+      chr = username.charCodeAt(i);
+      hash = (hash << 5) - hash + chr;
+      hash |= 0; // Convert to 32bit integer
+    }
+  }
+  const colorCount = backgroundColors.length;
+  const index = Math.abs(hash) % colorCount;
+  return backgroundColors[index];
+}
+
+/** Returns true when the image aspect ratio is portrait-ish or wide landscape (not square-ish). */
+export function isFit(aspectRatio?: number): boolean {
+  return !!aspectRatio && (aspectRatio < 3 / 4 || aspectRatio > 4 / 3);
+}


### PR DESCRIPTION
<!-- Insert GitHub issue number below. An issue is required for all PRs -->

- Fixes #

## Description

Migrates `ebay-avatar` from `@ebay/ebayui-core-react` to `@evo-web/react` as `evo-avatar`.

- Adds `EvoAvatar` and `EvoAvatarImage` components under `packages/evo-react/src/avatar/`
- Uses `a11yText` prop (mapped to `aria-label` internally) aligned with the evo-marko component
- Fixes `isFit` logic: uses `aspectRatio > 4/3` (portrait OR wide landscape) matching evo-marko — the original used `< 4/3` which was a bug
- Imports `@ebay/skin/avatar.mjs` directly in the component (no global CSS required)
- Uses `EvoIconAvatarSignedOut` instead of the `<EbayIcon name="..." />` pattern
- React 19 native `ref`, named function declarations, no `forwardRef`, no default exports
- Adds `subcomponents: { EvoAvatarImage }` in the Storybook meta so autodocs renders a props table tab per sub-component
- Updates the `evo-migrate-react` skill with guidance on the `subcomponents` convention for future migrations
- Adds browser tests (`vitest-browser-react`) and SSR snapshot tests

## Notes

The `isFit` bug fix is a deliberate behaviour change from `ebayui-core-react`: wide landscape images (aspect ratio > 4/3) now correctly get the `avatar--fit` class, consistent with the Marko implementation.

## Screenshots

N/A — visual output is identical to the existing `ebay-avatar` component; Percy will confirm.

## Checklist

<!-- For all PR types -->

- [ ] I verify the linked issue has been triaged ("Needs Triage" label removed)
- [ ] I verify all changes are within scope of the linked issue
- [ ] I added/updated/removed testing (Storybook in Skin) coverage as appropriate