### PR TITLE
refactor(evo-marko): make apis more consistent

### DIFF
--- a/.changeset/metal-deer-double.md
+++ b/.changeset/metal-deer-double.md
@@ -1,0 +1,5 @@
+---
+"@evo-web/marko": patch
+---
+
+Unify API naming

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ _site
 
 # agentic local settings
 .claude/settings.local.json
+.auto

--- a/packages/evo-marko/src/tags/evo-fake-tabs/examples/custom-selected-index.marko
+++ b/packages/evo-marko/src/tags/evo-fake-tabs/examples/custom-selected-index.marko
@@ -1,4 +1,4 @@
-<evo-fake-tabs selectedIndex=1>
+<evo-fake-tabs selected=1>
     <@tab href="https://www.ebay.com/">
         Tab 1
     </@tab>

--- a/packages/evo-marko/src/tags/evo-fake-tabs/examples/default.marko
+++ b/packages/evo-marko/src/tags/evo-fake-tabs/examples/default.marko
@@ -1,4 +1,4 @@
-<evo-fake-tabs selectedIndex=1 ...input>
+<evo-fake-tabs selected=1 ...input>
     <@tab href="https://www.ebay.com/">
         Tab 1
     </@tab>

--- a/packages/evo-marko/src/tags/evo-fake-tabs/fake-tabs.stories.ts
+++ b/packages/evo-marko/src/tags/evo-fake-tabs/fake-tabs.stories.ts
@@ -19,7 +19,7 @@ export default {
   },
 
   argTypes: {
-    selectedIndex: {
+    selected: {
       type: "number",
       control: "number",
       description: "Zero-based index of selected tab tab and panel",

--- a/packages/evo-marko/src/tags/evo-fake-tabs/index.marko
+++ b/packages/evo-marko/src/tags/evo-fake-tabs/index.marko
@@ -1,11 +1,11 @@
 export interface Input extends Marko.HTML.Div {
-    selectedIndex?: number;
+    selected?: number;
     size?: "large" | "regular";
     tab?: Marko.AttrTag<Marko.HTML.A>;
     tabMatchesCurrentUrl?: boolean;
 }
 <const/{
-    selectedIndex = 0,
+    selected = 0,
     class: inputClass,
     size = "regular",
     tab: tabs,
@@ -27,7 +27,7 @@ export interface Input extends Marko.HTML.Div {
             <li class=[tabClass, "fake-tabs__item"]>
                 <a
                     ...htmlTab
-                    aria-current=selectedIndex === i && tabAriaCurrent/>
+                    aria-current=selected === i && tabAriaCurrent/>
             </li>
         </for>
     </ul>

--- a/packages/evo-marko/src/tags/evo-fake-tabs/test/test.server.ts
+++ b/packages/evo-marko/src/tags/evo-fake-tabs/test/test.server.ts
@@ -18,10 +18,10 @@ describe("fake-tabs", () => {
   });
 
   it("renders with other selected index", async () => {
-    await snapshotHTML(Default, {selectedIndex: 2});
+    await snapshotHTML(Default, {selected: 2});
   });
   it("renders with no selected index", async () => {
-    await snapshotHTML(Default, {selectedIndex: -1});
+    await snapshotHTML(Default, {selected: -1});
   });
 
 });

--- a/packages/evo-marko/src/tags/evo-filter-chip/filter-chip.stories.ts
+++ b/packages/evo-marko/src/tags/evo-filter-chip/filter-chip.stories.ts
@@ -47,12 +47,12 @@ export default {
         },
       },
     },
-    expanded: {
+    open: {
       controllable: true,
       type: "boolean",
       control: "boolean",
       description:
-        "Only used for menu variant. True/false if the menu is in expanded state or not",
+        "Only used for menu variant. True/false if the menu is open or not",
     },
     a11ySelectedText: {
       type: "string",

--- a/packages/evo-marko/src/tags/evo-filter-chip/index.marko
+++ b/packages/evo-marko/src/tags/evo-filter-chip/index.marko
@@ -6,15 +6,15 @@ export interface Input
     icon?: Marko.AttrTag<{ content?: Marko.Body }>;
     image?: Marko.AttrTag<Marko.HTML.Img>;
     a11ySelectedText?: string;
-    expanded?: boolean;
-    expandedChange?: (expanded: boolean) => void;
+    open?: boolean;
+    openChange?: (open: boolean) => void;
 }
 <const/{
     class: inputClass,
     content,
     disabled,
     selected: inputSelected,
-    expanded: inputExpanded,
+    open: inputOpen,
     icon,
     image,
     a11ySelectedText,
@@ -30,7 +30,7 @@ export interface Input
     mounted = true;
 </script>
 <let/selected:=input.selected>
-<let/expanded:=input.expanded>
+<let/open:=input.open>
 
 <define/Root|input: (Marko.HTML.A | Marko.HTML.Button)|>
     <if=isAnchor>
@@ -62,7 +62,7 @@ export interface Input
     onClick(e: PointerEvent, target: HTMLButtonElement) {
         if (!disabled) {
             if (isMenu) {
-                expanded = !expanded;
+                open = !open;
             } else {
                 selected = !selected;
             }

--- a/packages/evo-marko/src/tags/evo-filter-chip/index.marko
+++ b/packages/evo-marko/src/tags/evo-filter-chip/index.marko
@@ -58,7 +58,7 @@ export interface Input
         inputClass,
     ]
     href=(!disabled ? href : undefined)
-    aria-expanded=variant === "menu" && (expanded ? "true" : "false")
+    aria-expanded=variant === "menu" && (open ? "true" : "false")
     onClick(e: PointerEvent, target: HTMLButtonElement) {
         if (!disabled) {
             if (isMenu) {

--- a/packages/evo-marko/src/tags/evo-infotip/README.md
+++ b/packages/evo-marko/src/tags/evo-infotip/README.md
@@ -1,0 +1,16 @@
+<h1 style="display: flex; justify-content: space-between; align-items: center;">
+    <span>
+        evo-infotip
+    </span>
+    <span style="font-weight: normal; font-size: medium; margin-bottom: -15px;">
+        DS v1.1.0
+    </span>
+</h1>
+
+Infotip component for displaying contextual information with an optional icon. Provides accessible tooltips and contextual help.
+
+## Examples and Documentation
+
+- [Storybook](https://ebay.github.io/evo-web/ebayui-core/?path=/story/overlays-evo-infotip)
+- [Storybook Docs](https://ebay.github.io/evo-web/ebayui-core/?path=/docs/overlays-evo-infotip)
+- [Code Examples](https://github.com/eBay/evo-web/tree/main/packages/evo-marko/src/tags/evo-infotip/examples)

--- a/packages/evo-marko/src/tags/evo-input/index.marko
+++ b/packages/evo-marko/src/tags/evo-input/index.marko
@@ -43,7 +43,7 @@ export interface Input extends Marko.HTML.Input {
 
 <evo-floating-label|{ showPlaceholder }|
     floatingLabel=floatingLabel
-    inputSize=size
+    size=inputSize
     alwaysUp=floatingLabelStatic
     htmlFor=inputId
     disabled=disabled
@@ -99,7 +99,11 @@ export interface Input extends Marko.HTML.Input {
             <${a11yText && "button"}
                 ...postfixIconInput
                 aria-label=a11yText
-                class=["icon-btn", "icon-btn--transparent", postfixIcon.class]
+                class=[
+                    "icon-btn",
+                    "icon-btn--transparent",
+                    postfixIcon.class,
+                ]
                 type="button"
                 disabled=disabled>
                 <${postfixIcon}/>

--- a/packages/evo-marko/src/tags/evo-input/index.marko
+++ b/packages/evo-marko/src/tags/evo-input/index.marko
@@ -1,5 +1,5 @@
 export interface Input extends Marko.HTML.Input {
-    size?: "regular" | "large";
+    inputSize?: "regular" | "large";
     fluid?: boolean;
     floatingLabel?: string;
     floatingLabelStatic?: boolean;
@@ -21,7 +21,7 @@ export interface Input extends Marko.HTML.Input {
     floatingLabelStatic,
     fluid,
     id,
-    size,
+    inputSize,
     invalid,
     postfixIcon,
     prefixIcon,
@@ -59,7 +59,7 @@ export interface Input extends Marko.HTML.Input {
             invalid && "textbox--invalid",
             readonly &&
                 "textbox--readonly" /** end remove after `:has` support */,
-            size === "large" && "textbox--large",
+            inputSize === "large" && "textbox--large",
             fluid && "textbox--fluid",
             inputClass,
         ]>

--- a/packages/evo-marko/src/tags/evo-input/index.marko
+++ b/packages/evo-marko/src/tags/evo-input/index.marko
@@ -1,5 +1,5 @@
 export interface Input extends Marko.HTML.Input {
-    inputSize?: "regular" | "large";
+    size?: "regular" | "large";
     fluid?: boolean;
     floatingLabel?: string;
     floatingLabelStatic?: boolean;
@@ -21,7 +21,7 @@ export interface Input extends Marko.HTML.Input {
     floatingLabelStatic,
     fluid,
     id,
-    inputSize,
+    size,
     invalid,
     postfixIcon,
     prefixIcon,
@@ -43,7 +43,7 @@ export interface Input extends Marko.HTML.Input {
 
 <evo-floating-label|{ showPlaceholder }|
     floatingLabel=floatingLabel
-    inputSize=inputSize
+    inputSize=size
     alwaysUp=floatingLabelStatic
     htmlFor=inputId
     disabled=disabled
@@ -59,7 +59,7 @@ export interface Input extends Marko.HTML.Input {
             invalid && "textbox--invalid",
             readonly &&
                 "textbox--readonly" /** end remove after `:has` support */,
-            inputSize === "large" && "textbox--large",
+            size === "large" && "textbox--large",
             fluid && "textbox--fluid",
             inputClass,
         ]>

--- a/packages/evo-marko/src/tags/evo-input/input.stories.ts
+++ b/packages/evo-marko/src/tags/evo-input/input.stories.ts
@@ -39,7 +39,7 @@ export default {
       control: "text",
       description: "The value of the input",
     },
-    inputSize: {
+    size: {
       type: "string",
       options: ["regular (default)", "large"],
       control: "inline-radio",
@@ -87,6 +87,12 @@ export default {
       description:
         "An `<evo-icon-*>` to show after the input. Cannot be used with floatingLabel.",
       "@": {
+        a11yText: {
+          type: "string",
+          control: "text",
+          description:
+            "A descriptive label for the postfix icon button. If set, the icon becomes clickable and wrapped with a `<button>` tag.",
+        },
         "aria-label": {
           type: "string",
           control: "text",

--- a/packages/evo-marko/src/tags/evo-input/input.stories.ts
+++ b/packages/evo-marko/src/tags/evo-input/input.stories.ts
@@ -39,7 +39,7 @@ export default {
       control: "text",
       description: "The value of the input",
     },
-    size: {
+    inputSize: {
       type: "string",
       options: ["regular (default)", "large"],
       control: "inline-radio",

--- a/packages/evo-marko/src/tags/evo-select/index.marko
+++ b/packages/evo-marko/src/tags/evo-select/index.marko
@@ -60,7 +60,7 @@ export interface Input extends Marko.HTML.Select {
 
 <evo-floating-label
     floatingLabel=floatingLabel
-    inputSize=size
+    size=size
     htmlFor=id
     disabled=disabled
     value=value

--- a/packages/evo-marko/src/tags/evo-textarea/index.marko
+++ b/packages/evo-marko/src/tags/evo-textarea/index.marko
@@ -31,7 +31,7 @@ export interface Input extends Marko.HTML.TextArea {
 
 <evo-floating-label|{ showPlaceholder }|
     floatingLabel=floatingLabel
-    inputSize=size
+    size=inputSize
     opaqueLabel=opaqueLabel
     alwaysUp=floatingLabelStatic
     htmlFor=textareaId

--- a/packages/evo-marko/src/tags/evo-textarea/index.marko
+++ b/packages/evo-marko/src/tags/evo-textarea/index.marko
@@ -1,5 +1,5 @@
 export interface Input extends Marko.HTML.TextArea {
-    size?: "regular" | "large";
+    inputSize?: "regular" | "large";
     fluid?: boolean;
     opaqueLabel?: boolean;
     floatingLabel?: string;
@@ -14,7 +14,7 @@ export interface Input extends Marko.HTML.TextArea {
     floatingLabelStatic,
     fluid,
     id,
-    size,
+    inputSize,
     invalid,
     opaqueLabel,
     style,
@@ -49,7 +49,7 @@ export interface Input extends Marko.HTML.TextArea {
             invalid && "textbox--invalid",
             readonly &&
                 "textbox--readonly" /** end remove after `:has` support */,
-            size === "large" && "textbox--large",
+            inputSize === "large" && "textbox--large",
             fluid && "textbox--fluid",
             inputClass,
         ]>

--- a/packages/evo-marko/src/tags/evo-textarea/index.marko
+++ b/packages/evo-marko/src/tags/evo-textarea/index.marko
@@ -1,5 +1,5 @@
 export interface Input extends Marko.HTML.TextArea {
-    inputSize?: "regular" | "large";
+    size?: "regular" | "large";
     fluid?: boolean;
     opaqueLabel?: boolean;
     floatingLabel?: string;
@@ -14,7 +14,7 @@ export interface Input extends Marko.HTML.TextArea {
     floatingLabelStatic,
     fluid,
     id,
-    inputSize,
+    size,
     invalid,
     opaqueLabel,
     style,
@@ -31,7 +31,7 @@ export interface Input extends Marko.HTML.TextArea {
 
 <evo-floating-label|{ showPlaceholder }|
     floatingLabel=floatingLabel
-    inputSize=inputSize
+    inputSize=size
     opaqueLabel=opaqueLabel
     alwaysUp=floatingLabelStatic
     htmlFor=textareaId
@@ -49,7 +49,7 @@ export interface Input extends Marko.HTML.TextArea {
             invalid && "textbox--invalid",
             readonly &&
                 "textbox--readonly" /** end remove after `:has` support */,
-            inputSize === "large" && "textbox--large",
+            size === "large" && "textbox--large",
             fluid && "textbox--fluid",
             inputClass,
         ]>

--- a/packages/evo-marko/src/tags/evo-textarea/textarea.stories.ts
+++ b/packages/evo-marko/src/tags/evo-textarea/textarea.stories.ts
@@ -25,7 +25,7 @@ export default {
       control: "text",
       description: "The value of the textarea",
     },
-    size: {
+    inputSize: {
       type: "string",
       options: ["regular (default)", "large"],
       control: "inline-radio",

--- a/packages/evo-marko/src/tags/evo-textarea/textarea.stories.ts
+++ b/packages/evo-marko/src/tags/evo-textarea/textarea.stories.ts
@@ -25,7 +25,7 @@ export default {
       control: "text",
       description: "The value of the textarea",
     },
-    inputSize: {
+    size: {
       type: "string",
       options: ["regular (default)", "large"],
       control: "inline-radio",

--- a/packages/evo-marko/src/tags/evo-tooltip/README.md
+++ b/packages/evo-marko/src/tags/evo-tooltip/README.md
@@ -1,0 +1,16 @@
+<h1 style="display: flex; justify-content: space-between; align-items: center;">
+    <span>
+        evo-tooltip
+    </span>
+    <span style="font-weight: normal; font-size: medium; margin-bottom: -15px;">
+        DS v1.1.0
+    </span>
+</h1>
+
+Tooltip component for displaying brief, contextual information on hover or focus. Provides accessible, non-interactive tooltips.
+
+## Examples and Documentation
+
+- [Storybook](https://ebay.github.io/evo-web/ebayui-core/?path=/story/overlays-evo-tooltip)
+- [Storybook Docs](https://ebay.github.io/evo-web/ebayui-core/?path=/docs/overlays-evo-tooltip)
+- [Code Examples](https://github.com/eBay/evo-web/tree/main/packages/evo-marko/src/tags/evo-tooltip/examples)

--- a/packages/evo-marko/src/tags/evo-tourtip/README.md
+++ b/packages/evo-marko/src/tags/evo-tourtip/README.md
@@ -1,0 +1,16 @@
+<h1 style="display: flex; justify-content: space-between; align-items: center;">
+    <span>
+        evo-tourtip
+    </span>
+    <span style="font-weight: normal; font-size: medium; margin-bottom: -15px;">
+        DS v1.1.0
+    </span>
+</h1>
+
+Tourtip component for guided tours and feature introductions. Provides accessible, interactive tooltips with navigation.
+
+## Examples and Documentation
+
+- [Storybook](https://ebay.github.io/evo-web/ebayui-core/?path=/story/overlays-evo-tourtip)
+- [Storybook Docs](https://ebay.github.io/evo-web/ebayui-core/?path=/docs/overlays-evo-tourtip)
+- [Code Examples](https://github.com/eBay/evo-web/tree/main/packages/evo-marko/src/tags/evo-tourtip/examples)

--- a/packages/evo-marko/src/tags/tags/evo-floating-label/index.marko
+++ b/packages/evo-marko/src/tags/tags/evo-floating-label/index.marko
@@ -1,6 +1,6 @@
 export interface Input {
     htmlFor?: Marko.HTMLAttributes["id"]
-    inputSize?: "regular" | "large";
+    size?: "regular" | "large";
     alwaysUp?: boolean;
     fluid?: boolean;
     opaqueLabel?: boolean;
@@ -20,7 +20,7 @@ export interface Input {
     floatingLabel,
     htmlFor,
     alwaysUp,
-    inputSize,
+    size,
     focused,
     value,
     invalid,
@@ -34,7 +34,7 @@ export interface Input {
 
 <${floatingLabel && defaultTag} class=[
     "floating-label",
-    inputSize === "large" && "floating-label--large",
+    size === "large" && "floating-label--large",
     opaqueLabel && "floating-label--opaque",
 ]>
     <if=floatingLabel>


### PR DESCRIPTION
Since `evo-marko` is still in beta, now is the time to make breaking changes to ensure that APIs are consistent across the board. As an experiment, I ran an `autoresearch` agent overnight and had it look for any names that don't match between components and it did a pretty good job!