### PR TITLE
fix(ebay-bar-chart): scale stacked charts by total

### DIFF
--- a/.changeset/fix-bar-chart-stacked-axis.md
+++ b/.changeset/fix-bar-chart-stacked-axis.md
@@ -1,0 +1,6 @@
+---
+"@ebay/ebayui-core": patch
+"@ebay/ui-core-react": patch
+---
+
+Fix ebay-bar-chart stacked y-axis scaling so 3+ stacked series render against their combined totals.

--- a/packages/ebayui-core-react/src/ebay-bar-chart/__tests__/index.spec.tsx
+++ b/packages/ebayui-core-react/src/ebay-bar-chart/__tests__/index.spec.tsx
@@ -78,6 +78,21 @@ const multiSeries: BarChartSeriesItem[] = [
     },
 ];
 
+const threeSeriesWithSharedX: BarChartSeriesItem[] = [
+    {
+        name: "Value 1",
+        data: [{ x: 1643673600000, y: 50, label: "$50" }],
+    },
+    {
+        name: "Value 2",
+        data: [{ x: 1643673600000, y: 40, label: "$40" }],
+    },
+    {
+        name: "Value 3",
+        data: [{ x: 1643673600000, y: 30, label: "$30" }],
+    },
+];
+
 describe("ebay-bar-chart rendering", () => {
     beforeEach(() => {
         vi.clearAllMocks();
@@ -118,6 +133,12 @@ describe("ebay-bar-chart rendering", () => {
         render(<EbayBarChart series={multiSeries} stacked />);
         const callProps = MockChart.mock.calls[0][0];
         expect(callProps.options.plotOptions.column.stacking).toBe("normal");
+    });
+
+    it("uses stacked totals for the y-axis max", () => {
+        render(<EbayBarChart series={threeSeriesWithSharedX} stacked />);
+        const callProps = MockChart.mock.calls[0][0];
+        expect(callProps.options.yAxis.max).toBe(120);
     });
 
     it("passes className to the container", () => {

--- a/packages/ebayui-core-react/src/ebay-bar-chart/bar-chart.tsx
+++ b/packages/ebayui-core-react/src/ebay-bar-chart/bar-chart.tsx
@@ -64,9 +64,20 @@ function prepareSeries(seriesProp: BarChartSeriesItem | BarChartSeriesItem[], st
     return series;
 }
 
-/** Compute the max data value across all series. */
-function getMaxValue(series: BarChartSeriesItem[]): number {
-    return Math.max(0, ...series.flatMap((serie) => serie.data.map((data) => data.y)));
+/** Compute the max y-axis value for grouped or stacked series. */
+function getMaxValue(series: BarChartSeriesItem[], stacked: boolean): number {
+    if (!stacked) {
+        return Math.max(0, ...series.flatMap((serie) => serie.data.map((data) => data.y)));
+    }
+
+    const stackTotals = new Map<number, number>();
+    series.forEach((serie) => {
+        serie.data.forEach((data) => {
+            stackTotals.set(data.x, (stackTotals.get(data.x) ?? 0) + data.y);
+        });
+    });
+
+    return Math.max(0, ...stackTotals.values());
 }
 
 function getXAxisConfig(xAxisLabelFormat?: string, xAxisPositioner?: () => number[]): Highcharts.XAxisOptions {
@@ -284,7 +295,7 @@ function buildChartOptions(
         },
         colors: colorMapping,
         xAxis: getXAxisConfig(xAxisLabelFormat, xAxisPositioner),
-        yAxis: getYAxisConfig(getMaxValue(preparedSeries), yAxisLabels, yAxisPositioner),
+        yAxis: getYAxisConfig(getMaxValue(preparedSeries, stacked), yAxisLabels, yAxisPositioner),
         legend: getLegendConfig(seriesProp),
         tooltip: getTooltipConfig(hc, stacked),
         plotOptions: getColumnPlotOptions(stacked, description),

--- a/packages/ebayui-core/src/components/ebay-bar-chart/component.ts
+++ b/packages/ebayui-core/src/components/ebay-bar-chart/component.ts
@@ -172,17 +172,31 @@ class BarChart extends Marko.Component<Input> {
         };
     }
 
+    getMaxValue(series: SeriesItem[]): number {
+        if (!this.input.stacked) {
+            return Math.max(
+                0,
+                ...series.flatMap((s) => s.data!.map((point: any) => point.y)),
+            );
+        }
+
+        const stackTotals = new Map<number, number>();
+        series.forEach((s) => {
+            s.data!.forEach((point: any) => {
+                stackTotals.set(
+                    point.x,
+                    (stackTotals.get(point.x) ?? 0) + point.y,
+                );
+            });
+        });
+
+        return Math.max(0, ...stackTotals.values());
+    }
+
     getYAxisConfig(series: SeriesItem[]): Highcharts.YAxisOptions {
         const yAxisLabels = this.input.yAxisLabels;
         const yAxisPositioner = this.input.yAxisPositioner;
-
-        let maxVal = 0; // use to determine the highest yAxis value
-        series.forEach((s) => {
-            maxVal = s.data!.reduce(
-                (p: number, c: any) => (c.y > p ? c.y : p),
-                maxVal,
-            ) as number;
-        });
+        const maxVal = this.getMaxValue(series); // use to determine the highest yAxis value
         let yLabelsItterator = 0;
         return {
             gridLineColor: gridColor, // sets the horizontal grid line colors

--- a/packages/ebayui-core/src/components/ebay-bar-chart/test/test.server.js
+++ b/packages/ebayui-core/src/components/ebay-bar-chart/test/test.server.js
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import BarChart from "../component";
+
+const threeSeriesWithSharedX = [
+    {
+        name: "Value 1",
+        data: [{ x: 1643673600000, y: 50, label: "$50" }],
+    },
+    {
+        name: "Value 2",
+        data: [{ x: 1643673600000, y: 40, label: "$40" }],
+    },
+    {
+        name: "Value 3",
+        data: [{ x: 1643673600000, y: 30, label: "$30" }],
+    },
+];
+
+function createBarChart(input = {}) {
+    const chart = Object.create(BarChart.prototype);
+    chart.input = input;
+    return chart;
+}
+
+describe("ebay-bar-chart y-axis config", () => {
+    it("uses stacked totals for the y-axis max", () => {
+        const chart = createBarChart({ stacked: true });
+
+        expect(chart.getYAxisConfig(threeSeriesWithSharedX).max).toBe(120);
+    });
+
+    it("uses individual values for the y-axis max when not stacked", () => {
+        const chart = createBarChart({ stacked: false });
+
+        expect(chart.getYAxisConfig(threeSeriesWithSharedX).max).toBe(50);
+    });
+});


### PR DESCRIPTION
<!-- Insert GitHub issue number below. An issue is required for all PRs -->

- Fixes #710

## Description

<!-- Briefly describe the proposed changes -->

Fixes `ebay-bar-chart` stacked chart scaling in both Marko and React by calculating the y-axis max from the combined stacked total for each shared `x` value instead of from the largest individual segment.

This prevents stacked examples with 3+ series from rendering too high/clipped and keeps the 2-series/non-stacked behavior unchanged.

Also adds regression coverage for:

- React stacked y-axis max with 3 shared-x series
- Marko stacked vs non-stacked y-axis max behavior

## Notes

<!-- Be sure to mention anything unusual, out-of-scope or new technical debt, etc -->

Screenshots will be uploaded manually after PR creation.

Validation run:

- `npm run test:server -w packages/ebayui-core -- src/components/ebay-bar-chart/test/test.server.js`
- `npm test -w packages/ebayui-core-react -- src/ebay-bar-chart/__tests__/index.spec.tsx`
- `npm run build`

## Screenshots

Before

<img width="1291" height="423" alt="Screenshot 2026-06-11 at 5 32 29 PM" src="https://github.com/user-attachments/assets/f90a3a07-2dd2-4321-b765-2265a0e28d7c" />

After
<img width="1525" height="423" alt="Screenshot 2026-06-11 at 5 32 38 PM" src="https://github.com/user-attachments/assets/fc7ae9bd-1cff-4a1d-8d13-7264ba5864f9" />


To be uploaded manually.

## Checklist

<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->

- [ ] I verify the linked issue has been triaged ("Needs Triage" label removed)
- [ ] I verify all changes are within scope of the linked issue
- [ ] I added/updated/removed testing (Storybook in Skin) coverage as appropriate

<!-- For CSS changes -->

- [ ] I tested the UI in all supported browsers
- [ ] I tested the UI in dark mode and RTL mode
