### PR TITLE
feat(dependabot): track _all_ updates for design-tokens package

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-name: "@ebay/design-tokens"
+    ignore:
+      - dependency-name: "@ebay/design-tokens"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,3 @@ updates:
       interval: "daily"
     allow:
       - dependency-name: "@ebay/design-tokens"
-    ignore:
-      - dependency-name: "@ebay/design-tokens"
-        update-types:
-          - "version-update:semver-major"
-          - "version-update:semver-minor"


### PR DESCRIPTION
Configure dependabot so that it triggers a PR for all patch updates to `@ebay/design-tokens`, to ensure that we are always up to date.
- This should remove the need for issues like #675 