### PR TITLE
fix(pagination): ability to configure heading level

### DIFF
--- a/.changeset/slick-cats-admire.md
+++ b/.changeset/slick-cats-admire.md
@@ -1,0 +1,7 @@
+---
+"@ebay/ui-core-react": patch
+"@ebay/ebayui-core": patch
+"@evo-web/marko": patch
+---
+
+fix(pagination): ability to configure heading level

--- a/packages/ebayui-core-react/src/ebay-pagination/__tests__/index.stories.tsx
+++ b/packages/ebayui-core-react/src/ebay-pagination/__tests__/index.stories.tsx
@@ -1,9 +1,9 @@
 import React, { ComponentProps, useState } from "react";
 import { action } from "storybook/actions";
-import { EbayPagination, EbayPaginationItem as Item } from "../index";
 import { EbayButton } from "../../ebay-button";
 import { EbayLightboxDialog } from "../../ebay-lightbox-dialog";
-import { EbayTabs, EbayTab, EbayTabPanel } from "../../ebay-tabs";
+import { EbayTab, EbayTabPanel, EbayTabs } from "../../ebay-tabs";
+import { EbayPagination, EbayPaginationItem as Item } from "../index";
 
 export default {
     title: "navigation & disclosure/ebay-pagination",
@@ -114,9 +114,6 @@ or import styles using SCSS/CSS
             action: "onSelect",
             table: { category: "Events" },
         },
-    },
-    args: {
-        a11yHeadingTag: "h2",
     },
 };
 

--- a/packages/ebayui-core-react/src/ebay-pagination/__tests__/index.stories.tsx
+++ b/packages/ebayui-core-react/src/ebay-pagination/__tests__/index.stories.tsx
@@ -72,6 +72,11 @@ or import styles using SCSS/CSS
         a11yPreviousText: { description: "a11y text for previous arrow button", control: "text" },
         a11yNextText: { description: "a11y text for next arrow button", control: "text" },
         a11yCurrentText: { description: "Description for the current page (e.g. Results of Page 1)", control: "text" },
+        a11yHeadingTag: {
+            description: "Heading tag for pagination (default: `h2`)",
+            control: "text",
+            table: { defaultValue: { summary: "h2" } },
+        },
         variant: {
             description:
                 "Either `show-last`, or `show-range` (default). If show-last then will show the last page always and will put `…` between the last visible range and the last page. `…` and the last page will take up two items in the range. `…` will be hidden when the range to the last item is fully visible.",
@@ -109,6 +114,9 @@ or import styles using SCSS/CSS
             action: "onSelect",
             table: { category: "Events" },
         },
+    },
+    args: {
+        a11yHeadingTag: "h2",
     },
 };
 

--- a/packages/ebayui-core-react/src/ebay-pagination/__tests__/render.spec.tsx
+++ b/packages/ebayui-core-react/src/ebay-pagination/__tests__/render.spec.tsx
@@ -1,6 +1,6 @@
-import React from "react";
-import { render, screen, within } from "@testing-library/react";
 import { composeStories } from "@storybook/react-vite";
+import { render, screen, within } from "@testing-library/react";
+import React from "react";
 import * as stories from "./index.stories";
 
 const { BasicLinks, ArrowsDisabled, Buttons, Fluid } = composeStories(stories);
@@ -95,7 +95,7 @@ describe("ebay-pagination rendering", () => {
 
         const h2 = within(status).getByRole("heading", { level: 2 });
         expect(h2).toHaveAttribute("id", "ebay-pagination-pagination-heading");
-        expect(h2).toHaveTextContent("Pagination - Current Page");
+        expect(h2).toHaveTextContent("Results Pagination - Page 1");
 
         const linkPrev = container.querySelector(".pagination__previous");
         expect(linkPrev).toHaveClass("icon-btn");

--- a/packages/ebayui-core-react/src/ebay-pagination/pagination.tsx
+++ b/packages/ebayui-core-react/src/ebay-pagination/pagination.tsx
@@ -2,6 +2,7 @@ import React, {
     Children,
     ComponentProps,
     FC,
+    JSX,
     ReactElement,
     cloneElement,
     useEffect,
@@ -21,6 +22,7 @@ import { EbayEventHandler } from "../common/event-utils/types";
 
 export type PaginationProps = Omit<ComponentProps<"nav">, "onSelect"> & {
     id?: string;
+    a11yHeadingTag?: keyof JSX.IntrinsicElements;
     a11yPreviousText?: string;
     a11yNextText?: string;
     a11yCurrentText?: string;
@@ -33,6 +35,7 @@ export type PaginationProps = Omit<ComponentProps<"nav">, "onSelect"> & {
 
 const EbayPagination: FC<PaginationProps> = ({
     id = "ebay-pagination",
+    a11yHeadingTag = "h2",
     className,
     a11yCurrentText = "Pagination - Current Page",
     a11yPreviousText = "Previous page",
@@ -192,6 +195,7 @@ const EbayPagination: FC<PaginationProps> = ({
     };
 
     const headingId = `${id}-pagination-heading`;
+    const A11yHeadingTag = a11yHeadingTag || "h2";
 
     return (
         <nav
@@ -202,9 +206,9 @@ const EbayPagination: FC<PaginationProps> = ({
             ref={paginationContainerRef}
         >
             <span aria-live="polite" role="status">
-                <h2 className="clipped" id={headingId}>
+                <A11yHeadingTag className="clipped" id={headingId}>
                     {a11yCurrentText}
-                </h2>
+                </A11yHeadingTag>
             </span>
             {createChildItems("previous")}
             <ol className="pagination__items">{createChildItems("page")}</ol>

--- a/packages/ebayui-core-react/src/ebay-pagination/pagination.tsx
+++ b/packages/ebayui-core-react/src/ebay-pagination/pagination.tsx
@@ -1,3 +1,4 @@
+import classNames from "classnames";
 import React, {
     Children,
     ComponentProps,
@@ -5,20 +6,19 @@ import React, {
     JSX,
     ReactElement,
     cloneElement,
+    createRef,
     useEffect,
     useRef,
     useState,
-    createRef,
 } from "react";
-import { EbayFakeMenuButton, EbayFakeMenuButtonItem as Item } from "../ebay-fake-menu-button";
-import classNames from "classnames";
-import { debounce } from "../common/debounce";
-import { calcPageState, getMaxWidth } from "./helpers";
 import { filterBy } from "../common/component-utils";
+import { debounce } from "../common/debounce";
+import { EbayEventHandler } from "../common/event-utils/types";
+import { EbayFakeMenuButton, EbayFakeMenuButtonItem as Item } from "../ebay-fake-menu-button";
+import { EbayIconOverflowHorizontal24 } from "../ebay-icon/icons/ebay-icon-overflow-horizontal-24";
+import { calcPageState, getMaxWidth } from "./helpers";
 import { PaginationItemProps, PaginationItemType } from "./pagination-item";
 import { ItemState, PaginationVariant } from "./types";
-import { EbayIconOverflowHorizontal24 } from "../ebay-icon/icons/ebay-icon-overflow-horizontal-24";
-import { EbayEventHandler } from "../common/event-utils/types";
 
 export type PaginationProps = Omit<ComponentProps<"nav">, "onSelect"> & {
     id?: string;
@@ -37,7 +37,7 @@ const EbayPagination: FC<PaginationProps> = ({
     id = "ebay-pagination",
     a11yHeadingTag = "h2",
     className,
-    a11yCurrentText = "Pagination - Current Page",
+    a11yCurrentText = "Results Pagination - Page 1",
     a11yPreviousText = "Previous page",
     a11yNextText = "Next page",
     variant = "show-range",
@@ -195,7 +195,7 @@ const EbayPagination: FC<PaginationProps> = ({
     };
 
     const headingId = `${id}-pagination-heading`;
-    const A11yHeadingTag = a11yHeadingTag || "h2";
+    const A11yHeadingTag = a11yHeadingTag;
 
     return (
         <nav

--- a/packages/ebayui-core/src/components/ebay-pagination/component.ts
+++ b/packages/ebayui-core/src/components/ebay-pagination/component.ts
@@ -27,6 +27,7 @@ export interface Item extends Omit<Marko.HTML.Button, "type" | `on${string}`> {
 interface PaginationInput extends Omit<Marko.HTML.Nav, `on${string}`> {
     item?: Marko.AttrTag<Item>;
     variant?: "show-range" | "show-last" | "overflow";
+    "a11y-heading-tag"?: keyof Marko.NativeTags;
     "a11y-current-text"?: Marko.HTMLAttributes["aria-label"];
     "a11y-previous-text"?: Marko.HTMLAttributes["aria-label"];
     "a11y-next-text"?: Marko.HTMLAttributes["aria-label"];

--- a/packages/ebayui-core/src/components/ebay-pagination/index.marko
+++ b/packages/ebayui-core/src/components/ebay-pagination/index.marko
@@ -4,12 +4,13 @@ import type { Item } from "./component";
 $ const {
     class: inputClass,
     item: items = [],
+    a11yHeadingTag,
     a11yCurrentText = "Results Pagination - Page 1",
     a11yPreviousText = "Previous page",
     a11yNextText = "Next page",
 } = input;
 static var disabledItem: Item = { disabled: true };
-static var ignoredAttributes = ["item"];
+static var ignoredAttributes = ["item", "a11yHeadingTag"];
 static var ignoredItemAttributes = ["current", "disabled"];
 static function isItemHidden(
     index: number,
@@ -52,9 +53,9 @@ $ var range = component._getVisibleRange(slicedItems);
     aria-labelledby:scoped="heading"
 >
     <span aria-live="polite" role="status">
-        <h2 id:scoped="heading" class="clipped">
+        <${a11yHeadingTag || "h2"} id:scoped="heading" class="clipped">
             ${a11yCurrentText}
-        </h2>
+        </>
     </span>
 
     <${component.getItemTag(prevItem)}

--- a/packages/ebayui-core/src/components/ebay-pagination/index.marko
+++ b/packages/ebayui-core/src/components/ebay-pagination/index.marko
@@ -4,7 +4,7 @@ import type { Item } from "./component";
 $ const {
     class: inputClass,
     item: items = [],
-    a11yHeadingTag,
+    a11yHeadingTag = "h2",
     a11yCurrentText = "Results Pagination - Page 1",
     a11yPreviousText = "Previous page",
     a11yNextText = "Next page",
@@ -61,7 +61,7 @@ $ const {
     key="root"
     aria-labelledby:scoped="heading">
     <span aria-live="polite" role="status">
-        <${a11yHeadingTag || "h2"} id:scoped="heading" class="clipped">
+        <${a11yHeadingTag} id:scoped="heading" class="clipped">
             ${a11yCurrentText}
         </>
     </span>

--- a/packages/ebayui-core/src/components/ebay-pagination/index.marko
+++ b/packages/ebayui-core/src/components/ebay-pagination/index.marko
@@ -8,10 +8,9 @@ $ const {
     a11yCurrentText = "Results Pagination - Page 1",
     a11yPreviousText = "Previous page",
     a11yNextText = "Next page",
+    ...htmlInput
 } = input;
 static var disabledItem: Item = { disabled: true };
-static var ignoredAttributes = ["item", "a11yHeadingTag"];
-static var ignoredItemAttributes = ["current", "disabled"];
 static function isItemHidden(
     index: number,
     range: {
@@ -44,14 +43,23 @@ $ var slicedItems = baseItems.slice(
     nextItem === disabledItem ? undefined : lastItemIndex,
 );
 $ var range = component._getVisibleRange(slicedItems);
+$ const {
+    current: prevItemCurrent,
+    disabled: prevItemDisabled,
+    ...prevItemHtmlInput
+} = prevItem;
+$ const {
+    current: nextItemCurrent,
+    disabled: nextItemDisabled,
+    ...nextItemHtmlInput
+} = nextItem;
 
 <nav
-    ...processHtmlAttributes(input, ignoredAttributes)
+    ...processHtmlAttributes(htmlInput)
     role="navigation"
     class=["pagination", inputClass]
     key="root"
-    aria-labelledby:scoped="heading"
->
+    aria-labelledby:scoped="heading">
     <span aria-live="polite" role="status">
         <${a11yHeadingTag || "h2"} id:scoped="heading" class="clipped">
             ${a11yCurrentText}
@@ -59,26 +67,29 @@ $ var range = component._getVisibleRange(slicedItems);
     </span>
 
     <${component.getItemTag(prevItem)}
-        ...processHtmlAttributes(prevItem, ignoredItemAttributes)
+        ...processHtmlAttributes(prevItemHtmlInput)
         class=[
             "pagination__previous",
             prevItem.href ? "icon-link" : "icon-btn",
             prevItem.class,
         ]
-        aria-disabled=prevItem.disabled && "true"
+        aria-disabled=prevItemDisabled && "true"
         aria-label=a11yPreviousText
         style=[prevItem.style, { minWidth: 40 }]
-        onClick("handlePreviousPageClick")
-    >
+        onClick("handlePreviousPageClick")>
         <ebay-arrow-left-16-icon/>
     </>
 
     <ol key="items" class="pagination__items">
         <for|item, i| of=slicedItems>
+            $ const {
+                current: itemCurrent,
+                disabled: itemDisabled,
+                ...itemHtmlInput
+            } = item;
             <if(range.dotsIndex === i || range.leadingDotsIndex === i)>
                 $ var hideDots = range.hideDots;
                 $ var isLeading = false;
-
                 $ if (range.leadingDotsIndex === i) {
                     isLeading = true;
                     hideDots = !!range.hideLeadingDots;
@@ -87,35 +98,36 @@ $ var range = component._getVisibleRange(slicedItems);
                     <if(range.hasOverflow)>
                         <span
                             class=["pagination__item", item.class]
-                            role="separator"
-                        >
+                            role="separator">
                             <ebay-fake-menu-button
                                 variant="icon"
                                 transparent
                                 icon=DotsIcon
                                 collapseOnSelect
-                                on-select("handleMenuPageNumber")
-                            >
-                                <for|item, j| of=slicedItems>
+                                on-select("handleMenuPageNumber")>
+                                <for|menuItem, j| of=slicedItems>
                                     $ var visible = (
                                         isLeading
                                             ? j < range.start
                                             : j > range.end
                                     );
                                     <if(isItemHidden(j, range) && visible)>
+                                        $ const {
+                                            current: menuItemCurrent,
+                                            disabled: menuItemDisabled,
+                                            ...menuItemHtmlInput
+                                        } = menuItem;
                                         <@item
                                             ...processHtmlAttributes(
-                                                item,
-                                                ignoredItemAttributes,
+                                                menuItemHtmlInput,
                                             )
                                             type=(
                                                 component.getItemTag(
-                                                    item,
+                                                    menuItem,
                                                 ) as Marko.HTML.Button["type"]
                                             )
-                                            data-page-number=j
-                                        >
-                                            <${item.renderBody}/>
+                                            data-page-number=j>
+                                            <${menuItem.renderBody}/>
                                         </@item>
                                     </if>
                                 </for>
@@ -125,8 +137,7 @@ $ var range = component._getVisibleRange(slicedItems);
                     <else>
                         <span
                             class=["pagination__item", item.class]
-                            role="separator"
-                        >
+                            role="separator">
                             <ebay-overflow-horizontal-24-icon/>
                         </span>
                     </else>
@@ -134,12 +145,11 @@ $ var range = component._getVisibleRange(slicedItems);
             </if>
             <li hidden=isItemHidden(i, range)>
                 <${component.getItemTag(item)}
-                    ...processHtmlAttributes(item, ignoredItemAttributes)
+                    ...processHtmlAttributes(itemHtmlInput)
                     key="pageItem[]"
                     class=["pagination__item", item.class]
-                    aria-current=item.current && "page"
-                    onClick("handlePageNumberClick", i)
-                >
+                    aria-current=itemCurrent && "page"
+                    onClick("handlePageNumberClick", i)>
                     <${item.renderBody}/>
                 </>
             </li>
@@ -147,17 +157,16 @@ $ var range = component._getVisibleRange(slicedItems);
     </ol>
 
     <${component.getItemTag(nextItem)}
-        ...processHtmlAttributes(nextItem, ignoredItemAttributes)
+        ...processHtmlAttributes(nextItemHtmlInput)
         class=[
             "pagination__next",
             nextItem.href ? "icon-link" : "icon-btn",
             nextItem.class,
         ]
-        aria-disabled=nextItem.disabled && "true"
+        aria-disabled=nextItemDisabled && "true"
         aria-label=a11yNextText
         style=[nextItem.style, { minWidth: 40 }]
-        onClick("handleNextPageClick")
-    >
+        onClick("handleNextPageClick")>
         <ebay-arrow-right-16-icon/>
     </>
 </nav>

--- a/packages/ebayui-core/src/components/ebay-pagination/marko-tag.json
+++ b/packages/ebayui-core/src/components/ebay-pagination/marko-tag.json
@@ -8,6 +8,7 @@
     "@a11y-previous-text": "string",
     "@a11y-next-text": "string",
     "@a11y-current-text": "string",
+    "@a11y-heading-tag": "string",
     "@role": "never",
     "@aria-labelledby": "never",
     "@variant": {

--- a/packages/ebayui-core/src/components/ebay-pagination/pagination.stories.ts
+++ b/packages/ebayui-core/src/components/ebay-pagination/pagination.stories.ts
@@ -36,6 +36,15 @@ export default {
             description:
                 "Localized, description for the current page (e.g. Results of Page 1)",
         },
+        a11yHeadingTag: {
+            control: { type: "text" },
+            table: {
+                defaultValue: {
+                    summary: "h2",
+                },
+            },
+            description: "Heading tag for the clipped pagination label",
+        },
         variant: {
             control: { type: "select" },
 
@@ -122,6 +131,9 @@ export default {
                 },
             },
         },
+    },
+    args: {
+        a11yHeadingTag: "h2",
     },
 };
 

--- a/packages/ebayui-core/src/components/ebay-pagination/pagination.stories.ts
+++ b/packages/ebayui-core/src/components/ebay-pagination/pagination.stories.ts
@@ -1,11 +1,11 @@
-import { addRenderBodies } from "../../common/storybook/utils";
+import { Story } from "@storybook/marko";
 import { tagToString } from "../../common/storybook/storybook-code-source";
+import { addRenderBodies } from "../../common/storybook/utils";
 import Readme from "./README.md";
-import Component from "./index.marko";
+import type { Input } from "./component";
 import interactiveTemplate from "./examples/buttons-interactive.marko";
 import interactiveCode from "./examples/buttons-interactive.marko?raw";
-import { Story } from "@storybook/marko";
-import type { Input } from "./component";
+import Component from "./index.marko";
 
 const Template: Story<Input> = (args: Input) => ({
     input: addRenderBodies(args),
@@ -131,9 +131,6 @@ export default {
                 },
             },
         },
-    },
-    args: {
-        a11yHeadingTag: "h2",
     },
 };
 

--- a/packages/evo-marko/src/tags/evo-pagination/index.marko
+++ b/packages/evo-marko/src/tags/evo-pagination/index.marko
@@ -7,6 +7,8 @@ export interface Item extends Omit<Marko.HTML.Button, "type"> {
 }
 
 export interface Input extends Marko.HTML.Nav {
+    /** HTML heading tag to use for the clipped pagination label. Defaults to `h2`. */
+    a11yHeadingTag?: keyof Marko.NativeTags;
     item?: Marko.AttrTag<Item>;
     prev?: Marko.AttrTag<Omit<IconButtonInput, "content">>;
     next?: Marko.AttrTag<Omit<IconButtonInput, "content">>;
@@ -24,6 +26,7 @@ static const MIN_PAGES = 5;
 <const/{
     class: inputClass,
     id,
+    a11yHeadingTag = "h2",
     variant,
     item: items,
     prev,
@@ -131,9 +134,9 @@ static const MIN_PAGES = 5;
     class=["pagination", inputClass]
     aria-labelledby=headingId>
     <span aria-live="polite" role="status">
-        <h2 id=headingId class="clipped">
+        <${a11yHeadingTag || "h2"} id=headingId class="clipped">
             ${a11yCurrentText}
-        </h2>
+        </>
     </span>
 
     <if=prev>

--- a/packages/evo-marko/src/tags/evo-pagination/index.marko
+++ b/packages/evo-marko/src/tags/evo-pagination/index.marko
@@ -7,7 +7,6 @@ export interface Item extends Omit<Marko.HTML.Button, "type"> {
 }
 
 export interface Input extends Marko.HTML.Nav {
-    /** HTML heading tag to use for the clipped pagination label. Defaults to `h2`. */
     a11yHeadingTag?: keyof Marko.NativeTags;
     item?: Marko.AttrTag<Item>;
     prev?: Marko.AttrTag<Omit<IconButtonInput, "content">>;
@@ -134,7 +133,7 @@ static const MIN_PAGES = 5;
     class=["pagination", inputClass]
     aria-labelledby=headingId>
     <span aria-live="polite" role="status">
-        <${a11yHeadingTag || "h2"} id=headingId class="clipped">
+        <${a11yHeadingTag} id=headingId class="clipped">
             ${a11yCurrentText}
         </>
     </span>

--- a/packages/evo-marko/src/tags/evo-pagination/pagination.stories.ts
+++ b/packages/evo-marko/src/tags/evo-pagination/pagination.stories.ts
@@ -29,6 +29,12 @@ export default {
       description:
         "Localized description for the current page (e.g. Results of Page 1)",
     },
+    a11yHeadingTag: {
+      type: "string",
+      control: "text",
+      description: "HTML heading tag to use for the a11y heading",
+      table: { defaultValue: { summary: "h2" } },
+    },
     item: {
       description: "Attribute tag representing a pagination item",
       "@": {
@@ -78,6 +84,9 @@ export default {
       description:
         "All attributes and event handlers from [the native HTML `<nav>` tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/nav) will be passed through",
     },
+  },
+  args: {
+    a11yHeadingTag: "h2",
   },
 } satisfies Meta<Input>;
 

--- a/packages/evo-marko/src/tags/evo-pagination/pagination.stories.ts
+++ b/packages/evo-marko/src/tags/evo-pagination/pagination.stories.ts
@@ -32,7 +32,7 @@ export default {
     a11yHeadingTag: {
       type: "string",
       control: "text",
-      description: "HTML heading tag to use for the a11y heading",
+      description: "HTML tag to use for the a11y heading",
       table: { defaultValue: { summary: "h2" } },
     },
     item: {
@@ -84,9 +84,6 @@ export default {
       description:
         "All attributes and event handlers from [the native HTML `<nav>` tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/nav) will be passed through",
     },
-  },
-  args: {
-    a11yHeadingTag: "h2",
   },
 } satisfies Meta<Input>;
 


### PR DESCRIPTION
<!-- Insert GitHub issue number below. An issue is required for all PRs -->

- Fixes #698

## Description

This change adds API enhancement for configuring the pagination accessibility heading tag via a11yHeadingTag (default remains h2) across `ebayui-core-react`, `ebayui-core`, and `evo-marko`.

## Checklist

<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->

- [x] I verify the linked issue has been triaged ("Needs Triage" label removed)
- [x] I verify all changes are within scope of the linked issue
- [x] I added/updated/removed testing (Storybook in Skin) coverage as appropriate
