### PR TITLE
fix(workflow): modified PR Percy workflow for better security

### DIFF
--- a/.github/workflows/percy-build.yml
+++ b/.github/workflows/percy-build.yml
@@ -1,0 +1,63 @@
+name: Percy Build
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    paths:
+      - 'packages/skin/dist/**'
+      - 'packages/skin/.storybook/**'
+      - 'packages/skin/src/sass/**/*.stories.js'
+      - '.github/workflows/percy-build.yml'
+      - '.github/workflows/percy.yml'
+      - 'packages/skin/.percy.yml'
+
+concurrency:
+  group: "percy-build-${{ github.head_ref }}"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build Storybook for Percy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch base branch
+        run: |
+          git remote add upstream https://github.com/${{ github.repository }}.git
+          git fetch upstream main:main
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Detect changed components
+        id: detect
+        uses: ./.github/actions/detect-changed-components
+        with:
+          sass-dir: 'packages/skin/src/sass'
+          base-branch: 'main'
+
+      - name: Build Storybook
+        run: npm run build:storybook -w packages/skin
+
+      - name: Save Percy metadata
+        run: |
+          echo "${{ steps.detect.outputs.components }}" > packages/skin/_site/public/storybook/.percy-components
+          echo "${{ github.event.pull_request.number }}" > packages/skin/_site/public/storybook/.percy-pr-number
+          echo "${{ github.event.pull_request.head.sha }}" > packages/skin/_site/public/storybook/.percy-commit
+          echo "${{ github.head_ref }}" > packages/skin/_site/public/storybook/.percy-branch
+
+      - name: Upload Storybook artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: storybook-static
+          path: packages/skin/_site/public/storybook
+          retention-days: 1

--- a/.github/workflows/percy-build.yml
+++ b/.github/workflows/percy-build.yml
@@ -49,11 +49,16 @@ jobs:
         run: npm run build:storybook -w packages/skin
 
       - name: Save Percy metadata
+        env:
+          COMPONENTS: ${{ steps.detect.outputs.components }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          HEAD_REF: ${{ github.head_ref }}
         run: |
-          echo "${{ steps.detect.outputs.components }}" > packages/skin/_site/public/storybook/.percy-components
-          echo "${{ github.event.pull_request.number }}" > packages/skin/_site/public/storybook/.percy-pr-number
-          echo "${{ github.event.pull_request.head.sha }}" > packages/skin/_site/public/storybook/.percy-commit
-          echo "${{ github.head_ref }}" > packages/skin/_site/public/storybook/.percy-branch
+          echo "$COMPONENTS" > packages/skin/_site/public/storybook/.percy-components
+          echo "$PR_NUMBER" > packages/skin/_site/public/storybook/.percy-pr-number
+          echo "$HEAD_SHA" > packages/skin/_site/public/storybook/.percy-commit
+          echo "$HEAD_REF" > packages/skin/_site/public/storybook/.percy-branch
 
       - name: Upload Storybook artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -1,14 +1,9 @@
 name: Percy Visual Regression
 
 on:
-  pull_request_target:
-    types: [opened, synchronize]
-    paths:
-      - 'packages/skin/dist/**'
-      - 'packages/skin/.storybook/**'
-      - 'packages/skin/src/sass/**/*.stories.js'
-      - '.github/workflows/percy.yml'
-      - 'packages/skin/.percy.yml'
+  workflow_run:
+    workflows: ["Percy Build"]
+    types: [completed]
   push:
     branches: ["main"]
     paths:
@@ -17,10 +12,6 @@ on:
       - 'packages/skin/src/sass/**/*.stories.js'
       - '.github/workflows/percy.yml'
       - 'packages/skin/.percy.yml'
-
-concurrency:
-  group: "percy-${{ github.workflow }}-${{ github.event_name == 'pull_request_target' && github.head_ref || github.ref }}"
-  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -31,22 +22,28 @@ permissions:
 jobs:
   percy-pr:
     name: Percy Snapshots (PR)
-    if: github.event_name == 'pull_request_target'
+    if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - name: Post pending status to PR
+        uses: actions/github-script@v7
+        env:
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         with:
-          # For fork PRs (pull_request_target), check out the contributor's branch
-          # so we snapshot their changes, not the base branch.
-          ref: ${{ github.event.pull_request.head.sha }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          fetch-depth: 0  # Need full history for git diff
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: process.env.HEAD_SHA,
+              state: 'pending',
+              context: 'Percy Visual Regression',
+              description: 'Percy snapshots running...',
+              target_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+            });
 
-      - name: Fetch base branch
-        run: |
-          git remote add upstream https://github.com/${{ github.repository }}.git
-          git fetch upstream main:main
+      - name: Checkout base branch
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -56,26 +53,57 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Detect changed components
-        id: detect
-        uses: ./.github/actions/detect-changed-components
+      - name: Download Storybook artifact
+        uses: actions/download-artifact@v4
         with:
-          sass-dir: 'packages/skin/src/sass'
-          base-branch: 'main'
+          name: storybook-static
+          path: storybook-static
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read Percy metadata
+        id: meta
+        run: |
+          echo "components=$(cat storybook-static/.percy-components)" >> $GITHUB_OUTPUT
+          echo "pr=$(cat storybook-static/.percy-pr-number)" >> $GITHUB_OUTPUT
 
       - name: Run Percy (Partial)
-        if: steps.detect.outputs.components != '' && steps.detect.outputs.components != 'all'
+        if: steps.meta.outputs.components != '' && steps.meta.outputs.components != 'all'
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
-          PERCY_PARTIAL_BUILD: 1
-          STORIES: ${{ steps.detect.outputs.components }}
-        run: npm run snapshots -w packages/skin
+          PERCY_COMMIT: ${{ github.event.workflow_run.head_sha }}
+          PERCY_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          PERCY_PULL_REQUEST: ${{ steps.meta.outputs.pr }}
+        run: npx percy storybook ./storybook-static --include "${{ steps.meta.outputs.components }}"
 
       - name: Run Percy (All)
-        if: steps.detect.outputs.components == 'all'
+        if: steps.meta.outputs.components == 'all'
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
-        run: npm run snapshots:all -w packages/skin
+          PERCY_COMMIT: ${{ github.event.workflow_run.head_sha }}
+          PERCY_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          PERCY_PULL_REQUEST: ${{ steps.meta.outputs.pr }}
+        run: npx percy storybook ./storybook-static
+
+      - name: Report Percy status to PR
+        if: always()
+        uses: actions/github-script@v7
+        env:
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const state = process.env.JOB_STATUS === 'success' ? 'success' : 'failure';
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: process.env.HEAD_SHA,
+              state,
+              context: 'Percy Visual Regression',
+              description: state === 'success' ? 'Percy snapshots passed' : 'Percy snapshots failed',
+              target_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+            });
 
   percy-main:
     name: Percy Baseline (Main Branch)

--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -15,9 +15,8 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
-  checks: write
   statuses: write
+  actions: read
 
 jobs:
   percy-pr:
@@ -64,8 +63,16 @@ jobs:
       - name: Read Percy metadata
         id: meta
         run: |
-          echo "components=$(cat storybook-static/.percy-components)" >> $GITHUB_OUTPUT
-          echo "pr=$(cat storybook-static/.percy-pr-number)" >> $GITHUB_OUTPUT
+          {
+            echo "components<<EOF"
+            tr -d '\n' < storybook-static/.percy-components
+            echo ""
+            echo "EOF"
+            echo "pr<<EOF"
+            tr -d '\n' < storybook-static/.percy-pr-number
+            echo ""
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Run Percy (Partial)
         if: steps.meta.outputs.components != '' && steps.meta.outputs.components != 'all'
@@ -74,7 +81,8 @@ jobs:
           PERCY_COMMIT: ${{ github.event.workflow_run.head_sha }}
           PERCY_BRANCH: ${{ github.event.workflow_run.head_branch }}
           PERCY_PULL_REQUEST: ${{ steps.meta.outputs.pr }}
-        run: npx percy storybook ./storybook-static --include "${{ steps.meta.outputs.components }}"
+          STORIES: ${{ steps.meta.outputs.components }}
+        run: npx percy storybook ./storybook-static --include "$STORIES"
 
       - name: Run Percy (All)
         if: steps.meta.outputs.components == 'all'


### PR DESCRIPTION
## Summary

Replaces the `pull_request_target` approach with a secure two-stage workflow that enables Percy visual regression snapshots for fork PRs without exposing secrets to untrusted code.

### Background

Percy snapshots were silently failing for all external contributor PRs because GitHub withholds repository secrets from `pull_request` workflows triggered by forks — `PERCY_TOKEN` was always an empty string for fork PRs.

A first fix using `pull_request_target` was implemented, but due to a recent exploit of this pattern: fork code running in a privileged context poisoned the npm cache, which was later restored by a release workflow with `id-token: write`, enabling unauthorized npm publishes. Given that our `ci.yml` release job also has `id-token: write`, the risk profile was unacceptable.

### Solution

Split Percy CI into two isolated workflow stages:

**Stage 1 — `percy-build.yml` (triggered by `pull_request`, no secrets)**
- Checks out the PR code via the standard `pull_request` event — no elevated privileges
- Detects which Skin components changed via the existing `detect-changed-components` action
- Builds a static Storybook from the PR's code
- Saves Percy metadata (component list, PR number) alongside the build
- Uploads everything as a short-lived GitHub Actions artifact

**Stage 2 — `percy.yml` (triggered by `workflow_run`, has secrets)**
- Only runs when Stage 1 completes successfully — cancelled or failed builds are skipped
- Checks out the base branch and installs dependencies from there — no fork code executes at this stage
- Posts a `pending` commit status to the PR immediately so the check is visible while Percy runs
- Downloads the pre-built Storybook artifact from Stage 1
- Reads the saved metadata; commit SHA and branch are sourced directly from the `workflow_run` event payload for reliability
- Runs `percy storybook` against the static artifact, filtered to changed components when applicable
- Posts a final `success` or `failure` commit status back to the PR regardless of outcome (`if: always()`)
- `PERCY_TOKEN` only ever exists in this stage, in a fully trusted context

The main branch baseline job is unchanged — it continues to run `snapshots:all` on push to `main`.

### Security Properties

- Fork code runs in Stage 1 with no secrets and no privileged context
- `PERCY_TOKEN` is fully isolated to Stage 2, which runs entirely from base-branch code
- Eliminates the cache poisoning vector that enabled the TanStack attack: Stage 1 and Stage 2 run in separate jobs with separate npm installs, so a poisoned cache from a fork PR cannot reach the privileged stage

### Trade-offs

- Storybook is always built in full in Stage 1, with Percy filtering to changed components in Stage 2 via `--include` — slightly slower than the previous partial-build approach but required for the isolation model
- Percy status checks appear with a short delay after Stage 1 completes rather than inline with other PR checks
