### PR TITLE
fix(docs): correct legacy React package name in CLAUDE.md and release skill

### DIFF
--- a/.claude/skills/evo-release-workflow/SKILL.md
+++ b/.claude/skills/evo-release-workflow/SKILL.md
@@ -59,7 +59,7 @@ feat(module): adding a new feature
 - `@ebay/skin` - markup CSS/SCSS changes
 - `@ebay/ebayui-core` - legacy Marko 5 components
 - `@evo-web/marko` - new Marko 6 components
-- `@ebay/ebayui-core-react` - legacy React components
+- `@ebay/ui-core-react` - legacy React components
 - `@evo-web/react` - new React components
 
 ### 3. Commit the Changeset File

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ HTML Semantic Structure → @ebay/skin (CSS/BEM) → Framework Components → In
 - `@ebay/skin` - Pure CSS/SCSS (foundation layer)
 - `@ebay/ebayui-core` - Marko 5 (legacy)
 - `@evo-web/marko` - Marko 6 (new, under migration)
-- `@ebay/ebayui-core-react` - React CJS (legacy)
+- `@ebay/ui-core-react` - React CJS (legacy)
 - `@evo-web/react` - React 19 ESM (new, under migration)
 
 ### Component Development Flow (MANDATORY)
@@ -166,7 +166,7 @@ Follow existing component structures:
 
 **CRITICAL package differences:**
 
-- `@ebay/ebayui-core-react`:
+- `@ebay/ui-core-react`:
   - Requires `React.forwardRef` wrapper for ref forwarding
   - CommonJS build target
   - External MakeupJS dependency


### PR DESCRIPTION
## Summary

- Fixes incorrect npm package name `@ebay/ebayui-core-react` → `@ebay/ui-core-react` in two places:
  - `CLAUDE.md` Package Structure and "CRITICAL package differences" sections
  - `.claude/skills/evo-release-workflow/SKILL.md` Common package names list

## Context

The wrong name was the source of the invalid changeset frontmatter caught in PR #722. The `evo-release-workflow` skill had a self-contradiction: the example on line 43 used the correct `@ebay/ui-core-react`, but the "Common package names" list on line 62 listed the non-existent `@ebay/ebayui-core-react`. AI agents reading the list generated invalid changesets as a result.

## Test plan

- [ ] Verify `.changeset/` files created after this merge reference `@ebay/ui-core-react` for legacy React changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)