### PR TITLE
feat(evo-react): migrate ebay-badge to evo-badge

### DIFF
--- a/.changeset/add-evo-badge-react.md
+++ b/.changeset/add-evo-badge-react.md
@@ -1,0 +1,5 @@
+---
+"@evo-web/react": patch
+---
+
+Add `EvoBadge` component migrated from `@ebay/ebayui-core-react/ebay-badge`

--- a/.claude/skills/evo-app-migrate-react/SKILL.md
+++ b/.claude/skills/evo-app-migrate-react/SKILL.md
@@ -63,6 +63,7 @@ When migrating a listed component, read the linked file completely and apply the
 | ebayui-core-react component | Migration details                                   |
 | --------------------------- | --------------------------------------------------- |
 | `ebay-accordion`            | [evo-accordion.md](components/evo-accordion.md)     |
+| `ebay-badge`                | [evo-badge.md](components/evo-badge.md)             |
 | `ebay-breadcrumbs`          | [evo-breadcrumbs.md](components/evo-breadcrumbs.md) |
 | `ebay-button`               | [evo-button.md](components/evo-button.md)           |
 | `ebay-details`              | [evo-details.md](components/evo-details.md)         |

--- a/.claude/skills/evo-app-migrate-react/components/evo-badge.md
+++ b/.claude/skills/evo-app-migrate-react/components/evo-badge.md
@@ -1,0 +1,37 @@
+# evo-badge migration guide
+
+## Changed props
+
+### `type` — narrowed values
+
+**Before:** `"menu" | "icon" | "img"`  
+**After:** `"menu" | "icon"` (omit the prop entirely for the default image badge)
+
+The `"img"` value has been removed. Omitting `type` (or not passing it) now produces the default badge with `role="img"`, which was previously the `type="img"` behaviour.
+
+```diff
+- <EbayBadge number={5} type="img" aria-label="5 unread items" />
++ <EvoBadge number={5} a11yText="5 unread items" />
+```
+
+### `aria-label` → `a11yText`
+
+The custom `aria-label` prop is replaced with `a11yText` (mapped internally to `aria-label`).
+
+`a11yText` is typed as `string | null`. Pass `null` explicitly _only_ if alternative accessibility information is present (e.g. `type="menu"` or `type="icon"` where the badge is considered decorative).
+
+```diff
+- <EbayBadge number={5} aria-label="5 unread items" />
++ <EvoBadge number={5} a11yText="5 unread items" />
+
+- <EbayBadge number={5} type="menu" />
++ <EvoBadge number={5} type="menu" a11yText={null} />
+```
+
+### `aria-hidden` — removed
+
+`aria-hidden` was set automatically by `EbayBadge` when `type` was not `"img"`. `EvoBadge` no longer sets `aria-hidden`; use `a11yText={null}` instead and rely on the absence of `role="img"` for non-image badges.
+
+## No other prop changes
+
+All standard `<span>` attributes pass through as before. `number` behaves identically (accepts `number | string`, rounds, clamps at 99+, renders nothing for ≤ 0).

--- a/.claude/skills/evo-migrate-react/SKILL.md
+++ b/.claude/skills/evo-migrate-react/SKILL.md
@@ -59,7 +59,7 @@ packages/evo-react/src/{name}/
 
 ## Documentation
 
-[Storybook](https://opensource.ebay.com/evo-web/react/main/?path=/docs/buttons-evo-button--documentation)
+[Storybook](https://opensource.ebay.com/evo-web/react/?path=/docs/buttons-evo-button--documentation)
 ```
 
 ---

--- a/packages/evo-react/src/badge/README.md
+++ b/packages/evo-react/src/badge/README.md
@@ -1,0 +1,5 @@
+# EvoBadge
+
+## Documentation
+
+[Storybook](https://opensource.ebay.com/evo-web/react/?path=/docs/graphics-icons-evo-badge--documentation)

--- a/packages/evo-react/src/badge/badge.stories.tsx
+++ b/packages/evo-react/src/badge/badge.stories.tsx
@@ -1,0 +1,70 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { EvoBadge } from "./badge";
+
+const meta: Meta<typeof EvoBadge> = {
+  title: "graphics & icons/evo-badge",
+  component: EvoBadge,
+  tags: ["autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component: `
+A badge component that displays a numeric count.
+
+## Usage
+
+\`\`\`tsx
+import { EvoBadge } from "@evo-web/react/badge";
+\`\`\`
+        `,
+      },
+    },
+  },
+  argTypes: {
+    number: {
+      control: "number",
+      description: "Used as the number to be placed in the badge",
+    },
+    type: {
+      control: "inline-radio",
+      options: ["menu", "icon"],
+      description:
+        "The badge type. Omit for the default image badge (role='img').",
+    },
+    a11yText: {
+      type: { name: "string", required: true },
+      control: "text",
+      description:
+        'A descriptive label of what the badge represents (e.g. "5 unread items"). Pass `null` explicitly _only_ if alternative accessibility information is present.',
+    },
+  },
+  args: {
+    number: 5,
+    a11yText: "5 unread items",
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof EvoBadge>;
+
+export const Default: Story = {
+  args: {
+    number: 5,
+    a11yText: "5 unread items",
+  },
+};
+
+export const LargeNumber: Story = {
+  args: {
+    number: 120,
+    a11yText: "120 unread items",
+  },
+};
+
+export const Zero: Story = {
+  args: {
+    number: 0,
+    a11yText: "0 unread items",
+  },
+};

--- a/packages/evo-react/src/badge/badge.stories.tsx
+++ b/packages/evo-react/src/badge/badge.stories.tsx
@@ -48,23 +48,4 @@ export default meta;
 
 type Story = StoryObj<typeof EvoBadge>;
 
-export const Default: Story = {
-  args: {
-    number: 5,
-    a11yText: "5 unread items",
-  },
-};
-
-export const LargeNumber: Story = {
-  args: {
-    number: 120,
-    a11yText: "120 unread items",
-  },
-};
-
-export const Zero: Story = {
-  args: {
-    number: 0,
-    a11yText: "0 unread items",
-  },
-};
+export const Default: Story = {};

--- a/packages/evo-react/src/badge/badge.tsx
+++ b/packages/evo-react/src/badge/badge.tsx
@@ -1,0 +1,30 @@
+import classNames from "classnames";
+import type { EvoBadgeProps } from "./types";
+import "@ebay/skin/badge.mjs";
+
+export function EvoBadge({
+  number,
+  type,
+  a11yText,
+  className,
+  ...rest
+}: EvoBadgeProps) {
+  const parsed = Math.round(parseInt(String(number), 10));
+
+  if (!(parsed > 0)) {
+    return null;
+  }
+
+  const isImg = type !== "menu" && type !== "icon";
+
+  return (
+    <span
+      {...rest}
+      className={classNames("badge", className)}
+      aria-label={a11yText ?? undefined}
+      role={isImg ? "img" : undefined}
+    >
+      {parsed > 99 ? "99+" : parsed}
+    </span>
+  );
+}

--- a/packages/evo-react/src/badge/badge.tsx
+++ b/packages/evo-react/src/badge/badge.tsx
@@ -9,7 +9,7 @@ export function EvoBadge({
   className,
   ...rest
 }: EvoBadgeProps) {
-  const parsed = Math.round(parseInt(String(number), 10));
+  const parsed = parseInt(String(number), 10);
 
   if (!(parsed > 0)) {
     return null;

--- a/packages/evo-react/src/badge/index.ts
+++ b/packages/evo-react/src/badge/index.ts
@@ -1,0 +1,2 @@
+export { EvoBadge } from "./badge";
+export type { EvoBadgeProps, BadgeType } from "./types";

--- a/packages/evo-react/src/badge/test/__snapshots__/test.server.tsx.snap
+++ b/packages/evo-react/src/badge/test/__snapshots__/test.server.tsx.snap
@@ -1,0 +1,15 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`EvoBadge SSR > renders defaults 1`] = `"<span class="badge" aria-label="5 unread items" role="img">5</span>"`;
+
+exports[`EvoBadge SSR > renders with a custom className 1`] = `"<span class="badge custom-class" aria-label="5 unread items" role="img">5</span>"`;
+
+exports[`EvoBadge SSR > renders with additional html attributes 1`] = `"<span data-testid="my-badge" class="badge" aria-label="5 unread items" role="img">5</span>"`;
+
+exports[`EvoBadge SSR > renders with null a11yText (no aria-label) 1`] = `"<span class="badge">5</span>"`;
+
+exports[`EvoBadge SSR > renders with type=icon 1`] = `"<span class="badge">5</span>"`;
+
+exports[`EvoBadge SSR > renders with type=menu 1`] = `"<span class="badge">5</span>"`;
+
+exports[`EvoBadge SSR > truncates numbers greater than 99 1`] = `"<span class="badge" aria-label="99+ unread items" role="img">99+</span>"`;

--- a/packages/evo-react/src/badge/test/test.browser.tsx
+++ b/packages/evo-react/src/badge/test/test.browser.tsx
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+import { render } from "vitest-browser-react";
+import { EvoBadge } from "../badge";
+
+describe("evo-badge", () => {
+  describe("given a positive number", () => {
+    it("renders the badge with the number", async () => {
+      const screen = await render(<EvoBadge number={5} a11yText="5 unread items" />);
+      await expect.element(screen.getByText("5")).toBeInTheDocument();
+    });
+
+    it("rounds down decimal values", async () => {
+      const screen = await render(<EvoBadge number={5.6} a11yText="5 unread items" />);
+      await expect.element(screen.getByText("5")).toBeInTheDocument();
+    });
+
+    it("truncates numbers greater than 99 to '99+'", async () => {
+      const screen = await render(<EvoBadge number={150} a11yText="99+ unread items" />);
+      await expect.element(screen.getByText("99+")).toBeInTheDocument();
+    });
+  });
+
+  describe("given a string number", () => {
+    it("renders the badge with the coerced number", async () => {
+      const screen = await render(<EvoBadge number="5" a11yText="5 unread items" />);
+      await expect.element(screen.getByText("5")).toBeInTheDocument();
+    });
+
+    it("rounds down decimal string values", async () => {
+      const screen = await render(<EvoBadge number="5.6" a11yText="5 unread items" />);
+      await expect.element(screen.getByText("5")).toBeInTheDocument();
+    });
+
+    it("does not render with an invalid string", async () => {
+      const { container } = await render(<EvoBadge number="five" a11yText="unread items" />);
+      expect(container.querySelector(".badge")).toBeNull();
+    });
+
+    it("does not render with a negative string", async () => {
+      const { container } = await render(<EvoBadge number="-5" a11yText="unread items" />);
+      expect(container.querySelector(".badge")).toBeNull();
+    });
+  });
+
+  describe("given zero or negative number", () => {
+    it("does not render when number is zero", async () => {
+      const { container } = await render(<EvoBadge number={0} a11yText="0 unread items" />);
+      expect(container.querySelector(".badge")).toBeNull();
+    });
+
+    it("does not render when number is negative", async () => {
+      const { container } = await render(<EvoBadge number={-5} a11yText="unread items" />);
+      expect(container.querySelector(".badge")).toBeNull();
+    });
+  });
+
+  describe("accessibility", () => {
+    it("has role='img' and aria-label by default", async () => {
+      const screen = await render(<EvoBadge number={3} a11yText="3 unread items" />);
+      const badge = screen.getByRole("img");
+      await expect.element(badge).toHaveAttribute("aria-label", "3 unread items");
+    });
+
+    it("does not set role='img' for menu type", async () => {
+      const { container } = await render(
+        <EvoBadge number={3} type="menu" a11yText={null} />,
+      );
+      const badge = container.querySelector(".badge");
+      expect(badge?.getAttribute("role")).toBeNull();
+    });
+
+    it("does not set role='img' for icon type", async () => {
+      const { container } = await render(
+        <EvoBadge number={3} type="icon" a11yText={null} />,
+      );
+      const badge = container.querySelector(".badge");
+      expect(badge?.getAttribute("role")).toBeNull();
+    });
+
+    it("passes null a11yText as no aria-label", async () => {
+      const { container } = await render(
+        <EvoBadge number={3} type="menu" a11yText={null} />,
+      );
+      const badge = container.querySelector(".badge");
+      expect(badge?.getAttribute("aria-label")).toBeNull();
+    });
+  });
+
+  describe("className passthrough", () => {
+    it("appends custom className to badge", async () => {
+      const { container } = await render(
+        <EvoBadge number={5} a11yText="5 unread items" className="custom-class" />,
+      );
+      const badge = container.querySelector(".badge");
+      expect(badge).toHaveClass("custom-class");
+    });
+  });
+});

--- a/packages/evo-react/src/badge/test/test.browser.tsx
+++ b/packages/evo-react/src/badge/test/test.browser.tsx
@@ -9,7 +9,7 @@ describe("evo-badge", () => {
       await expect.element(screen.getByText("5")).toBeInTheDocument();
     });
 
-    it("rounds down decimal values", async () => {
+    it("truncates decimal values", async () => {
       const screen = await render(<EvoBadge number={5.6} a11yText="5 unread items" />);
       await expect.element(screen.getByText("5")).toBeInTheDocument();
     });
@@ -26,7 +26,7 @@ describe("evo-badge", () => {
       await expect.element(screen.getByText("5")).toBeInTheDocument();
     });
 
-    it("rounds down decimal string values", async () => {
+    it("truncates decimal string values", async () => {
       const screen = await render(<EvoBadge number="5.6" a11yText="5 unread items" />);
       await expect.element(screen.getByText("5")).toBeInTheDocument();
     });

--- a/packages/evo-react/src/badge/test/test.server.tsx
+++ b/packages/evo-react/src/badge/test/test.server.tsx
@@ -1,0 +1,63 @@
+import { it, expect, describe } from "vitest";
+import { renderToString } from "react-dom/server";
+import { EvoBadge } from "../badge";
+import type { BadgeType } from "../types";
+
+describe("EvoBadge SSR", () => {
+  it("renders defaults", () => {
+    expect(
+      renderToString(<EvoBadge number={5} a11yText="5 unread items" />),
+    ).toMatchSnapshot();
+  });
+
+  it("renders nothing for zero", () => {
+    expect(
+      renderToString(<EvoBadge number={0} a11yText="0 unread items" />),
+    ).toBe("");
+  });
+
+  it("renders nothing for negative numbers", () => {
+    expect(
+      renderToString(<EvoBadge number={-1} a11yText="unread items" />),
+    ).toBe("");
+  });
+
+  it("truncates numbers greater than 99", () => {
+    expect(
+      renderToString(<EvoBadge number={150} a11yText="99+ unread items" />),
+    ).toMatchSnapshot();
+  });
+
+  it.each<BadgeType>(["menu", "icon"])(
+    "renders with type=%s",
+    (type) => {
+      expect(
+        renderToString(
+          <EvoBadge number={5} type={type} a11yText={null} />,
+        ),
+      ).toMatchSnapshot();
+    },
+  );
+
+  it("renders with null a11yText (no aria-label)", () => {
+    expect(
+      renderToString(<EvoBadge number={5} type="menu" a11yText={null} />),
+    ).toMatchSnapshot();
+  });
+
+  it("renders with a custom className", () => {
+    expect(
+      renderToString(
+        <EvoBadge number={5} a11yText="5 unread items" className="custom-class" />,
+      ),
+    ).toMatchSnapshot();
+  });
+
+  it("renders with additional html attributes", () => {
+    expect(
+      renderToString(
+        <EvoBadge number={5} a11yText="5 unread items" data-testid="my-badge" />,
+      ),
+    ).toMatchSnapshot();
+  });
+});

--- a/packages/evo-react/src/badge/types.ts
+++ b/packages/evo-react/src/badge/types.ts
@@ -2,7 +2,7 @@ import type { ComponentProps } from "react";
 
 export type BadgeType = "menu" | "icon";
 
-export type EvoBadgeProps = Omit<ComponentProps<"span">, "role" | "aria-label"> & {
+export type EvoBadgeProps = Omit<ComponentProps<"span">, "role" | "aria-label" | "children"> & {
   number?: number | string;
   type?: BadgeType;
   a11yText: string | null;

--- a/packages/evo-react/src/badge/types.ts
+++ b/packages/evo-react/src/badge/types.ts
@@ -1,0 +1,22 @@
+import type { ComponentProps } from "react";
+
+export type BadgeType = "menu" | "icon";
+
+export type EvoBadgeProps = Omit<ComponentProps<"span">, "role" | "aria-label"> & {
+  /**
+   * The number to display in the badge.
+   */
+  number?: number | string;
+  /**
+   * The badge type. Omit for the default image/img role badge.
+   */
+  type?: BadgeType;
+  /**
+   * The accessible label for the badge.
+   *
+   * English default to be overridden is `"n unread items"`.
+   *
+   * Pass `null` explicitly _only_ if alternative accessibility information is present.
+   */
+  a11yText: string | null;
+};

--- a/packages/evo-react/src/badge/types.ts
+++ b/packages/evo-react/src/badge/types.ts
@@ -3,20 +3,7 @@ import type { ComponentProps } from "react";
 export type BadgeType = "menu" | "icon";
 
 export type EvoBadgeProps = Omit<ComponentProps<"span">, "role" | "aria-label"> & {
-  /**
-   * The number to display in the badge.
-   */
   number?: number | string;
-  /**
-   * The badge type. Omit for the default image/img role badge.
-   */
   type?: BadgeType;
-  /**
-   * The accessible label for the badge.
-   *
-   * English default to be overridden is `"n unread items"`.
-   *
-   * Pass `null` explicitly _only_ if alternative accessibility information is present.
-   */
   a11yText: string | null;
 };


### PR DESCRIPTION
<!-- Insert GitHub issue number below. An issue is required for all PRs -->

- Fixes #

## Description

Migrates `ebay-badge` from `@ebay/ebayui-core-react` to a new `EvoBadge` component in `@evo-web/react`.

**Key changes from `EbayBadge`:**
- `aria-label` prop replaced with `a11yText: string | null` (aligns with evo-marko convention; mapped internally to `aria-label`)
- `type` values narrowed from `"menu" | "icon" | "img"` to `"menu" | "icon"` — omitting `type` produces the default `role="img"` badge
- `aria-hidden` no longer set automatically; use `a11yText={null}` for non-image badges instead
- Named exports only, no `FC<Props>`, no `forwardRef`, no `import React`
- Skin CSS imported as `@ebay/skin/badge.mjs`

**Files added:**
- `packages/evo-react/src/badge/badge.tsx` — `EvoBadge` component
- `packages/evo-react/src/badge/types.ts` — `EvoBadgeProps`, `BadgeType`
- `packages/evo-react/src/badge/index.ts` — named re-exports
- `packages/evo-react/src/badge/README.md`
- `packages/evo-react/src/badge/badge.stories.tsx`
- `packages/evo-react/src/badge/test/test.browser.tsx` — `vitest-browser-react` tests
- `packages/evo-react/src/badge/test/test.server.tsx` — SSR snapshot tests
- `.changeset/add-evo-badge-react.md` — patch bump for `@evo-web/react`

**Skill updates:**
- `.claude/skills/evo-migrate-react/SKILL.md` — fixed example Storybook URL (removed `/main` path segment)
- `.claude/skills/evo-app-migrate-react/components/evo-badge.md` — per-component app migration guide
- `.claude/skills/evo-app-migrate-react/SKILL.md` — added `ebay-badge` row to component table

## Notes

N/A

## Screenshots

N/A — no visual changes (CSS is unchanged; component wraps existing Skin badge classes)

## Checklist

- [ ] I verify the linked issue has been triaged ("Needs Triage" label removed)
- [ ] I verify all changes are within scope of the linked issue
- [ ] I added/updated/removed testing (Storybook in Skin) coverage as appropriate