### PR TITLE
feat(evo-react): add `as` prop to EvoButton for custom link component support

### DIFF
--- a/.changeset/evo-button-as-prop.md
+++ b/.changeset/evo-button-as-prop.md
@@ -1,0 +1,5 @@
+---
+"@evo-web/react": patch
+---
+
+Add `as` prop to `EvoButton` anchor variant to support custom link components (e.g. React Router `Link`, Next.js `Link`). Only applies when `href` is provided.

--- a/packages/evo-react/src/button/button.stories.tsx
+++ b/packages/evo-react/src/button/button.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { EvoButton } from "./button";
 import { EvoButtonCell } from "./button-cell";
 import type { AnchorButtonProps } from "./types";
+import { ComponentProps } from "react";
 
 // Use AnchorButtonProps so `as` (anchor-only prop) is a valid argType key.
 const meta: Meta<AnchorButtonProps> = {
@@ -106,6 +107,52 @@ type Story = StoryObj<typeof EvoButton>;
 export const Default: Story = {
   args: {
     children: "Button",
+  },
+};
+
+function Link({ to, ...rest }: ComponentProps<"a"> & { to?: string }) {
+  return (
+    <a
+      data-custom-link="true"
+      {...rest}
+      href={to}
+      onClick={(event) => {
+        event.preventDefault();
+        alert("client side navigation");
+      }}
+    />
+  );
+}
+
+export const WithCustomLinkComponent: Story = {
+  render: (args) => {
+    return (
+      <EvoButton
+        {...(args as unknown as AnchorButtonProps)}
+        href="/home"
+        as={({ href, ...rest }) => <Link {...rest} to={href} />}
+        priority="primary"
+      >
+        Click me
+      </EvoButton>
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: `
+Pass a custom component via the \`as\` prop to replace the native \`<a>\`. Only applies when \`href\` is set. Here we simulate React Router\'s \`<Link to="/home">\`
+
+\`\`\`tsx
+import { Link, href } from "react-router";
+
+<EvoButton
+  href={href("/home")}
+  as=(({ href, ...rest }) => <Link {...rest} to={href} />)
+\`\`\`
+`,
+      },
+    },
   },
 };
 

--- a/packages/evo-react/src/button/button.stories.tsx
+++ b/packages/evo-react/src/button/button.stories.tsx
@@ -1,8 +1,10 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { EvoButton } from "./button";
 import { EvoButtonCell } from "./button-cell";
+import type { AnchorButtonProps } from "./types";
 
-const meta: Meta<typeof EvoButton> = {
+// Use AnchorButtonProps so `as` (anchor-only prop) is a valid argType key.
+const meta: Meta<AnchorButtonProps> = {
   title: "buttons/evo-button",
   component: EvoButton,
   subcomponents: { EvoButtonCell },

--- a/packages/evo-react/src/button/button.stories.tsx
+++ b/packages/evo-react/src/button/button.stories.tsx
@@ -80,6 +80,11 @@ import { EvoButton } from "@evo-web/react/button";
       control: "text",
       description: "Link URL (renders as anchor)",
     },
+    as: {
+      control: false,
+      description:
+        "Override the anchor element with a custom component (e.g. React Router's `Link`). Only applies when `href` is provided.",
+    },
     children: {
       control: "text",
       description: "Button text content",

--- a/packages/evo-react/src/button/button.tsx
+++ b/packages/evo-react/src/button/button.tsx
@@ -31,6 +31,7 @@ export function EvoButton(
     onEscape,
     truncate = false,
     href,
+    as: Component = "a",
     className: extraClasses,
     borderless,
     fixedHeight,
@@ -111,7 +112,7 @@ export function EvoButton(
 
   if (href) {
     return (
-      <a
+      <Component
         {...(rest as React.ComponentProps<"a">)}
         className={className}
         href={disabled ? undefined : href}
@@ -119,7 +120,7 @@ export function EvoButton(
         aria-live={ariaLive}
       >
         {bodyContent}
-      </a>
+      </Component>
     );
   }
 

--- a/packages/evo-react/src/button/button.tsx
+++ b/packages/evo-react/src/button/button.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import classNames from "classnames";
 import type {
   AnchorButtonProps,
+  EvoButtonProps,
   NativeButtonProps,
   Priority,
   Size,
@@ -31,12 +32,12 @@ export function EvoButton(
     onEscape,
     truncate = false,
     href,
-    as: Component = "a",
+    as: _as,
     className: extraClasses,
     borderless,
     fixedHeight,
     ...rest
-  } = props;
+  } = props as EvoButtonProps;
   const classPrefix = href ? "fake-btn" : "btn";
   const priorityStyles: { [key in Priority]: string } = {
     primary: `${classPrefix}--primary`,
@@ -111,6 +112,7 @@ export function EvoButton(
   };
 
   if (href) {
+    const Component = (_as as AnchorButtonProps["as"]) ?? "a";
     return (
       <Component
         {...(rest as React.ComponentProps<"a">)}

--- a/packages/evo-react/src/button/test/__snapshots__/test.server.tsx.snap
+++ b/packages/evo-react/src/button/test/__snapshots__/test.server.tsx.snap
@@ -74,6 +74,8 @@ exports[`EvoButton SSR > should render with ButtonCell 1`] = `"<button class="bt
 
 exports[`EvoButton SSR > should render with aria-label 1`] = `"<button aria-label="Submit form" class="btn btn--secondary">Submit</button>"`;
 
+exports[`EvoButton SSR > should render with custom \`as\` component 1`] = `"<a data-custom-link="true" href="/home" class="fake-btn fake-btn--primary">Custom Link</a>"`;
+
 exports[`EvoButton SSR > should render with custom className 1`] = `"<button class="btn custom-class btn--secondary">Button</button>"`;
 
 exports[`EvoButton SSR > should render with data attributes 1`] = `"<button data-testid="button" class="btn btn--secondary">Button</button>"`;

--- a/packages/evo-react/src/button/test/test.browser.tsx
+++ b/packages/evo-react/src/button/test/test.browser.tsx
@@ -133,6 +133,42 @@ describe("evo-button", () => {
     });
   });
 
+  describe("as prop", () => {
+    it("renders with a custom component when `as` is provided", async () => {
+      type CustomLinkProps = React.ComponentProps<"a">;
+      const CustomLink = ({ href, children, ...rest }: CustomLinkProps) => (
+        <a data-custom-link="true" href={href} {...rest}>
+          {children}
+        </a>
+      );
+
+      const screen = await render(
+        <EvoButton href="/home" as={CustomLink}>
+          Custom Link
+        </EvoButton>,
+      );
+
+      const link = screen.getByRole("link");
+      await expect.element(link).toHaveAttribute("data-custom-link", "true");
+      await expect.element(link).toHaveAttribute("href", "/home");
+    });
+
+    it("applies all button classes when `as` is provided", async () => {
+      type CustomLinkProps = React.ComponentProps<"a">;
+      const CustomLink = (props: CustomLinkProps) => <a {...props} />;
+
+      const screen = await render(
+        <EvoButton href="/home" as={CustomLink} priority="primary">
+          Custom Link
+        </EvoButton>,
+      );
+
+      const link = screen.getByRole("link");
+      await expect.element(link).toHaveClass("fake-btn");
+      await expect.element(link).toHaveClass("fake-btn--primary");
+    });
+  });
+
   describe("anchor element behavior", () => {
     it("renders as link when href is provided", async () => {
       const screen = await render(

--- a/packages/evo-react/src/button/test/test.server.tsx
+++ b/packages/evo-react/src/button/test/test.server.tsx
@@ -155,7 +155,7 @@ describe("EvoButton SSR", () => {
   it("should render with custom `as` component", () => {
     type CustomLinkProps = React.ComponentProps<"a">;
     const CustomLink = ({ href, children, ...rest }: CustomLinkProps) => (
-      <a data-custom-link href={href} {...rest}>
+      <a data-custom-link="true" href={href} {...rest}>
         {children}
       </a>
     );

--- a/packages/evo-react/src/button/test/test.server.tsx
+++ b/packages/evo-react/src/button/test/test.server.tsx
@@ -152,6 +152,23 @@ describe("EvoButton SSR", () => {
     ).toMatchSnapshot();
   });
 
+  it("should render with custom `as` component", () => {
+    type CustomLinkProps = React.ComponentProps<"a">;
+    const CustomLink = ({ href, children, ...rest }: CustomLinkProps) => (
+      <a data-custom-link href={href} {...rest}>
+        {children}
+      </a>
+    );
+
+    expect(
+      renderToString(
+        <EvoButton href="/home" as={CustomLink} priority="primary">
+          Custom Link
+        </EvoButton>,
+      ),
+    ).toMatchSnapshot();
+  });
+
   it("should render disabled link without href", () => {
     expect(
       renderToString(

--- a/packages/evo-react/src/button/types.ts
+++ b/packages/evo-react/src/button/types.ts
@@ -1,4 +1,4 @@
-import type { ComponentProps, KeyboardEvent } from "react";
+import type { ComponentProps, ComponentType, KeyboardEvent } from "react";
 
 export type Priority = "primary" | "secondary" | "tertiary" | "none";
 export type Variant = "standard" | "destructive" | "form";
@@ -23,6 +23,7 @@ type BaseButtonProps = {
 export type AnchorButtonProps = ComponentProps<"a"> &
   BaseButtonProps & {
     href: string;
+    as?: ComponentType<ComponentProps<"a">>;
     onEscape?: (e: KeyboardEvent<HTMLAnchorElement>) => void;
     disabled?: boolean;
   };

--- a/packages/evo-react/src/button/types.ts
+++ b/packages/evo-react/src/button/types.ts
@@ -31,6 +31,7 @@ export type AnchorButtonProps = ComponentProps<"a"> &
 export type NativeButtonProps = ComponentProps<"button"> &
   BaseButtonProps & {
     href?: never;
+    as?: never;
     onEscape?: (e: KeyboardEvent<HTMLButtonElement>) => void;
   };
 


### PR DESCRIPTION
<!-- Insert GitHub issue number below. An issue is required for all PRs -->

- Fixes #

## Description

Adds an `as` prop to `EvoButton`'s anchor variant (i.e. when `href` is provided), following the same pattern established in `evo-breadcrumbs`. This allows consumers to substitute the native `<a>` element with any component that accepts the same props — such as React Router's `<Link>`, Next.js's `<Link>`, or any other framework router.

**Usage example:**
```tsx
import { Link } from 'react-router';

function LinkHref({ href, ...rest }) {
  return <Link to={href} {...rest} />
}

<EvoButton href="/home" as={LinkHref} priority="primary">
  Go Home
</EvoButton>
```

**Changes:**
- `types.ts` — Added `as?: ComponentType<ComponentProps<"a">>` to `AnchorButtonProps` and `as?: never` to `NativeButtonProps` (so the prop is safely destructurable across the union without TypeScript errors)
- `button.tsx` — Destructures `as` from props (keeping it out of `...rest` so it's never leaked to the DOM) and uses the resolved `Component` in the anchor branch
- `button.stories.tsx` — Widened `Meta` type to `AnchorButtonProps` and documented `as` in `argTypes`
- `test/test.server.tsx` — Added SSR snapshot test for the `as` prop
- `test/test.browser.tsx` — Added two browser tests: verifies custom component renders with its own attributes, and that all `fake-btn` classes are correctly applied

## Notes

- `as` is **only** valid when `href` is also provided. Passing `as` without `href` is a TypeScript error (`as?: never` on `NativeButtonProps`)
- The prop is extracted before `...rest` spread so it is never forwarded to the DOM
- Pattern is identical to `evo-breadcrumbs` (`BreadcrumbLink` component on the `evo-react-breadcrumb` branch)

## Screenshots

N/A — no visual change; the rendered HTML is identical to the default `<a>` unless a custom component changes its own output.

## Checklist

<!-- For all PR types -->

- [ ] I verify the linked issue has been triaged ("Needs Triage" label removed)
- [ ] I verify all changes are within scope of the linked issue
- [ ] I added/updated/removed testing (Storybook in Skin) coverage as appropriate