### PR TITLE
feat(icon-button): use :has() selector for badged state

### DIFF
--- a/.changeset/dark-sloths-relate.md
+++ b/.changeset/dark-sloths-relate.md
@@ -1,0 +1,6 @@
+---
+"@ebay/skin": minor
+"@evo-web/marko": patch
+---
+
+feat(icon-button): use "has()" selector for badged use case

--- a/packages/evo-marko/src/tags/evo-icon-button/index.marko
+++ b/packages/evo-marko/src/tags/evo-icon-button/index.marko
@@ -51,7 +51,6 @@ export interface Input
     class=[
         inputClass,
         baseClassName,
-        badge?.number && `${baseClassName}--badged`,
         transparent && `${baseClassName}--transparent`,
         validPriorities.includes(priority) && `${baseClassName}--${priority}`,
         size && validSizes.includes(size) && `${baseClassName}--${size}`,

--- a/packages/skin/dist/icon-button/icon-button.css
+++ b/packages/skin/dist/icon-button/icon-button.css
@@ -156,12 +156,16 @@ a.icon-link.icon-link--primary:visited > svg {
     fill: var(--color-foreground-on-accent);
 }
 a.icon-link--badged,
-button.icon-btn--badged {
+a.icon-link--badged:has(.badge),
+button.icon-btn--badged,
+button.icon-btn:has(.badge) {
     overflow: visible;
     position: relative;
 }
 a.icon-link--badged .badge,
-button.icon-btn--badged .badge {
+a.icon-link--badged:has(.badge) .badge,
+button.icon-btn--badged .badge,
+button.icon-btn:has(.badge) .badge {
     left: 24px;
     pointer-events: none;
     position: absolute;

--- a/packages/skin/dist/icon-button/icon-button.css
+++ b/packages/skin/dist/icon-button/icon-button.css
@@ -156,14 +156,14 @@ a.icon-link.icon-link--primary:visited > svg {
     fill: var(--color-foreground-on-accent);
 }
 a.icon-link--badged,
-a.icon-link--badged:has(.badge),
+a.icon-link:has(.badge),
 button.icon-btn--badged,
 button.icon-btn:has(.badge) {
     overflow: visible;
     position: relative;
 }
 a.icon-link--badged .badge,
-a.icon-link--badged:has(.badge) .badge,
+a.icon-link:has(.badge) .badge,
 button.icon-btn--badged .badge,
 button.icon-btn:has(.badge) .badge {
     left: 24px;

--- a/packages/skin/src/sass/icon-button/icon-button.scss
+++ b/packages/skin/src/sass/icon-button/icon-button.scss
@@ -119,7 +119,7 @@ a.icon-link.icon-link--primary:visited > svg {
 button.icon-btn--badged,
 a.icon-link--badged,
 button.icon-btn:has(.badge),
-a.icon-link--badged:has(.badge) {
+a.icon-link:has(.badge) {
     overflow: visible;
     position: relative;
 

--- a/packages/skin/src/sass/icon-button/icon-button.scss
+++ b/packages/skin/src/sass/icon-button/icon-button.scss
@@ -115,8 +115,11 @@ a.icon-link.icon-link--primary:visited > svg {
     fill: var(--color-foreground-on-accent);
 }
 
+/* `--badged` should be removed after full browser support for `:has` */
 button.icon-btn--badged,
-a.icon-link--badged {
+a.icon-link--badged,
+button.icon-btn:has(.badge),
+a.icon-link--badged:has(.badge) {
     overflow: visible;
     position: relative;
 


### PR DESCRIPTION
<!-- Insert GitHub issue number below. An issue is required for all PRs -->

- Fixes #

## Description

Replaces the `icon-btn--badged` manual modifier class with a CSS `:has(.badge)` selector so the overflow/positioning styles apply automatically whenever a `.badge` element is present inside the icon button — no explicit modifier needed on the host element.

**Skin (`icon-button.scss`):** Extends the `overflow: visible; position: relative` rule block to also match `button.icon-btn:has(.badge)` and `a.icon-link--badged:has(.badge)`.

**evo-marko (`evo-icon-button/index.marko`):** Removes the line that conditionally appended `${baseClassName}--badged` based on `badge?.number`, delegating the visual treatment entirely to the CSS `:has()` selector.

## Notes

- The `--badged` modifier class is preserved in the CSS for backwards compatibility with any existing usage.

## Screenshots

<!-- Upload screenshots of UI before & after these changes -->

## Checklist

- [ ] I verify the linked issue has been triaged ("Needs Triage" label removed)
- [ ] I verify all changes are within scope of the linked issue
- [ ] I added/updated/removed testing (Storybook in Skin) coverage as appropriate

<!-- For CSS changes -->

- [ ] I tested the UI in all supported browsers
- [ ] I tested the UI in dark mode and RTL mode