### PR TITLE
fix(ebay-video): add stopPropagation to big play button click

### DIFF
--- a/.changeset/funny-parents-occur.md
+++ b/.changeset/funny-parents-occur.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ebayui-core": patch
+---
+
+fix(ebay-video): add stopPropagation to big play button click

--- a/packages/ebayui-core/src/components/ebay-video/component.ts
+++ b/packages/ebayui-core/src/components/ebay-video/component.ts
@@ -451,7 +451,8 @@ class Video extends Marko.Component<Input, State> {
                 "aria-label",
                 this.input.a11yPlayText || "Play",
             );
-            playButton.onclick = () => {
+            playButton.onclick = (e) => {
+                e.stopPropagation();
                 this.video.play();
             };
 


### PR DESCRIPTION
## Description

We add a custom big play button to the Shaka video player with an onclick listener that calls `video.play()`. Without `event.stopPropagation()`, this same click was then pausing the now playing video instantly.

