### PR TITLE
docs(ebay-video): add captions example

### DIFF
--- a/packages/ebayui-core/src/components/ebay-video/video.stories.ts
+++ b/packages/ebayui-core/src/components/ebay-video/video.stories.ts
@@ -10,6 +10,9 @@ import compactLayoutRaw from "./examples/compact-layout.marko?raw";
 import autoPlayComponent from "./examples/auto-play-viewport.marko";
 import autoPlayRaw from "./examples/auto-play-viewport.marko?raw";
 
+import captionsComponent from "./examples/captions.marko";
+import captionsRaw from "./examples/captions.marko?raw";
+
 const Template: Story<Input> = (args: Input) => ({
     input: {
         ...args,
@@ -338,4 +341,9 @@ export const CompactLayout = buildExtensionTemplate(
 export const AutoPlayViewport = buildExtensionTemplate(
     autoPlayComponent,
     autoPlayRaw,
+);
+
+export const Captions = buildExtensionTemplate(
+    captionsComponent,
+    captionsRaw,
 );


### PR DESCRIPTION
Add example with captions in the `.dash` file, so `<shaka-player>` automatically includes its `cc` button