### PR TITLE
fix(test): suppress dev-only icon warn in test env and fix flaky carousel scroll test

### DIFF
--- a/.changeset/fix-test-noise-icon-warn-carousel-scroll.md
+++ b/.changeset/fix-test-noise-icon-warn-carousel-scroll.md
@@ -1,0 +1,9 @@
+---
+"@evo-web/react": patch
+"@ebay/ebayui-core": patch
+---
+
+Fix test noise and flaky carousel scroll test.
+
+- `@evo-web/react`: Guard `EvoIcon`'s missing-provider `console.warn` with `process.env.NODE_ENV === 'development'` so it is silent in Vitest (`NODE_ENV=test`) without removing the warning from development builds.
+- `@ebay/ebayui-core`: Fix flaky `ebay-carousel` browser test — "when it is scrolled to the second slide" `beforeEach` was calling `waitForCarouselUpdate()` which resolved immediately from the init render's `move` event, before the 640 ms scroll debounce fired. Replaced with `vi.advanceTimersByTimeAsync(700)` to deterministically trigger the debounce and flush the resulting Marko re-render.

--- a/packages/ebayui-core/src/components/ebay-carousel/test/test.browser.js
+++ b/packages/ebayui-core/src/components/ebay-carousel/test/test.browser.js
@@ -443,7 +443,7 @@ describe("given a discrete carousel", () => {
                 const list = thirdItem.parentElement;
                 list.scrollLeft = thirdItem.offsetLeft;
                 fireEvent.scroll(list);
-                await waitForCarouselUpdate();
+                await vi.advanceTimersByTimeAsync(700);
             });
 
             it("then it emitted the scroll event", () => {

--- a/packages/evo-react/src/icon/icon.tsx
+++ b/packages/evo-react/src/icon/icon.tsx
@@ -54,9 +54,11 @@ export function EvoIcon({
     // This is to make sure that the next request received has an empty "lookup" Set.
     // On the browser this is not an issue since there is always one single instance per page.
     if (typeof window === "undefined" && typeof setImmediate !== "undefined") {
-      console.warn(
-        `Icon "${__name}" used without wrapping it in a <EvoIconProvider />, for better server performance make sure to wrap your application with <EvoIconProvider> component.`,
-      );
+      if (process.env.NODE_ENV === "development") {
+        console.warn(
+          `Icon "${__name}" used without wrapping it in a <EvoIconProvider />, for better server performance make sure to wrap your application with <EvoIconProvider> component.`,
+        );
+      }
 
       setImmediate(() => {
         fallbackLookup.clear();

--- a/packages/evo-react/src/icon/test/test.server.tsx
+++ b/packages/evo-react/src/icon/test/test.server.tsx
@@ -80,6 +80,7 @@ describe("evo-icon SSR", () => {
     });
 
     it("warns about missing provider on server", () => {
+      vi.stubEnv("NODE_ENV", "development");
       const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
       renderToString(<EvoIconCart16 />);
@@ -91,6 +92,7 @@ describe("evo-icon SSR", () => {
       );
 
       consoleSpy.mockRestore();
+      vi.unstubAllEnvs();
     });
   });
 });


### PR DESCRIPTION
<!-- Insert GitHub issue number below. An issue is required for all PRs -->

- Fixes #

## Description

### evo-react: suppress `EvoIcon` missing-provider warning in non-development environments

The `EvoIcon` component logs a `console.warn` on the server when used without an `<EvoIconProvider />`. This warning was also firing during Vitest runs (`NODE_ENV=test`), polluting test output.

**Changes:**
- Wrap the `console.warn` in `icon.tsx` with `process.env.NODE_ENV === 'development'` so it only fires in dev.
- In `test.server.tsx`, the dedicated test that asserts the warning fires now uses `vi.stubEnv('NODE_ENV', 'development')` to opt into development mode, then restores via `vi.unstubAllEnvs()`.

### ebay-carousel: fix flaky `when it is scrolled to the second slide` test

The `beforeEach` was calling `waitForCarouselUpdate()` after firing the scroll event, expecting it to wait for the debounce. However, `waitForCarouselUpdate` waits for `emitted('move').length === 1`, which is **already satisfied by the carousel's init render** — causing it to resolve immediately, before the 640 ms `onScrollDebounced` timeout fired. Whether the assertion passed was purely a function of machine speed.

**Fix:** Replace `await waitForCarouselUpdate()` with `await vi.advanceTimersByTimeAsync(700)`:
- Explicitly ticks the fake clock past the 640 ms debounce so it fires deterministically.
- The async variant (vs. synchronous `advanceTimersByTime`) also flushes the microtasks that Marko's `setState` re-render runs on, ensuring button-disabled states are updated before the assertions in `thenItMovedToTheSecondSlide` run.

## Notes

N/A

## Screenshots

N/A — no visual changes

## Checklist

- [ ] I verify the linked issue has been triaged ("Needs Triage" label removed)
- [ ] I verify all changes are within scope of the linked issue
- [ ] I added/updated/removed testing (Storybook in Skin) coverage as appropriate