### PR TITLE
fix(evo-button): add href and switch to define pattern

### DIFF
--- a/.changeset/plenty-dolls-punch.md
+++ b/.changeset/plenty-dolls-punch.md
@@ -1,0 +1,5 @@
+---
+"@evo-web/marko": patch
+---
+
+Add href to evo-button

--- a/packages/evo-marko/src/tags/evo-button/index.marko
+++ b/packages/evo-marko/src/tags/evo-button/index.marko
@@ -61,8 +61,16 @@ export interface Input extends Marko.HTML.Button, Omit<Marko.HTML.A, "type" |`on
 )>
 <const/variantClass=variant !== "standard" && `${baseClass}--${variant}`>
 
-<const/tag=href ? "a" : "button">
-<${tag}
+<define/Root|input: (Marko.HTML.Button | Marko.HTML.A)|>
+    <if=href>
+        <a ...(input as Marko.HTML.A) href=href/>
+    </if>
+    <else>
+        <button ...(input as Marko.HTML.Button) type=type/>
+    </else>
+</define>
+
+<Root
     ...htmlInput
     onKeyDown(e: KeyboardEvent) {
         if (e.key === "Escape" && !input.disabled) {
@@ -82,10 +90,8 @@ export interface Input extends Marko.HTML.Button, Omit<Marko.HTML.A, "type" |`on
         borderless && `${baseClass}--borderless`,
         validPriorities.includes(priority) && `${baseClass}--${priority}`,
     ]
-    type=type ?? (tag === "button" && "button")
-    aria-disabled=partiallyDisabled && "true"
-    aria-label=(bodyState === "loading" ? a11yLoadingText : input["aria-label"])
->
+    aria-disabled=(partiallyDisabled && "true")
+    aria-label=(bodyState === "loading" ? a11yLoadingText : input["aria-label"])>
     <if=(bodyState === "loading")>
         <span class="btn__cell">
             <evo-progress-spinner a11yText=null/>

--- a/packages/evo-marko/src/tags/evo-button/test/__snapshots__/test.server.ts.snap
+++ b/packages/evo-marko/src/tags/evo-button/test/__snapshots__/test.server.ts.snap
@@ -166,7 +166,7 @@ exports[`renders fake version 1`] = `
 "<a
   arialabel="fake button"
   class="fake-btn fake-btn--large fake-btn--primary"
-  type="button"
+  href="#"
 >
   Button
 </a>"


### PR DESCRIPTION
The button was dynamically switching to `<a>` when `href` was added, but because of an oversight it didn't actually pass `href` to the tag. This adds it, and switches to the recommended pattern over dynamic tag