### PR TITLE
fix(evo-marko): close menus on focus out

### DIFF
--- a/.changeset/smooth-sheep-crash.md
+++ b/.changeset/smooth-sheep-crash.md
@@ -1,0 +1,5 @@
+---
+"@evo-web/marko": patch
+---
+
+Fix collapse behavior for menu button

--- a/packages/evo-marko/src/tags/evo-fake-menu-button/index.marko
+++ b/packages/evo-marko/src/tags/evo-fake-menu-button/index.marko
@@ -38,6 +38,7 @@ export interface Input extends Marko.HTML.Span {
     transparent: inputTransparent,
     a11yText,
     onKeyDown,
+    onFocusOut,
     ...htmlInput
 }=input>
 
@@ -81,6 +82,12 @@ export interface Input extends Marko.HTML.Span {
     onKeyDown(e, el) {
         if (open && e.key === "Escape") open = false;
         onKeyDown && onKeyDown(e, el);
+    }
+    onFocusOut(e, el) {
+        if (!el.contains(e.relatedTarget as Node)) {
+            open = false;
+        }
+        onFocusOut && onFocusOut(e, el);
     }>
     <${tagName as any}
         class="fake-menu-button__button"

--- a/packages/evo-marko/src/tags/evo-fake-menu-button/test/test.browser.ts
+++ b/packages/evo-marko/src/tags/evo-fake-menu-button/test/test.browser.ts
@@ -78,18 +78,12 @@ describe.skip("evo-fake-menu-button", () => {
 
     describe("when an item is clicked", () => {
       beforeEach(async () => {
-        const firstItem = component.container.querySelector(
-          ".fake-menu-button__item",
-        ) as HTMLElement;
-        await fireEvent.click(firstItem);
+        await fireEvent.click(component.getByRole("link", { name: /item 1/i }));
       });
 
       it("should fire native click event", () => {
         // Native click events pass through -- no custom event wrapping
-        const firstItem = component.container.querySelector(
-          ".fake-menu-button__item",
-        );
-        expect(firstItem).toBeTruthy();
+        expect(component.getByRole("link", { name: /item 1/i })).toBeTruthy();
       });
     });
 
@@ -101,9 +95,7 @@ describe("given the evo-fake-menu-button is open", () => {
 
   beforeEach(async () => {
     component = await render(Default);
-    triggerButton = component.container.querySelector(
-      ".fake-menu-button__button",
-    ) as HTMLElement;
+    triggerButton = component.getByRole("button", { name: /eBay Menu/i });
     await fireEvent.click(triggerButton);
   });
 

--- a/packages/evo-marko/src/tags/evo-fake-menu-button/test/test.browser.ts
+++ b/packages/evo-marko/src/tags/evo-fake-menu-button/test/test.browser.ts
@@ -92,5 +92,30 @@ describe.skip("evo-fake-menu-button", () => {
         expect(firstItem).toBeTruthy();
       });
     });
+
+  });
+});
+
+describe("given the evo-fake-menu-button is open", () => {
+  let triggerButton: HTMLElement;
+
+  beforeEach(async () => {
+    component = await render(Default);
+    triggerButton = component.container.querySelector(
+      ".fake-menu-button__button",
+    ) as HTMLElement;
+    await fireEvent.click(triggerButton);
+  });
+
+  describe("when focus moves outside the component", () => {
+    beforeEach(async () => {
+      await fireEvent.focusOut(triggerButton, {
+        relatedTarget: document.body,
+      });
+    });
+
+    it("then it collapses", () => {
+      expect(triggerButton).toHaveAttribute("aria-expanded", "false");
+    });
   });
 });

--- a/packages/evo-marko/src/tags/evo-menu-button/index.marko
+++ b/packages/evo-marko/src/tags/evo-menu-button/index.marko
@@ -46,6 +46,7 @@ export interface Input<
     collapseOnSelect,
     transparent: inputTransparent,
     onKeyDown,
+    onFocusOut,
     ...htmlInput
 }=input>
 
@@ -105,6 +106,12 @@ export interface Input<
     onKeyDown(e, el) {
         if (open && e.key === "Escape") open = false;
         onKeyDown && onKeyDown(e, el);
+    }
+    onFocusOut(e, el) {
+        if (!el.contains(e.relatedTarget as Node)) {
+            open = false;
+        }
+        onFocusOut && onFocusOut(e, el);
     }>
     <${tagName as any}
         class=[`menu-button__button`]

--- a/packages/evo-marko/src/tags/evo-menu-button/test/test.browser.ts
+++ b/packages/evo-marko/src/tags/evo-menu-button/test/test.browser.ts
@@ -227,6 +227,7 @@ describe.skip("given the menu is in the expanded state", () => {
             expect(component.emitted("collapse")).to.have.property("length", 1);
         });
     });
+
 });
 
 describe.skip("given the menu is in the expanded state with radio items", () => {
@@ -372,6 +373,28 @@ describe.skip("given the menu is in the expanded state with checkbox items", () 
 
         it("then the item is unchecked", () => {
             expect(firstItem).toHaveAttribute("aria-checked", "false");
+        });
+    });
+});
+
+describe("given the evo-menu-button is open", () => {
+    beforeEach(async () => {
+        component = await render(Default);
+        await fireEvent.click(component.getByRole("button"));
+    });
+
+    describe("when focus moves outside the component", () => {
+        beforeEach(async () => {
+            await fireEvent.focusOut(component.getByRole("button"), {
+                relatedTarget: document.body,
+            });
+        });
+
+        it("then it collapses", () => {
+            expect(component.getByRole("button")).toHaveAttribute(
+                "aria-expanded",
+                "false",
+            );
         });
     });
 });


### PR DESCRIPTION
Collapse `evo-menu-button` and `evo-fake-menu-button` on focus out
