### PR TITLE
fix(date-textbox): return focus to icon btn

### DIFF
--- a/.changeset/stale-rules-write.md
+++ b/.changeset/stale-rules-write.md
@@ -1,0 +1,6 @@
+---
+"@ebay/ui-core-react": patch
+"@ebay/ebayui-core": patch
+---
+
+fix(date-textbox): return focus to icon btn

--- a/packages/ebayui-core-react/src/ebay-calendar/calendar.tsx
+++ b/packages/ebayui-core-react/src/ebay-calendar/calendar.tsx
@@ -1,11 +1,11 @@
 // TODO: Check onKeydown event on non interactive table event
 /* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
+import classNames from "classnames";
 import React, { FC, FocusEvent, KeyboardEvent, MouseEvent, useEffect, useRef, useState } from "react";
 import { EbayIconButton } from "../ebay-icon-button";
-import { DayISO, fromISO, getWeekdayInfo, localeOverride, offsetISO, toISO } from "./date-utils";
-import classNames from "classnames";
 import { EbayIconChevronLeft24 } from "../ebay-icon/icons/ebay-icon-chevron-left-24";
 import { EbayIconChevronRight24 } from "../ebay-icon/icons/ebay-icon-chevron-right-24";
+import { DayISO, fromISO, getWeekdayInfo, localeOverride, offsetISO, toISO } from "./date-utils";
 
 export type EbayCalendarProps = {
     selected?: DayISO | DayISO[];
@@ -369,7 +369,7 @@ const EbayCalendar: FC<EbayCalendarProps> = ({
                                             const isDisabled = isDayDisabled(dayISO);
                                             const a11yTexts = [
                                                 "",
-                                                isSelected && a11ySelectedText,
+                                                !interactive && isSelected && a11ySelectedText,
                                                 isRangeStart && a11yRangeStartText,
                                                 !isRangeStart && !isRangeEnd && isInRange && a11yInRangeText,
                                                 isRangeEnd && a11yRangeEndText,

--- a/packages/ebayui-core-react/src/ebay-date-textbox/__tests__/index.spec.tsx
+++ b/packages/ebayui-core-react/src/ebay-date-textbox/__tests__/index.spec.tsx
@@ -65,6 +65,41 @@ describe("<EbayDateTextbox />", () => {
         expect(container.querySelector(".date-textbox__popover")).toHaveAttribute("hidden");
     });
 
+    describe("focus management", () => {
+        it("should return focus to the calendar button when selecting a date and collapseOnSelect is true", () => {
+            render(<EbayDateTextbox collapseOnSelect />);
+            fireEvent.click(screen.getByLabelText("open calendar"));
+            fireEvent.click(screen.getByText("1"));
+
+            expect(screen.getByLabelText("open calendar")).toHaveFocus();
+        });
+
+        it("should not return focus to the calendar button when selecting the first date of a range", () => {
+            render(<EbayDateTextbox range collapseOnSelect />);
+            fireEvent.click(screen.getByLabelText("open calendar"));
+            fireEvent.click(screen.getByText("1"));
+
+            expect(screen.getByLabelText("open calendar")).not.toHaveFocus();
+        });
+
+        it("should return focus to the calendar button when completing a range and collapseOnSelect is true", () => {
+            render(<EbayDateTextbox range collapseOnSelect />);
+            fireEvent.click(screen.getByLabelText("open calendar"));
+            fireEvent.click(screen.getByText("1"));
+            fireEvent.click(screen.getByText("2"));
+
+            expect(screen.getByLabelText("open calendar")).toHaveFocus();
+        });
+    });
+
+    it("should not close the calendar when selecting the first date of a range and collapseOnSelect is true", () => {
+        const { container } = render(<EbayDateTextbox range collapseOnSelect />);
+        fireEvent.click(screen.getByLabelText("open calendar"));
+
+        fireEvent.click(screen.getByText("1"));
+        expect(container.querySelector(".date-textbox__popover")).not.toHaveAttribute("hidden");
+    });
+
     it("should close the calendar when selecting a range and collapseOnSelect is true", () => {
         const { container } = render(<EbayDateTextbox range collapseOnSelect />);
         fireEvent.click(screen.getByLabelText("open calendar"));

--- a/packages/ebayui-core-react/src/ebay-date-textbox/date-textbox.tsx
+++ b/packages/ebayui-core-react/src/ebay-date-textbox/date-textbox.tsx
@@ -190,17 +190,20 @@ const EbayDateTextbox: FC<EbayDateTextboxProps> = ({
                     eventData.rangeStart = iso;
                     eventData.rangeEnd = selected;
                 }
+                if (collapseOnSelect) {
+                    expander.current.expanded = false;
+                    containerRef.current?.querySelector<HTMLElement>(".ebay-date-textbox--main > .icon-btn")?.focus();
+                }
             }
             onChange(event, eventData);
         } else {
             onChange(event, {
                 selected: iso,
             });
-        }
-
-        if (collapseOnSelect) {
-            expander.current.expanded = false;
-            containerRef.current?.querySelector<HTMLElement>(".ebay-date-textbox--main > .icon-btn")?.focus();
+            if (collapseOnSelect) {
+                expander.current.expanded = false;
+                containerRef.current?.querySelector<HTMLElement>(".ebay-date-textbox--main > .icon-btn")?.focus();
+            }
         }
     };
 

--- a/packages/ebayui-core-react/src/ebay-date-textbox/date-textbox.tsx
+++ b/packages/ebayui-core-react/src/ebay-date-textbox/date-textbox.tsx
@@ -200,6 +200,7 @@ const EbayDateTextbox: FC<EbayDateTextboxProps> = ({
 
         if (collapseOnSelect) {
             expander.current.expanded = false;
+            containerRef.current?.querySelector<HTMLElement>(".ebay-date-textbox--main > .icon-btn")?.focus();
         }
     };
 

--- a/packages/ebayui-core/src/components/ebay-calendar/index.marko
+++ b/packages/ebayui-core/src/components/ebay-calendar/index.marko
@@ -25,14 +25,16 @@ $ var monthDates = [...Array(numMonths)].map((_, i) =>
                 <ebay-icon-button
                     transparent
                     size="small"
-                    disabled=(state.disableBefore && component.getFirstVisibleISO() <= state.disableBefore)
+                    disabled=(
+                        state.disableBefore &&
+                        component.getFirstVisibleISO() <= state.disableBefore
+                    )
                     aria-label=getA11yShowMonthText(
                         component.monthTitle(
                             component.getMonthDate(state.offset - 1),
                         ),
                     )
-                    onClick("prevMonth", false)
-                >
+                    onClick("prevMonth", false)>
                     <ebay-chevron-left-24-icon/>
                 </ebay-icon-button>
                 <for|monthDate| of=monthDates>
@@ -41,14 +43,16 @@ $ var monthDates = [...Array(numMonths)].map((_, i) =>
                 <ebay-icon-button
                     transparent
                     size="small"
-                    disabled=(state.disableAfter && component.getLastVisibleISO() >= state.disableAfter)
+                    disabled=(
+                        state.disableAfter &&
+                        component.getLastVisibleISO() >= state.disableAfter
+                    )
                     aria-label=getA11yShowMonthText(
                         component.monthTitle(
                             component.getMonthDate(state.offset + numMonths),
                         ),
                     )
-                    onClick("nextMonth", false)
-                >
+                    onClick("nextMonth", false)>
                     <ebay-chevron-right-24-icon/>
                 </ebay-icon-button>
             </div>
@@ -80,8 +84,7 @@ $ var monthDates = [...Array(numMonths)].map((_, i) =>
                         ).getDate();
                         <for|row|
                             from=0
-                            to=Math.floor((numBlankDays + daysInMonth) / 7)
-                        >
+                            to=Math.floor((numBlankDays + daysInMonth) / 7)>
                             <tr>
                                 $ var startDate = row * 7 - numBlankDays + 1;
                                 $ var endDate = startDate + 6;
@@ -118,7 +121,11 @@ $ var monthDates = [...Array(numMonths)].map((_, i) =>
                                     );
                                     $ var a11yTexts = [""];
                                     $ {
-                                        if (a11ySelectedText && isSelected)
+                                        if (
+                                            a11ySelectedText &&
+                                            isSelected &&
+                                            !interactive
+                                        )
                                             a11yTexts.push(a11ySelectedText);
                                     }
                                     $ {
@@ -154,11 +161,14 @@ $ var monthDates = [...Array(numMonths)].map((_, i) =>
                                                     a11yTexts.length > 1 &&
                                                     `${day}${a11yTexts.join(a11ySeparator)}`
                                                 )
-                                                tabindex=state.tabindexISO !==
-                                                    dayISO && -1
+                                                tabindex=(
+                                                    state.tabindexISO !==
+                                                        dayISO && -1
+                                                )
                                                 aria-current=isToday && "date"
-                                                aria-pressed=isSelected &&
-                                                "true"
+                                                aria-pressed=(
+                                                    isSelected && "true"
+                                                )
                                                 onClick("onDaySelect", dayISO)
                                                 onFocus("onDayFocus", dayISO)
                                                 onMouseover(
@@ -166,8 +176,7 @@ $ var monthDates = [...Array(numMonths)].map((_, i) =>
                                                     dayISO,
                                                 )
                                                 onBlur("onDayBlur")
-                                                onMouseout("onDayBlur")
-                                            >
+                                                onMouseout("onDayBlur")>
                                                 ${day}
                                             </button>
                                         </if>
@@ -199,8 +208,7 @@ $ var monthDates = [...Array(numMonths)].map((_, i) =>
                                                     "calendar__cell--current":
                                                         isToday,
                                                 }
-                                                href=link
-                                            >
+                                                href=link>
                                                 ${day}
                                                 <if(a11yTexts.length > 1)>
                                                     <span class="clipped">

--- a/packages/ebayui-core/src/components/ebay-date-textbox/component.ts
+++ b/packages/ebayui-core/src/components/ebay-date-textbox/component.ts
@@ -1,13 +1,13 @@
 import Expander from "makeup-expander";
-import { DropdownUtil } from "../../common/dropdown";
+import { getLocale, parse } from "../../common/dates";
 import { type DayISO, dateArgToISO } from "../../common/dates/date-utils";
+import { DropdownUtil } from "../../common/dropdown";
 import type { WithNormalizedProps } from "../../global";
+import type { Input as CalendarInput } from "../ebay-calendar/component";
 import type {
     TextboxEvent,
     Input as TextboxInput,
 } from "../ebay-textbox/component-browser";
-import type { Input as CalendarInput } from "../ebay-calendar/component";
-import { getLocale, parse } from "../../common/dates";
 
 const MIN_WIDTH_FOR_DOUBLE_PANE = 600;
 
@@ -141,13 +141,19 @@ class DateTextbox extends Marko.Component<Input, State> {
                 }
                 if (this.input.collapseOnSelect) {
                     this.expander.expanded = false;
+                    this.focusCalendarButton();
                 }
             }
         } else if (this.input.collapseOnSelect) {
             this.expander.expanded = false;
+            this.focusCalendarButton();
         }
 
         this.emitSelectedChange();
+    }
+
+    focusCalendarButton() {
+        (this.getComponent("mainTextbox")?.getEl("iconBtn") as HTMLElement)?.focus();
     }
 
     /**

--- a/packages/ebayui-core/src/components/ebay-date-textbox/index.marko
+++ b/packages/ebayui-core/src/components/ebay-date-textbox/index.marko
@@ -36,6 +36,7 @@ $ const formatValue = (date: DayISO | null) => {
         />
     </if>
     <ebay-textbox
+        key="mainTextbox"
         class="ebay-date-textbox--main"
         placeholder=mainPlaceholder
         buttonAriaLabel=a11yOpenPopoverText

--- a/packages/ebayui-core/src/components/ebay-date-textbox/test/__snapshots__/test.server.js.snap
+++ b/packages/ebayui-core/src/components/ebay-date-textbox/test/__snapshots__/test.server.js.snap
@@ -10,7 +10,7 @@ exports[`date-textbox > renders defaults 1`] = `
     [36m>[39m
       [36m<input[39m
         [33mclass[39m=[32m"textbox__control"[39m
-        [33mid[39m=[32m"s0-2-textbox"[39m
+        [33mid[39m=[32m"s0-@mainTextbox-textbox"[39m
         [33mplaceholder[39m=[32m"MM/DD/YYYY"[39m
         [33mtype[39m=[32m"text"[39m
         [33mvalue[39m=[32m"01/27/2024"[39m
@@ -371,7 +371,6 @@ exports[`date-textbox > renders defaults 1`] = `
                     [33mclass[39m=[32m"calendar__cell--selected"[39m
                   [36m>[39m
                     [36m<button[39m
-                      [33maria-label[39m=[32m"27 - selected"[39m
                       [33maria-pressed[39m=[32m"true"[39m
                       [33mtype[39m=[32m"button"[39m
                     [36m>[39m
@@ -454,7 +453,7 @@ exports[`date-textbox > renders localized 1`] = `
     [36m>[39m
       [36m<label[39m
         [33mclass[39m=[32m"floating-label__label"[39m
-        [33mfor[39m=[32m"s0-0-2-textbox"[39m
+        [33mfor[39m=[32m"s0-0-@mainTextbox-textbox"[39m
       [36m>[39m
         [0mEinde[0m
       [36m</label>[39m
@@ -463,7 +462,7 @@ exports[`date-textbox > renders localized 1`] = `
       [36m>[39m
         [36m<input[39m
           [33mclass[39m=[32m"textbox__control"[39m
-          [33mid[39m=[32m"s0-0-2-textbox"[39m
+          [33mid[39m=[32m"s0-0-@mainTextbox-textbox"[39m
           [33mplaceholder[39m=[32m"JJJJ/MM/DD"[39m
           [33mtype[39m=[32m"text"[39m
           [33mvalue[39m=[32m""[39m
@@ -826,7 +825,6 @@ exports[`date-textbox > renders localized 1`] = `
                     [33mclass[39m=[32m"calendar__cell--selected"[39m
                   [36m>[39m
                     [36m<button[39m
-                      [33maria-label[39m=[32m"27 - Geselekteerde"[39m
                       [33maria-pressed[39m=[32m"true"[39m
                       [33mtype[39m=[32m"button"[39m
                     [36m>[39m
@@ -888,7 +886,7 @@ exports[`date-textbox > renders with clear 1`] = `
     [36m>[39m
       [36m<input[39m
         [33mclass[39m=[32m"textbox__control"[39m
-        [33mid[39m=[32m"s0-0-2-textbox"[39m
+        [33mid[39m=[32m"s0-0-@mainTextbox-textbox"[39m
         [33mplaceholder[39m=[32m"MM/DD/YYYY"[39m
         [33mtype[39m=[32m"text"[39m
         [33mvalue[39m=[32m"01/27/2024"[39m
@@ -1249,7 +1247,6 @@ exports[`date-textbox > renders with clear 1`] = `
                     [33mclass[39m=[32m"calendar__cell--selected"[39m
                   [36m>[39m
                     [36m<button[39m
-                      [33maria-label[39m=[32m"27 - selected"[39m
                       [33maria-pressed[39m=[32m"true"[39m
                       [33mtype[39m=[32m"button"[39m
                     [36m>[39m
@@ -1318,7 +1315,7 @@ exports[`date-textbox > renders with custom today 1`] = `
     [36m>[39m
       [36m<input[39m
         [33mclass[39m=[32m"textbox__control"[39m
-        [33mid[39m=[32m"s0-2-textbox"[39m
+        [33mid[39m=[32m"s0-@mainTextbox-textbox"[39m
         [33mplaceholder[39m=[32m"MM/DD/YYYY"[39m
         [33mtype[39m=[32m"text"[39m
         [33mvalue[39m=[32m""[39m
@@ -1738,7 +1735,7 @@ exports[`date-textbox > renders with floating label 1`] = `
     [36m>[39m
       [36m<input[39m
         [33mclass[39m=[32m"textbox__control"[39m
-        [33mid[39m=[32m"s0-2-textbox"[39m
+        [33mid[39m=[32m"s0-@mainTextbox-textbox"[39m
         [33mplaceholder[39m=[32m"MM/DD/YYYY"[39m
         [33mtype[39m=[32m"text"[39m
         [33mvalue[39m=[32m"01/27/2024"[39m
@@ -2099,7 +2096,6 @@ exports[`date-textbox > renders with floating label 1`] = `
                     [33mclass[39m=[32m"calendar__cell--selected"[39m
                   [36m>[39m
                     [36m<button[39m
-                      [33maria-label[39m=[32m"27 - selected"[39m
                       [33maria-pressed[39m=[32m"true"[39m
                       [33mtype[39m=[32m"button"[39m
                     [36m>[39m
@@ -2161,7 +2157,7 @@ exports[`date-textbox > renders with floating label array with ranged 1`] = `
     [36m>[39m
       [36m<input[39m
         [33mclass[39m=[32m"textbox__control"[39m
-        [33mid[39m=[32m"s0-2-textbox"[39m
+        [33mid[39m=[32m"s0-@mainTextbox-textbox"[39m
         [33mplaceholder[39m=[32m"MM/DD/YYYY"[39m
         [33mtype[39m=[32m"text"[39m
         [33mvalue[39m=[32m"01/27/2024"[39m
@@ -2522,7 +2518,6 @@ exports[`date-textbox > renders with floating label array with ranged 1`] = `
                     [33mclass[39m=[32m"calendar__cell--selected"[39m
                   [36m>[39m
                     [36m<button[39m
-                      [33maria-label[39m=[32m"27 - selected"[39m
                       [33maria-pressed[39m=[32m"true"[39m
                       [33mtype[39m=[32m"button"[39m
                     [36m>[39m
@@ -2584,7 +2579,7 @@ exports[`date-textbox > renders with floating label array without ranged 1`] = `
     [36m>[39m
       [36m<input[39m
         [33mclass[39m=[32m"textbox__control"[39m
-        [33mid[39m=[32m"s0-2-textbox"[39m
+        [33mid[39m=[32m"s0-@mainTextbox-textbox"[39m
         [33mplaceholder[39m=[32m"MM/DD/YYYY"[39m
         [33mtype[39m=[32m"text"[39m
         [33mvalue[39m=[32m"01/27/2024"[39m
@@ -2945,7 +2940,6 @@ exports[`date-textbox > renders with floating label array without ranged 1`] = `
                     [33mclass[39m=[32m"calendar__cell--selected"[39m
                   [36m>[39m
                     [36m<button[39m
-                      [33maria-label[39m=[32m"27 - selected"[39m
                       [33maria-pressed[39m=[32m"true"[39m
                       [33mtype[39m=[32m"button"[39m
                     [36m>[39m
@@ -3007,7 +3001,7 @@ exports[`date-textbox > renders with placeholder 1`] = `
     [36m>[39m
       [36m<input[39m
         [33mclass[39m=[32m"textbox__control"[39m
-        [33mid[39m=[32m"s0-2-textbox"[39m
+        [33mid[39m=[32m"s0-@mainTextbox-textbox"[39m
         [33mplaceholder[39m=[32m"placeholder"[39m
         [33mtype[39m=[32m"text"[39m
         [33mvalue[39m=[32m"01/27/2024"[39m
@@ -3368,7 +3362,6 @@ exports[`date-textbox > renders with placeholder 1`] = `
                     [33mclass[39m=[32m"calendar__cell--selected"[39m
                   [36m>[39m
                     [36m<button[39m
-                      [33maria-label[39m=[32m"27 - selected"[39m
                       [33maria-pressed[39m=[32m"true"[39m
                       [33mtype[39m=[32m"button"[39m
                     [36m>[39m
@@ -3430,7 +3423,7 @@ exports[`date-textbox > renders with placeholder array with ranged 1`] = `
     [36m>[39m
       [36m<input[39m
         [33mclass[39m=[32m"textbox__control"[39m
-        [33mid[39m=[32m"s0-2-textbox"[39m
+        [33mid[39m=[32m"s0-@mainTextbox-textbox"[39m
         [33mplaceholder[39m=[32m"placeholder 2"[39m
         [33mtype[39m=[32m"text"[39m
         [33mvalue[39m=[32m"01/27/2024"[39m
@@ -3791,7 +3784,6 @@ exports[`date-textbox > renders with placeholder array with ranged 1`] = `
                     [33mclass[39m=[32m"calendar__cell--selected"[39m
                   [36m>[39m
                     [36m<button[39m
-                      [33maria-label[39m=[32m"27 - selected"[39m
                       [33maria-pressed[39m=[32m"true"[39m
                       [33mtype[39m=[32m"button"[39m
                     [36m>[39m
@@ -3853,7 +3845,7 @@ exports[`date-textbox > renders with placeholder array without ranged 1`] = `
     [36m>[39m
       [36m<input[39m
         [33mclass[39m=[32m"textbox__control"[39m
-        [33mid[39m=[32m"s0-2-textbox"[39m
+        [33mid[39m=[32m"s0-@mainTextbox-textbox"[39m
         [33mplaceholder[39m=[32m"placeholder 2"[39m
         [33mtype[39m=[32m"text"[39m
         [33mvalue[39m=[32m"01/27/2024"[39m
@@ -4214,7 +4206,6 @@ exports[`date-textbox > renders with placeholder array without ranged 1`] = `
                     [33mclass[39m=[32m"calendar__cell--selected"[39m
                   [36m>[39m
                     [36m<button[39m
-                      [33maria-label[39m=[32m"27 - selected"[39m
                       [33maria-pressed[39m=[32m"true"[39m
                       [33mtype[39m=[32m"button"[39m
                     [36m>[39m

--- a/packages/ebayui-core/src/components/ebay-date-textbox/test/test.browser.js
+++ b/packages/ebayui-core/src/components/ebay-date-textbox/test/test.browser.js
@@ -117,4 +117,70 @@ describe("ebay-date-textbox", () => {
             });
         });
     });
+
+    describe("with collapseOnSelect", () => {
+        beforeEach(async () => {
+            await page.viewport(1250, 500);
+        });
+
+        describe("when a single date is selected", () => {
+            beforeEach(async () => {
+                component = await render(Default, {
+                    value: "01/27/2024",
+                    collapseOnSelect: true,
+                });
+                await fireEvent.click(
+                    component.getByLabelText("open calendar"),
+                );
+                await fireEvent.click(component.getAllByText("16")[0]);
+            });
+
+            it("then focus returns to the calendar button", () => {
+                expect(document.activeElement).to.equal(
+                    component.getByLabelText("open calendar"),
+                );
+            });
+        });
+
+        describe("with range", () => {
+            describe("when the first date of a range is selected", () => {
+                beforeEach(async () => {
+                    component = await render(Default, {
+                        range: true,
+                        collapseOnSelect: true,
+                    });
+                    await fireEvent.click(
+                        component.getByLabelText("open calendar"),
+                    );
+                    await fireEvent.click(component.getAllByText("16")[0]);
+                });
+
+                it("then focus does not return to the calendar button", () => {
+                    expect(document.activeElement).not.to.equal(
+                        component.getByLabelText("open calendar"),
+                    );
+                });
+            });
+
+            describe("when the range is completed", () => {
+                beforeEach(async () => {
+                    component = await render(Default, {
+                        value: "01/27/2024",
+                        range: true,
+                        collapseOnSelect: true,
+                    });
+                    await fireEvent.click(
+                        component.getByLabelText("open calendar"),
+                    );
+                    await fireEvent.click(component.getAllByText("3")[1]);
+                });
+
+                it("then focus returns to the calendar button", () => {
+                    expect(document.activeElement).to.equal(
+                        component.getByLabelText("open calendar"),
+                    );
+                });
+            });
+        });
+    });
 });

--- a/packages/ebayui-core/src/components/ebay-textbox/index.marko
+++ b/packages/ebayui-core/src/components/ebay-textbox/index.marko
@@ -110,6 +110,7 @@ $ var disablePrefix = !!floatingLabel && !floatingLabelStatic;
         </if>
         <if(displayIcon && postfixIcon)>
             <${buttonAriaLabel && "button"}
+                key="iconBtn"
                 class="icon-btn icon-btn--transparent"
                 aria-label=buttonAriaLabel
                 type=buttonAriaLabel && "button"

--- a/packages/ebayui-core/src/components/ebay-textbox/test/__snapshots__/test.server.js.snap
+++ b/packages/ebayui-core/src/components/ebay-textbox/test/__snapshots__/test.server.js.snap
@@ -154,11 +154,11 @@ exports[`ebay-textbox > renders a textarea element with postfix icon 1`] = `
     [36m<svg[39m
       [33maria-hidden[39m=[32m"true"[39m
       [33mclass[39m=[32m"icon icon--24"[39m
-      [33mdata-marko-key[39m=[32m"@svg s0-0-9-1-0"[39m
+      [33mdata-marko-key[39m=[32m"@svg s0-0-8-1-0"[39m
       [33mfocusable[39m=[32m"false"[39m
     [36m>[39m
       [36m<defs[39m
-        [33mdata-marko-key[39m=[32m"@defs s0-0-9-1-0"[39m
+        [33mdata-marko-key[39m=[32m"@defs s0-0-8-1-0"[39m
       [36m>[39m
         [36m<symbol[39m
           [33mid[39m=[32m"icon-profile-24"[39m

--- a/packages/skin/src/sass/calendar/stories/calendar.stories.js
+++ b/packages/skin/src/sass/calendar/stories/calendar.stories.js
@@ -244,7 +244,8 @@ export const interactive = () => /* HTML */ `
                             >
                                 <button
                                     tabindex="-1"
-                                    aria-label="23 - selected - start of range"
+                                    aria-label="23 - start of range"
+                                    aria-pressed="true"
                                 >
                                     23
                                 </button>
@@ -280,7 +281,8 @@ export const interactive = () => /* HTML */ `
                             >
                                 <button
                                     tabindex="-1"
-                                    aria-label="27 - selected - end of range"
+                                    aria-label="27 - end of range"
+                                    aria-pressed="true"
                                 >
                                     27
                                 </button>


### PR DESCRIPTION
<!-- Insert GitHub issue number below. An issue is required for all PRs -->

- Fixes #729

## Description

After selecting a day in an interactive calendar, focus was dropped to document.body with no programmatic or visible placement on any element.

**ebay-date-textbox (Marko + React):** When collapseOnSelect is true and the popover closes after a selection (single date or completed range), focus is explicitly returned to the calendar icon button — the standard pattern of returning focus to the control that opened an overlay.

The **selected** text was being appended to aria-label even in interactive mode, where aria-pressed="true" already communicates selected state — causing screen readers to double-announce. Removed for interactive buttons.

## Checklist

<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->

- [x] I verify the linked issue has been triaged ("Needs Triage" label removed)
- [x] I verify all changes are within scope of the linked issue
- [ ] I added/updated/removed testing (Storybook in Skin) coverage as appropriate
