### PR TITLE
fix(FakeMenuButton): remove usage of aria-haspopup

### DIFF
--- a/.changeset/all-horses-greet.md
+++ b/.changeset/all-horses-greet.md
@@ -1,0 +1,6 @@
+---
+"@ebay/ui-core-react": patch
+"@evo-web/marko": patch
+---
+
+fix(FakeMenuButton): remove usage of aria-haspopup

--- a/packages/ebayui-core-react/src/ebay-fake-menu-button/__tests__/index.stories.tsx
+++ b/packages/ebayui-core-react/src/ebay-fake-menu-button/__tests__/index.stories.tsx
@@ -97,11 +97,6 @@ or import styles using SCSS/CSS
         checked: { description: "Not yet implemented", control: "boolean" },
         "badge-number": { description: "Not yet implemented", control: "number" },
         "badge-aria-label": { description: "Not yet implemented", control: "text" },
-        onClick: {
-            description: "For a non-link menu item, with param `{ originalEvent }`",
-            action: "onClick",
-            table: { category: "Events" },
-        },
         onKeyDown: {
             description: "Triggered on key down",
             action: "onKeyDown",

--- a/packages/ebayui-core-react/src/ebay-fake-menu-button/__tests__/render.spec.tsx
+++ b/packages/ebayui-core-react/src/ebay-fake-menu-button/__tests__/render.spec.tsx
@@ -33,7 +33,6 @@ describe("ebay-fake-menu-button rendering", () => {
         const buttonContainer: HTMLElement = container.querySelector(".fake-menu-button");
         const button = getByRole(buttonContainer, "button");
         expect(button).toHaveAttribute("aria-expanded", "false");
-        expect(button).toHaveAttribute("aria-haspopup", "true");
         expect(button).toHaveClass("btn fake-menu-button__button btn--secondary");
         expect(button).toHaveTextContent("eBay Menu");
         const svg = buttonContainer.querySelector("svg");
@@ -45,7 +44,6 @@ describe("ebay-fake-menu-button rendering", () => {
         const buttonContainer: HTMLElement = container.querySelector(".fake-menu-button");
         const button = getByRole(buttonContainer, "button");
         expect(button).toHaveAttribute("aria-expanded", "true");
-        expect(button).toHaveAttribute("aria-haspopup", "true");
         expect(button).toHaveClass("btn fake-menu-button__button btn--secondary");
         expect(button).toHaveTextContent("eBay Menu");
         const menu: HTMLElement = buttonContainer.querySelector(".fake-menu");
@@ -71,7 +69,6 @@ describe("ebay-fake-menu-button rendering", () => {
         const buttonContainer: HTMLElement = container.querySelector(".fake-menu-button");
         const button = getByRole(buttonContainer, "button");
         expect(button).toHaveAttribute("aria-expanded", "false");
-        expect(button).toHaveAttribute("aria-haspopup", "true");
         expect(button).toHaveAttribute("disabled", "");
         expect(button).toHaveClass("btn fake-menu-button__button btn--secondary");
         expect(button).toHaveTextContent("eBay Menu");
@@ -84,7 +81,6 @@ describe("ebay-fake-menu-button rendering", () => {
         const buttonContainer: HTMLElement = container.querySelector(".fake-menu-button");
         const button = getByRole(buttonContainer, "button");
         expect(button).toHaveAttribute("aria-expanded", "false");
-        expect(button).toHaveAttribute("aria-haspopup", "true");
         expect(button).toHaveClass("btn fake-menu-button__button btn--borderless");
         expect(button).toHaveTextContent("eBay Menu");
         const svg = buttonContainer.querySelector("svg");
@@ -96,7 +92,6 @@ describe("ebay-fake-menu-button rendering", () => {
         const buttonContainer: HTMLElement = container.querySelector(".fake-menu-button");
         const button = getByRole(buttonContainer, "button");
         expect(button).toHaveAttribute("aria-expanded", "true");
-        expect(button).toHaveAttribute("aria-haspopup", "true");
         expect(button).toHaveClass("btn fake-menu-button__button btn--secondary");
         expect(button).toHaveTextContent("Menu has a button width");
         const menu = buttonContainer.querySelector(".fake-menu");

--- a/packages/ebayui-core-react/src/ebay-fake-menu-button/menu-button.tsx
+++ b/packages/ebayui-core-react/src/ebay-fake-menu-button/menu-button.tsx
@@ -111,13 +111,12 @@ const EbayMenuButton: FC<Props> = ({
 
     const buttonProps: Omit<ButtonProps, "type" | "ref"> = {
         ref: refs.setHost,
+        ...rest,
         className: "fake-menu-button__button",
         "aria-expanded": !!expanded,
-        "aria-haspopup": true,
         "aria-label": a11yText,
         "aria-controls": menuId,
         onClick: () => setExpanded(!expanded),
-        ...rest,
     };
 
     return (

--- a/packages/evo-marko/src/tags/evo-fake-menu-button/index.marko
+++ b/packages/evo-marko/src/tags/evo-fake-menu-button/index.marko
@@ -89,7 +89,6 @@ export interface Input extends Marko.HTML.Span {
         borderless=borderless
         variant=(variant === "form" ? "form" as any : undefined)
         transparent=transparent
-        aria-haspopup="true"
         aria-expanded=expander.ariaExpanded
         aria-label=a11yText
         disabled=disabled


### PR DESCRIPTION
<!-- Insert GitHub issue number below. An issue is required for all PRs -->

- Fixes #695

## Description

Removes the incorrect `aria-haspopup` attribute from the `ebay-fake-menu-button` trigger button in both the React (`@ebay/ebayui-core-react`) and Marko (`@evo-web/marko`) implementations.

**Changes:**
- `packages/ebayui-core-react/src/ebay-fake-menu-button/menu-button.tsx`: Removed `aria-haspopup: true` from button props and moved `...rest` spread before explicit props so consumer-provided attributes cannot accidentally override controlled attributes.
- `packages/evo-marko/src/tags/evo-fake-menu-button/index.marko`: Removed `aria-haspopup="true"`.
- Updated `render.spec.tsx` to remove the now-stale `aria-haspopup` assertions and refreshed obsolete snapshots.
- Removed stale `onClick` event entry from Storybook argTypes.

A changeset has been included marking both packages as a `patch` release.

## Notes

N/A

## Screenshots

N/A — no visual changes

## Checklist

<!-- For all PR types -->

- [ ] I verify the linked issue has been triaged ("Needs Triage" label removed)
- [ ] I verify all changes are within scope of the linked issue
- [ ] I added/updated/removed testing (Storybook in Skin) coverage as appropriate