### PR TITLE
fix(ebay-filter-menu): preserve checked state by item identity

### DIFF
--- a/.changeset/filter-menu-stable-selection.md
+++ b/.changeset/filter-menu-stable-selection.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ui-core-react": patch
+---
+
+Fix EbayFilterMenu checkbox selection so filtered items remain checked by item value instead of index.

--- a/packages/ebayui-core-react/src/ebay-filter-menu/__tests__/index.spec.tsx
+++ b/packages/ebayui-core-react/src/ebay-filter-menu/__tests__/index.spec.tsx
@@ -91,6 +91,60 @@ describe("EbayFilterMenu Component", () => {
         });
     });
 
+    it("should keep the selected checkbox item checked by value when items are filtered", async () => {
+        const getCheckboxItem = (name: string) => screen.getByRole("menuitemcheckbox", { name });
+        const { rerender } = render(
+            <EbayFilterMenu type="checkbox">
+                <EbayFilterMenuItem value="item1">Item 1</EbayFilterMenuItem>
+                <EbayFilterMenuItem value="item2">Item 2</EbayFilterMenuItem>
+                <EbayFilterMenuItem value="item3">Item 3</EbayFilterMenuItem>
+            </EbayFilterMenu>,
+        );
+
+        await userEvent.click(getCheckboxItem("Item 2"));
+
+        rerender(
+            <EbayFilterMenu type="checkbox">
+                <EbayFilterMenuItem value="item2">Item 2</EbayFilterMenuItem>
+                <EbayFilterMenuItem value="item3">Item 3</EbayFilterMenuItem>
+            </EbayFilterMenu>,
+        );
+
+        expect(getCheckboxItem("Item 2")).toHaveAttribute("aria-checked", "true");
+        expect(getCheckboxItem("Item 3")).toHaveAttribute("aria-checked", "false");
+    });
+
+    it("should preserve a selected checkbox item while it is filtered out", async () => {
+        const getCheckboxItem = (name: string) => screen.getByRole("menuitemcheckbox", { name });
+        const { rerender } = render(
+            <EbayFilterMenu type="checkbox">
+                <EbayFilterMenuItem value="item1">Item 1</EbayFilterMenuItem>
+                <EbayFilterMenuItem value="item2">Item 2</EbayFilterMenuItem>
+                <EbayFilterMenuItem value="item3">Item 3</EbayFilterMenuItem>
+            </EbayFilterMenu>,
+        );
+
+        await userEvent.click(getCheckboxItem("Item 2"));
+
+        rerender(
+            <EbayFilterMenu type="checkbox">
+                <EbayFilterMenuItem value="item3">Item 3</EbayFilterMenuItem>
+            </EbayFilterMenu>,
+        );
+
+        expect(getCheckboxItem("Item 3")).toHaveAttribute("aria-checked", "false");
+
+        rerender(
+            <EbayFilterMenu type="checkbox">
+                <EbayFilterMenuItem value="item2">Item 2</EbayFilterMenuItem>
+                <EbayFilterMenuItem value="item3">Item 3</EbayFilterMenuItem>
+            </EbayFilterMenu>,
+        );
+
+        expect(getCheckboxItem("Item 2")).toHaveAttribute("aria-checked", "true");
+        expect(getCheckboxItem("Item 3")).toHaveAttribute("aria-checked", "false");
+    });
+
     it("should update selected elements correctly when unselecting a checkbox", async () => {
         const handleChange = vi.fn();
         render(

--- a/packages/ebayui-core-react/src/ebay-filter-menu/filter-menu.tsx
+++ b/packages/ebayui-core-react/src/ebay-filter-menu/filter-menu.tsx
@@ -3,7 +3,9 @@ import React, {
     FC,
     Fragment,
     KeyboardEvent,
+    Key,
     MouseEvent,
+    ReactElement,
     RefObject,
     useEffect,
     useRef,
@@ -27,6 +29,35 @@ import classNames from "classnames";
 import { EbayButton } from "../ebay-button";
 import { EbayIconClear20 } from "../ebay-icon/icons/ebay-icon-clear-20";
 import { EbayIconSearch16 } from "../ebay-icon/icons/ebay-icon-search-16";
+
+type FilterMenuItemElement = ReactElement<EbayFilterMenuItemProps>;
+type ItemIdentity = NonNullable<Key>;
+
+const getItemIdentity = (item: FilterMenuItemElement, index: number): ItemIdentity =>
+    (item.props.value ?? item.key ?? index) as ItemIdentity;
+
+const getCheckedItemIds = (items: FilterMenuItemElement[]): ItemIdentity[] =>
+    items.reduce<ItemIdentity[]>((checkedItemIds, item, index) => {
+        if (item.props.checked) {
+            return [...checkedItemIds, getItemIdentity(item, index)];
+        }
+
+        return checkedItemIds;
+    }, []);
+
+const getCheckedItemId = (items: FilterMenuItemElement[]): ItemIdentity | undefined => {
+    const checkedIndex = items.findIndex((item) => item.props.checked);
+
+    return checkedIndex > -1 ? getItemIdentity(items[checkedIndex], checkedIndex) : undefined;
+};
+
+const updateCheckedItemIds = (checkedItemIds: ItemIdentity[], itemId: ItemIdentity, checked?: boolean) => {
+    if (checked) {
+        return checkedItemIds.includes(itemId) ? checkedItemIds : [...checkedItemIds, itemId];
+    }
+
+    return checkedItemIds.filter((checkedItemId) => checkedItemId !== itemId);
+};
 
 export type EbayFilterMenuProps = Omit<ComponentProps<"span">, "onChange"> & {
     classPrefix?: string;
@@ -74,10 +105,8 @@ const EbayFilterMenu: FC<EbayFilterMenuProps> = ({
     const items = filterByType(children, EbayFilterMenuItem);
     const menuId = useRandomId();
     const [searchTerm, setSearchTerm] = useState(searchHeaderValue || "");
-    const [checkedIndex, setCheckedIndex] = useState<number>(() =>
-        items.map((item, index) => item.props.checked && index).find((value) => typeof value === "number"),
-    );
-    const [checkedItems, setCheckedItems] = useState<boolean[]>(() => items.map((item) => Boolean(item.props.checked)));
+    const [checkedItemId, setCheckedItemId] = useState<ItemIdentity | undefined>(() => getCheckedItemId(items));
+    const [checkedItemIds, setCheckedItemIds] = useState<ItemIdentity[]>(() => getCheckedItemIds(items));
 
     useEffect(() => {
         let rovingTabIndex: ReturnType<typeof createLinear>;
@@ -101,18 +130,26 @@ const EbayFilterMenu: FC<EbayFilterMenuProps> = ({
         };
     }, [isForm]);
 
-    const buildCurrentEventData: () => FilterMenuEventData = () => ({
+    const isItemChecked = (
+        item: FilterMenuItemElement,
+        index: number,
+        selectedItemId = checkedItemId,
+        selectedItemIds = checkedItemIds,
+    ) => {
+        const itemId = getItemIdentity(item, index);
+
+        return isRadio ? selectedItemId === itemId : selectedItemIds.includes(itemId);
+    };
+
+    const buildCurrentEventData = (
+        selectedItemId = checkedItemId,
+        selectedItemIds = checkedItemIds,
+    ): FilterMenuEventData => ({
         checked: items
-            .filter((item, index) => (isRadio ? checkedIndex === index : checkedItems[index]))
+            .filter((item, index) => isItemChecked(item, index, selectedItemId, selectedItemIds))
             .map((item) => item.props.value),
         checkedIndex: items
-            .map((item, index) => {
-                if (isRadio) {
-                    return index === checkedIndex && index;
-                }
-
-                return checkedItems[index] && index;
-            })
+            .map((item, index) => isItemChecked(item, index, selectedItemId, selectedItemIds) && index)
             .filter((value) => typeof value === "number"),
     });
     const handleFooterButtonClick = (event) => {
@@ -165,32 +202,25 @@ const EbayFilterMenu: FC<EbayFilterMenuProps> = ({
             return;
         }
 
+        const itemId = getItemIdentity(items[indexToToggle], indexToToggle);
+
         if (isRadio) {
-            setCheckedIndex(indexToToggle);
+            setCheckedItemId(itemId);
             onChange?.(event, {
                 index: indexToToggle,
-                checked: [items[indexToToggle].props.value],
-                checkedIndex: [indexToToggle],
+                ...buildCurrentEventData(itemId, checkedItemIds),
                 currentChecked: checked,
             });
         } else {
-            const newCheckedItems = checkedItems.map((itemChecked, itemIndex) => {
-                if (itemIndex === indexToToggle) {
-                    return checked;
-                }
-                return itemChecked;
-            });
+            const newCheckedItemIds = updateCheckedItemIds(checkedItemIds, itemId, checked);
 
             onChange?.(event, {
                 index: indexToToggle,
-                checked: items.filter((item, index) => newCheckedItems[index]).map((item) => item.props.value),
-                checkedIndex: newCheckedItems
-                    .map((isChecked, index) => isChecked && index)
-                    .filter((value) => typeof value === "number"),
+                ...buildCurrentEventData(checkedItemId, newCheckedItemIds),
                 currentChecked: checked,
             });
 
-            setCheckedItems(newCheckedItems);
+            setCheckedItemIds(newCheckedItemIds);
         }
     };
 
@@ -232,7 +262,7 @@ const EbayFilterMenu: FC<EbayFilterMenuProps> = ({
                             __classPrefix: baseClass,
                             __type: type,
                             __variant: variant,
-                            checked: isRadio ? index === checkedIndex : checkedItems[index],
+                            checked: isItemChecked(item, index),
                             onClick: (event, { checked, value }) => {
                                 if (item.props.disabled) {
                                     return;
@@ -252,7 +282,7 @@ const EbayFilterMenu: FC<EbayFilterMenuProps> = ({
                                 item.props.onKeyDown?.(event);
                                 // For "Space" key, the onClick event is triggered on checkboxes, so we ignore on forms
                                 if (event.key === "Enter" || (event.key === " " && !isForm)) {
-                                    const currentChecked = isRadio ? index === checkedIndex : checkedItems[index];
+                                    const currentChecked = isItemChecked(item, index);
                                     handleItemClick(event, {
                                         checked: !currentChecked,
                                         index,


### PR DESCRIPTION
<!-- Insert GitHub issue number below. An issue is required for all PRs -->

- Fixes #690

## Description

Fixes `EbayFilterMenu` checkbox state when the visible item list changes during filtering/search.

- Tracks checked checkbox items by stable item identity (`value`, then React key, with index as a fallback) instead of the visible array index.
- Keeps the originally selected item checked when filtering changes the visible item positions.
- Preserves the selected item while it is temporarily filtered out, without marking the first visible item checked.
- Adds regression coverage for both visible reordering/filtering and filtered-out preservation cases.

## Notes

- Pushed with `--no-verify` at user request because the repo pre-push hook runs the full build, which is currently failing in unrelated `@ebay/ebayui-core` browser snapshot/carousel tests outside this React filter-menu change.
- Focused validation passed:
  - `npm test -w packages/ebayui-core-react -- src/ebay-filter-menu/__tests__/index.spec.tsx`
  - `npm run type:check -w packages/ebayui-core-react`
  - `codiff -w`
- Full `npm run build` was attempted on the clean branch and failed in unrelated `@ebay/ebayui-core` browser tests.

## Screenshots

N/A — no visual changes.

## Checklist

<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->

- [ ] I verify the linked issue has been triaged ("Needs Triage" label removed)
- [ ] I verify all changes are within scope of the linked issue
- [ ] I added/updated/removed testing (Storybook in Skin) coverage as appropriate

<!-- For CSS changes -->

- [ ] I tested the UI in all supported browsers
- [ ] I tested the UI in dark mode and RTL mode
