### PR TITLE
docs(tourtip): update index convention

### DIFF
--- a/packages/ebayui-core-react/src/ebay-tourtip/__tests__/index.spec.tsx
+++ b/packages/ebayui-core-react/src/ebay-tourtip/__tests__/index.spec.tsx
@@ -16,7 +16,7 @@ const renderComponent = (props?: TourtipProps) =>
             <EbayTourtipContent>
                 <p>Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
             </EbayTourtipContent>
-            <EbayTourtipFooter index="1 / 3">
+            <EbayTourtipFooter index="1 of 3">
                 <button className="fake-link">Back</button>
                 <button className="btn btn--primary">Next</button>
             </EbayTourtipFooter>
@@ -93,7 +93,7 @@ describe("<EbayTourtip>", () => {
                         <EbayTourtipContent>
                             <p>Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
                         </EbayTourtipContent>
-                        <EbayTourtipFooter index="1 / 3">
+                        <EbayTourtipFooter index="1 of 3">
                             <button className="fake-link">Back</button>
                             <button className="btn btn--primary">Next</button>
                         </EbayTourtipFooter>

--- a/packages/ebayui-core-react/src/ebay-tourtip/__tests__/index.stories.tsx
+++ b/packages/ebayui-core-react/src/ebay-tourtip/__tests__/index.stories.tsx
@@ -184,7 +184,7 @@ export const FooterTourtip = (args) => (
             <EbayTourtipContent>
                 <p>Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
             </EbayTourtipContent>
-            <EbayTourtipFooter index="1 / 3">
+            <EbayTourtipFooter index="1 of 3">
                 <button className="fake-link">Back</button>
                 <button className="btn btn--primary">Next</button>
             </EbayTourtipFooter>
@@ -202,7 +202,7 @@ export const FooterAndHeadingTourtip = (args) => (
             <EbayTourtipContent>
                 <p>Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
             </EbayTourtipContent>
-            <EbayTourtipFooter index="1 / 3">
+            <EbayTourtipFooter index="1 of 3">
                 <button className="fake-link">Back</button>
                 <button className="btn btn--primary">Next</button>
             </EbayTourtipFooter>
@@ -234,7 +234,7 @@ export const Controlled = {
                             <EbayTourtipContent>
                                 <p>{text}</p>
                             </EbayTourtipContent>
-                            <EbayTourtipFooter index={`${i + 1} / ${items.length}`}>
+                            <EbayTourtipFooter index={`${i + 1} of ${items.length}`}>
                                 {i > 0 && (
                                     <button className="fake-link" onClick={() => setOpenIndex(i - 1)}>
                                         Back

--- a/packages/ebayui-core-react/src/ebay-tourtip/__tests__/render.spec.tsx
+++ b/packages/ebayui-core-react/src/ebay-tourtip/__tests__/render.spec.tsx
@@ -46,7 +46,7 @@ describe("ebay-tourtip rendering", () => {
         );
 
         const footer: HTMLElement = overlay.querySelector(".tourtip__footer");
-        expect(footer.querySelector(".tourtip__index")).toHaveTextContent("1 / 3");
+        expect(footer.querySelector(".tourtip__index")).toHaveTextContent("1 of 3");
         expect(within(footer).getByRole("button", { name: "Back" })).toHaveClass("fake-link");
         expect(within(footer).getByRole("button", { name: "Next" })).toHaveClass("btn btn--primary");
     });
@@ -72,7 +72,7 @@ describe("ebay-tourtip rendering", () => {
         expect(heading).toHaveTextContent("Title");
 
         const footer: HTMLElement = overlay.querySelector(".tourtip__footer");
-        expect(footer.querySelector(".tourtip__index")).toHaveTextContent("1 / 3");
+        expect(footer.querySelector(".tourtip__index")).toHaveTextContent("1 of 3");
         expect(within(footer).getByRole("button", { name: "Back" })).toHaveClass("fake-link");
         expect(within(footer).getByRole("button", { name: "Next" })).toHaveClass("btn btn--primary");
     });

--- a/packages/skin/src/sass/tourtip/stories/tourtip.stories.js
+++ b/packages/skin/src/sass/tourtip/stories/tourtip.stories.js
@@ -62,7 +62,7 @@ export const withActions = () => `
                     <span class="tourtip__index">1 of 3</span>
                     <button class="fake-link">Back</button>
                     <button class="btn btn--primary">Next</button>
-                </span>
+                </div>
             </div>
         </div>
     </div>
@@ -87,7 +87,7 @@ export const withOneAction = () => `
                 <div class="tourtip__footer">
                     <span class="tourtip__index">2 of 3</span>
                     <button class="btn btn--primary">Next</button>
-                </span>
+                </div>
             </div>
         </div>
     </div>

--- a/packages/skin/src/sass/tourtip/stories/tourtip.stories.js
+++ b/packages/skin/src/sass/tourtip/stories/tourtip.stories.js
@@ -59,7 +59,7 @@ export const withActions = () => `
                     </svg>
                 </button>
                 <div class="tourtip__footer">
-                    <span class="tourtip__index">1 / 3</span>
+                    <span class="tourtip__index">1 of 3</span>
                     <button class="fake-link">Back</button>
                     <button class="btn btn--primary">Next</button>
                 </span>
@@ -85,7 +85,7 @@ export const withOneAction = () => `
                     </svg>
                 </button>
                 <div class="tourtip__footer">
-                    <span class="tourtip__index">2 / 3</span>
+                    <span class="tourtip__index">2 of 3</span>
                     <button class="btn btn--primary">Next</button>
                 </span>
             </div>

--- a/src/routes/_index/components/tourtip/css+page.marko
+++ b/src/routes/_index/components/tourtip/css+page.marko
@@ -248,7 +248,7 @@
               </button>
               <div class="tourtip__footer">
                 <span class="tourtip__index">
-                  1 / 3
+                  1 of 3
                 </span>
                 <button class="fake-link">
                   Back
@@ -304,7 +304,7 @@
             </button>
             <div class="tourtip__footer">
               <span class="tourtip__index">
-                1 / 3
+                1 of 3
               </span>
               <button class="fake-link">
                 Back


### PR DESCRIPTION
<!-- Insert GitHub issue number below. An issue is required for all PRs -->

- Fixes #709 

No code changes required here (so no changeset), but convention has been updated to use `x of y` instead of `x/y` for tourtips.