### PR TITLE
fix(ebayui-core-react): avoid closed dropdown floating styles

### DIFF
--- a/.changeset/quiet-filters-scroll.md
+++ b/.changeset/quiet-filters-scroll.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ui-core-react": patch
+---
+
+Prevent dropdown floating styles from being applied while closed.

--- a/packages/ebayui-core-react/src/common/__tests__/floating-ui.spec.tsx
+++ b/packages/ebayui-core-react/src/common/__tests__/floating-ui.spec.tsx
@@ -1,0 +1,49 @@
+import { renderHook } from "@testing-library/react";
+import { useFloating } from "@floating-ui/react";
+import { vi } from "vitest";
+import { useFloatingDropdown } from "../floating-ui";
+
+vi.mock("@floating-ui/react", () => ({
+    autoUpdate: vi.fn(),
+    flip: vi.fn(() => ({ name: "flip" })),
+    offset: vi.fn(() => ({ name: "offset" })),
+    shift: vi.fn(() => ({ name: "shift" })),
+    arrow: vi.fn(() => ({ name: "arrow" })),
+    inline: vi.fn(() => ({ name: "inline" })),
+    useFloating: vi.fn(),
+}));
+
+describe("useFloatingDropdown", () => {
+    const floatingStyles = {
+        position: "absolute",
+        left: 0,
+        top: 0,
+        transform: "translate(0px, 0px)",
+    } as const;
+
+    const refs = {
+        reference: { current: null },
+        floating: { current: null },
+        setReference: vi.fn(),
+        setFloating: vi.fn(),
+    };
+
+    beforeEach(() => {
+        vi.mocked(useFloating).mockReturnValue({
+            floatingStyles,
+            refs,
+        } as unknown as ReturnType<typeof useFloating>);
+    });
+
+    it("should not return overlay styles when closed", () => {
+        const { result } = renderHook(() => useFloatingDropdown({ open: false }));
+
+        expect(result.current.overlayStyles).toBeUndefined();
+    });
+
+    it("should return overlay styles when open", () => {
+        const { result } = renderHook(() => useFloatingDropdown({ open: true }));
+
+        expect(result.current.overlayStyles).toBe(floatingStyles);
+    });
+});

--- a/packages/ebayui-core-react/src/common/floating-ui.ts
+++ b/packages/ebayui-core-react/src/common/floating-ui.ts
@@ -3,7 +3,7 @@ import { autoUpdate, flip, offset, shift, arrow, inline, useFloating, type Place
 import { PointerDirection } from "./tooltip-utils/types";
 
 export type FloatingDropdownHookReturn = {
-    overlayStyles: ReturnType<typeof useFloating>["floatingStyles"];
+    overlayStyles: ReturnType<typeof useFloating>["floatingStyles"] | undefined;
     refs: {
         host: ReturnType<typeof useFloating>["refs"]["reference"];
         overlay: ReturnType<typeof useFloating>["refs"]["floating"];
@@ -33,7 +33,7 @@ export function useFloatingDropdown({ open, options }: FloatingDropdownHookArgs)
     });
 
     return {
-        overlayStyles: floatingStyles,
+        overlayStyles: open ? floatingStyles : undefined,
         refs: {
             host: refs.reference,
             overlay: refs.floating,

--- a/packages/ebayui-core-react/src/ebay-filter-menu-button/__tests__/index.spec.tsx
+++ b/packages/ebayui-core-react/src/ebay-filter-menu-button/__tests__/index.spec.tsx
@@ -40,6 +40,16 @@ function setupMockEnv() {
 }
 
 describe("EbayFilterMenuButton", () => {
+    it("should not apply floating styles while collapsed", () => {
+        const { container } = render(
+            <EbayFilterMenuButton text="Menu">
+                <EbayFilterMenuItem>Option 1</EbayFilterMenuItem>
+            </EbayFilterMenuButton>,
+        );
+
+        expect(container.querySelector(".filter-menu-button__menu")).not.toHaveAttribute("style");
+    });
+
     it("should call onExpand when the menu is expanded", async () => {
         const onExpand = vi.fn();
         render(


### PR DESCRIPTION
<!-- Insert GitHub issue number below. An issue is required for all PRs -->

- Fixes #703

## Description

<!-- Briefly describe the proposed changes -->

Prevents React dropdown components using `useFloatingDropdown` from applying Floating UI's initial inline positioning styles while closed. This avoids the initial closed-state `transform` style from affecting `EbayFilterMenuButton` when it is positioned lower on the page.

Adds unit coverage for the shared dropdown hook and a component regression test for the collapsed filter menu button.

## Notes

<!-- Be sure to mention anything unusual, out-of-scope or new technical debt, etc -->

Marko does not have this issue and is intentionally unchanged.

## Screenshots

<!-- Upload screenshots of UI before & after these changes -->

N/A — no visual changes.

## Checklist

<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->

- [ ] I verify the linked issue has been triaged ("Needs Triage" label removed)
- [ ] I verify all changes are within scope of the linked issue
- [ ] I added/updated/removed testing (Storybook in Skin) coverage as appropriate

<!-- For CSS changes -->

- [ ] I tested the UI in all supported browsers
- [ ] I tested the UI in dark mode and RTL mode
