### PR TITLE
docs: publish previews for PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,6 @@ jobs:
     if: github.ref == 'refs/heads/main'
     permissions:
       contents: write
-      packages: write
-      pull-requests: write
-      issues: read
     environment:
       name: github-pages
       url: https://opensource.ebay.com/evo-web/
@@ -59,6 +56,8 @@ jobs:
         run: npm ci
       - name: Build site
         run: npm run deploy
+        env:
+          BASE_URL: /evo-web/
       - name: Deploy to gh-pages branch (root)
         run: |
           git config user.name "github-actions[bot]"
@@ -68,6 +67,7 @@ jobs:
             --dest . \
             --branch gh-pages \
             --nojekyll \
+            --add \
             --message "deploy: main @ ${{ github.sha }}" \
             --repo "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
   release:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,16 +60,26 @@ jobs:
           BASE_URL: /evo-web/
       - name: Deploy to gh-pages branch (root)
         run: |
+          set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          npx gh-pages \
-            --dist _site/public \
-            --dest . \
-            --branch gh-pages \
-            --nojekyll \
-            --add \
-            --message "deploy: main @ ${{ github.sha }}" \
-            --repo "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
+
+          git fetch origin gh-pages
+          git worktree add /tmp/gh-pages-deploy gh-pages
+
+          # Wipe everything except the previews/ subdirectory and git internals
+          find /tmp/gh-pages-deploy -mindepth 1 -maxdepth 1 \
+            ! -name '.git' ! -name 'previews' \
+            -exec rm -rf {} +
+
+          # Copy the freshly-built site in (previews/ is untouched)
+          cp -r _site/public/. /tmp/gh-pages-deploy/
+          touch /tmp/gh-pages-deploy/.nojekyll
+
+          cd /tmp/gh-pages-deploy
+          git add -A
+          git commit -m "deploy: main @ ${{ github.sha }}"
+          git push "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git" gh-pages
   release:
     needs: [build]
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,17 +37,14 @@ jobs:
   # Deployment job
   deploy:
     if: github.ref == 'refs/heads/main'
-    # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
     permissions:
-      pages: write
-      id-token: write
       contents: write
       packages: write
       pull-requests: write
       issues: read
     environment:
       name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+      url: https://opensource.ebay.com/evo-web/
     runs-on: ubuntu-latest
     needs: [build]
     steps:
@@ -60,15 +57,19 @@ jobs:
           cache: npm
       - name: Install dependencies
         run: npm ci
-      - name: Deploy job
+      - name: Build site
         run: npm run deploy
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: _site/public
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+      - name: Deploy to gh-pages branch (root)
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          npx gh-pages \
+            --dist _site/public \
+            --dest . \
+            --branch gh-pages \
+            --nojekyll \
+            --message "deploy: main @ ${{ github.sha }}" \
+            --repo "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
   release:
     needs: [build]
     permissions:

--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -7,9 +7,11 @@ on:
 jobs:
   cleanup-preview:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: write
       pull-requests: write
+      issues: write
     steps:
       - name: Checkout gh-pages branch
         uses: actions/checkout@v6

--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -1,0 +1,55 @@
+name: PR Preview Cleanup
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  cleanup-preview:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout gh-pages branch
+        uses: actions/checkout@v6
+        with:
+          ref: gh-pages
+
+      - name: Remove preview directory and push
+        run: |
+          PR=${{ github.event.pull_request.number }}
+          if [ -d "previews/pr-${PR}" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git rm -rf "previews/pr-${PR}"
+            git commit -m "cleanup: remove preview for pr-${PR}"
+            git push "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git" gh-pages
+          else
+            echo "No preview directory found for pr-${PR}, nothing to clean up."
+          fi
+
+      - name: Update preview comment
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr = context.payload.pull_request.number;
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr,
+            });
+            const existing = comments.find(
+              c => c.user.login === 'github-actions[bot]' && c.body.includes('PR Preview Deployed') && !c.body.includes('_(removed)_')
+            );
+            if (existing) {
+              const struck = existing.body
+                .replace('### PR Preview Deployed', '### PR Preview Deployed _(removed)_');
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: struck,
+              });
+            }

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -11,9 +11,11 @@ concurrency:
 jobs:
   deploy-preview:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: write
       pull-requests: write
+      issues: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -17,6 +17,30 @@ jobs:
       pull-requests: write
       issues: write
     steps:
+      - name: Post "updating" status to PR
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr = context.payload.pull_request.number;
+            const sha = context.payload.pull_request.head.sha;
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr,
+            });
+            const existing = comments.find(
+              c => c.user.login === 'github-actions[bot]' && c.body.includes('PR Preview Deployed')
+            );
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: existing.body.trimEnd() + ` _(deploying ${sha}...)_`,
+              });
+            }
+
       - name: Checkout code
         uses: actions/checkout@v6
 
@@ -55,13 +79,6 @@ jobs:
             const pr = context.payload.pull_request.number;
             const sha = context.payload.pull_request.head.sha.slice(0, 7);
             const url = `https://opensource.ebay.com/evo-web/previews/pr-${pr}/`;
-            const body = [
-              `### PR Preview Deployed`,
-              ``,
-              `[Website](${url}) • [\`evo-marko\`](${url}marko/) • [\`evo-react\`](${url}react/) • [\`ebayui-core\`](${url}ebayui-core/) • [\`ebayui-core-react\`](${url}ebayui-core-react/) • [\`skin\`](${url}skin-storybook/)`,
-              ``,
-              `###### commit ${sha}`,
-            ].join('\n');
 
             // Find and update an existing bot comment, or create a new one
             const { data: comments } = await github.rest.issues.listComments({
@@ -77,9 +94,16 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 comment_id: existing.id,
-                body,
+                body: existing.body.replace(/ _\(deploying [a-f0-9]{40}\)_/, ''),
               });
             } else {
+              const body = [
+                `### PR Preview Deployed`,
+                ``,
+                `[Website](${url}) • [\`evo-marko\`](${url}marko/) • [\`evo-react\`](${url}react/) • [\`ebayui-core\`](${url}ebayui-core/) • [\`ebayui-core-react\`](${url}ebayui-core-react/) • [\`skin\`](${url}skin-storybook/)`,
+                ``,
+                `###### commit ${sha}`,
+              ].join('\n');
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,87 @@
+name: PR Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: "preview-${{ github.head_ref }}"
+  cancel-in-progress: true
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build site (preview base URL)
+        run: npm run deploy
+        env:
+          BASE_URL: /evo-web/previews/pr-${{ github.event.pull_request.number }}/
+
+      - name: Deploy to gh-pages branch (preview subdirectory)
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          npx gh-pages \
+            --dist _site/public \
+            --dest previews/pr-${{ github.event.pull_request.number }} \
+            --branch gh-pages \
+            --nojekyll \
+            --add \
+            --message "preview: pr-${{ github.event.pull_request.number }} @ ${{ github.sha }}" \
+            --repo "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
+
+      - name: Post preview URL to PR
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr = context.payload.pull_request.number;
+            const sha = context.sha.slice(0, 7);
+            const url = `https://opensource.ebay.com/evo-web/previews/pr-${pr}/`;
+            const body = [
+              `### PR Preview Deployed`,
+              ``,
+              `[Website](${url}) • [\`evo-marko\`](${url}marko/) • [\`evo-react\`](${url}react/) • [\`ebayui-core\`](${url}ebayui-core/) • [\`ebayui-core-react\`](${url}ebayui-core-react/) • [\`skin\`](${url}skin-storybook/)`,
+              ``,
+              `###### commit ${sha}`,
+            ].join('\n');
+
+            // Find and update an existing bot comment, or create a new one
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr,
+            });
+            const existing = comments.find(
+              c => c.user.login === 'github-actions[bot]' && c.body.includes('PR Preview Deployed')
+            );
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr,
+                body,
+              });
+            }

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -94,7 +94,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 comment_id: existing.id,
-                body: existing.body.replace(/ _\(deploying [a-f0-9]{40}\)_/, ''),
+                body: existing.body.replace(/###### commit .+$/, `###### commit ${sha}`),
               });
             } else {
               const body = [

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -53,7 +53,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const pr = context.payload.pull_request.number;
-            const sha = context.sha.slice(0, 7);
+            const sha = context.payload.pull_request.head.sha.slice(0, 7);
             const url = `https://opensource.ebay.com/evo-web/previews/pr-${pr}/`;
             const body = [
               `### PR Preview Deployed`,

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build:ci": "CI=true && npm run build",
     "change": "changeset add",
     "deploy": "copyfiles src/data/component-metadata.json public/ -u 2 && npm run deploy:build && npm run deploy:copy-site",
-    "deploy:build": "concurrently --kill-others-on-fail \"BASE_URL=/evo-web/ marko-run build -o ./_site\" \"npm run deploy -w packages/skin\" \"npm run deploy -w packages/ebayui-core\" \"npm run deploy -w packages/evo-marko\" \"npm run deploy -w packages/ebayui-core-react\" \"npm run deploy -w packages/evo-react\"",
+    "deploy:build": "concurrently --kill-others-on-fail \"marko-run build -o ./_site\" \"npm run deploy -w packages/skin\" \"npm run deploy -w packages/ebayui-core\" \"npm run deploy -w packages/evo-marko\" \"npm run deploy -w packages/ebayui-core-react\" \"npm run deploy -w packages/evo-react\"",
     "deploy:copy-site": "copyfiles packages/skin/_site/public _site/public/skin-storybook -u 4 && copyfiles packages/ebayui-core/_site _site/public/ebayui-core -u 3 && copyfiles packages/evo-marko/_site _site/public/marko -u 3 && copyfiles packages/ebayui-core-react/_site _site/public/ebayui-core-react -u 3 && copyfiles packages/evo-react/_site _site/public/react -u 3",
     "postinstall": "npx playwright install --with-deps chromium",
     "lint": "stylelint src --config .stylelintrc",


### PR DESCRIPTION
Modifies the site publishing GitHub Action to enable previews for PRs.

All PR previews will be available on `https://opensource.ebay.com/evo-web/previews/pr-000/...`

Note that we'll need to change to "deploy from branch" in GH settings once this is merged to ensure that it worked