### PR TITLE
fix(charts): support modal tooltip rendering

### DIFF
--- a/.changeset/chart-tooltip-outside.md
+++ b/.changeset/chart-tooltip-outside.md
@@ -1,0 +1,6 @@
+---
+"@ebay/ebayui-core": minor
+"@ebay/ui-core-react": minor
+---
+
+Add `renderTooltipOutside` to bar, area, and donut charts so tooltips can render inside modal containers when needed.

--- a/packages/ebayui-core-react/src/ebay-area-chart/__tests__/index.spec.tsx
+++ b/packages/ebayui-core-react/src/ebay-area-chart/__tests__/index.spec.tsx
@@ -97,6 +97,18 @@ describe("ebay-area-chart rendering", () => {
         expect(callProps.highcharts).toBeDefined();
     });
 
+    it("defaults tooltip outside to true", () => {
+        render(<EbayAreaChart series={sampleSeries} />);
+        const callProps = MockChart.mock.calls[0][0];
+        expect(callProps.options.tooltip.outside).toBe(true);
+    });
+
+    it("sets tooltip outside=false when renderTooltipOutside is false", () => {
+        render(<EbayAreaChart series={sampleSeries} renderTooltipOutside={false} />);
+        const callProps = MockChart.mock.calls[0][0];
+        expect(callProps.options.tooltip.outside).toBe(false);
+    });
+
     it("disables legend for single series", () => {
         render(<EbayAreaChart series={sampleSeries} />);
         const callProps = MockChart.mock.calls[0][0];

--- a/packages/ebayui-core-react/src/ebay-area-chart/__tests__/index.stories.tsx
+++ b/packages/ebayui-core-react/src/ebay-area-chart/__tests__/index.stories.tsx
@@ -94,6 +94,11 @@ import { EbayAreaChart } from "@ebay/ui-core-react/ebay-area-chart";
                 'Custom function to format the date header in the tooltip. Defaults to `"Jan 1, 2022"` format.',
             table: { category: "Callbacks" },
         },
+        renderTooltipOutside: {
+            description:
+                "When `true` (default), renders the tooltip outside the chart SVG to prevent clipping. Set to `false` when rendering inside a modal or dialog.",
+            control: "boolean",
+        },
         highchartOptions: {
             description:
                 "Escape hatch for passing raw Highcharts options. Deep-merged into the default config — use sparingly.",

--- a/packages/ebayui-core-react/src/ebay-area-chart/area-chart.tsx
+++ b/packages/ebayui-core-react/src/ebay-area-chart/area-chart.tsx
@@ -80,6 +80,7 @@ const EbayAreaChart: FC<EbayAreaChartProps> = ({
     xLabelFormatter,
     yLabelFormatter = defaultYLabelFormatter,
     areaType = "areaspline",
+    renderTooltipOutside = true,
     highchartOptions,
     className,
     ...rest
@@ -153,7 +154,7 @@ const EbayAreaChart: FC<EbayAreaChartProps> = ({
             backgroundColor: tooltipBackgroundColor,
             borderWidth: 0,
             borderRadius: 10,
-            outside: true,
+            outside: renderTooltipOutside,
             shadow: false,
             shared: true,
             style: { filter: tooltipShadows, fontSize: "12px" },
@@ -201,6 +202,7 @@ const EbayAreaChart: FC<EbayAreaChartProps> = ({
         yLabelFormatter,
         tooltipValueFormatter,
         tooltipTitleFormatter,
+        renderTooltipOutside,
         highchartOptions,
     ]);
 

--- a/packages/ebayui-core-react/src/ebay-area-chart/types.ts
+++ b/packages/ebayui-core-react/src/ebay-area-chart/types.ts
@@ -8,6 +8,7 @@ type EbayAreaChartBaseProps = Omit<ComponentProps<"div">, "title"> & {
     tooltipTitleFormatter?: (value: number | string, dateFormat: typeof Highcharts.dateFormat) => string;
     xLabelFormatter?: (value: number | string, dateFormat: typeof Highcharts.dateFormat) => string;
     yLabelFormatter?: (value: number | string) => string;
+    renderTooltipOutside?: boolean;
     highchartOptions?: Highcharts.Options;
 };
 

--- a/packages/ebayui-core-react/src/ebay-bar-chart/__tests__/index.spec.tsx
+++ b/packages/ebayui-core-react/src/ebay-bar-chart/__tests__/index.spec.tsx
@@ -123,6 +123,18 @@ describe("ebay-bar-chart rendering", () => {
         expect(callProps.highcharts).toBeDefined();
     });
 
+    it("defaults tooltip outside to true", () => {
+        render(<EbayBarChart series={sampleSeries} />);
+        const callProps = MockChart.mock.calls[0][0];
+        expect(callProps.options.tooltip.outside).toBe(true);
+    });
+
+    it("sets tooltip outside=false when renderTooltipOutside is false", () => {
+        render(<EbayBarChart series={sampleSeries} renderTooltipOutside={false} />);
+        const callProps = MockChart.mock.calls[0][0];
+        expect(callProps.options.tooltip.outside).toBe(false);
+    });
+
     it("renders multi-series chart", () => {
         const { container } = render(<EbayBarChart series={multiSeries} />);
         const wrapper = container.querySelector(".ebay-bar-chart");

--- a/packages/ebayui-core-react/src/ebay-bar-chart/__tests__/index.stories.tsx
+++ b/packages/ebayui-core-react/src/ebay-bar-chart/__tests__/index.stories.tsx
@@ -1,4 +1,8 @@
+import React, { useState } from "react";
 import { Meta, StoryObj } from "@storybook/react-vite";
+import { EbayButton } from "../../ebay-button";
+import { EbayDialogHeader } from "../../ebay-dialog-base";
+import { EbayLightboxDialog } from "../../ebay-lightbox-dialog";
 import { EbayBarChart } from "../index";
 import type { EbayBarChartProps, BarChartSeriesItem } from "../types";
 
@@ -82,6 +86,11 @@ import { EbayBarChart } from "@ebay/ui-core-react/ebay-bar-chart";
         },
         stacked: {
             description: "When `true`, bars stack vertically; when `false`, bars render side-by-side. Default: `false`",
+            control: "boolean",
+        },
+        renderTooltipOutside: {
+            description:
+                "When `true` (default), renders the tooltip outside the chart SVG to prevent clipping. Set to `false` when rendering inside a modal or dialog.",
             control: "boolean",
         },
     },
@@ -249,6 +258,21 @@ function getSeriesData(seriesCount: number, days: number): BarChartSeriesItem[] 
     }));
 }
 
+function BarChartInsideLightbox(args: EbayBarChartProps) {
+    const [open, setOpen] = useState(false);
+    const close = () => setOpen(false);
+
+    return (
+        <div>
+            <EbayButton onClick={() => setOpen(true)}>Open Chart Dialog</EbayButton>
+            <EbayLightboxDialog open={open} onClose={close} a11yCloseText="Close chart dialog" size="wide">
+                <EbayDialogHeader>Bar chart in lightbox</EbayDialogHeader>
+                <EbayBarChart {...args} />
+            </EbayLightboxDialog>
+        </div>
+    );
+}
+
 // Single series stories
 export const SingleSeriesFiveDays: StoryObj<EbayBarChartProps> = {
     args: {
@@ -335,6 +359,24 @@ export const WithTitle: StoryObj<EbayBarChartProps> = {
         description: "Daily revenue breakdown across product categories",
         series: getSeriesData(3, 8),
     },
+};
+
+export const InsideLightboxDialog: StoryObj<EbayBarChartProps> = {
+    args: {
+        title: "Revenue Over Time",
+        description: "Daily revenue breakdown across product categories inside a lightbox dialog",
+        series: getSeriesData(3, 8),
+        yAxisLabels: ["$0", "$1k", "$2k", "$3k", "$4k", "$5k"],
+        renderTooltipOutside: false,
+    },
+    parameters: {
+        docs: {
+            description: {
+                story: "Modal usage story for GH-740: the bar chart is mounted in a closed lightbox dialog, then displayed when the dialog opens. Set `renderTooltipOutside` to `false` when rendering inside a modal or dialog.",
+            },
+        },
+    },
+    render: (args) => <BarChartInsideLightbox {...args} />,
 };
 
 // Custom x-axis format

--- a/packages/ebayui-core-react/src/ebay-bar-chart/bar-chart.tsx
+++ b/packages/ebayui-core-react/src/ebay-bar-chart/bar-chart.tsx
@@ -134,7 +134,11 @@ function getLegendConfig(seriesProp: BarChartSeriesItem | BarChartSeriesItem[]):
     };
 }
 
-function getTooltipConfig(hc: typeof highcharts, stacked: boolean): Highcharts.TooltipOptions {
+function getTooltipConfig(
+    hc: typeof highcharts,
+    stacked: boolean,
+    renderTooltipOutside: boolean,
+): Highcharts.TooltipOptions {
     const formatter: Highcharts.TooltipFormatterCallbackFunction = function (this: Highcharts.Point) {
         const chartSeries = this.series.chart.series;
         const date = hc.dateFormat("%b %e, %Y", this.x as number, false);
@@ -184,7 +188,7 @@ function getTooltipConfig(hc: typeof highcharts, stacked: boolean): Highcharts.T
         backgroundColor: tooltipBackgroundColor,
         borderWidth: 0,
         borderRadius: 10,
-        outside: true,
+        outside: renderTooltipOutside,
         shadow: false,
         style: { filter: tooltipShadows, fontSize: "12px" },
         positioner: stacked ? positioner : undefined,
@@ -274,6 +278,7 @@ function buildChartOptions(
         | "yAxisLabels"
         | "yAxisPositioner"
         | "stacked"
+        | "renderTooltipOutside"
     >,
     preparedSeries: BarChartSeriesItem[],
 ): Highcharts.Options {
@@ -285,6 +290,7 @@ function buildChartOptions(
         yAxisLabels,
         yAxisPositioner,
         stacked = false,
+        renderTooltipOutside = true,
     } = props;
 
     return {
@@ -297,7 +303,7 @@ function buildChartOptions(
         xAxis: getXAxisConfig(xAxisLabelFormat, xAxisPositioner),
         yAxis: getYAxisConfig(getMaxValue(preparedSeries, stacked), yAxisLabels, yAxisPositioner),
         legend: getLegendConfig(seriesProp),
-        tooltip: getTooltipConfig(hc, stacked),
+        tooltip: getTooltipConfig(hc, stacked, renderTooltipOutside),
         plotOptions: getColumnPlotOptions(stacked, description),
         credits: { enabled: false },
     };
@@ -312,6 +318,7 @@ const EbayBarChart: FC<EbayBarChartProps> = ({
     yAxisLabels,
     yAxisPositioner,
     stacked = false,
+    renderTooltipOutside = true,
     className,
     ...rest
 }) => {
@@ -329,10 +336,21 @@ const EbayBarChart: FC<EbayBarChartProps> = ({
                     yAxisLabels,
                     yAxisPositioner,
                     stacked,
+                    renderTooltipOutside,
                 },
                 preparedSeries,
             ),
-        [description, series, xAxisLabelFormat, xAxisPositioner, yAxisLabels, yAxisPositioner, stacked, preparedSeries],
+        [
+            description,
+            series,
+            xAxisLabelFormat,
+            xAxisPositioner,
+            yAxisLabels,
+            yAxisPositioner,
+            stacked,
+            renderTooltipOutside,
+            preparedSeries,
+        ],
     );
 
     return (

--- a/packages/ebayui-core-react/src/ebay-bar-chart/types.ts
+++ b/packages/ebayui-core-react/src/ebay-bar-chart/types.ts
@@ -37,4 +37,6 @@ export type EbayBarChartProps = Omit<ComponentProps<"div">, "title"> & {
     yAxisPositioner?: () => number[];
     /** When true, bars stack vertically; when false, bars render side-by-side. Default: false */
     stacked?: boolean;
+    /** When true, renders the tooltip outside the chart SVG to prevent clipping. Default: true */
+    renderTooltipOutside?: boolean;
 };

--- a/packages/ebayui-core-react/src/ebay-donut-chart/__tests__/index.spec.tsx
+++ b/packages/ebayui-core-react/src/ebay-donut-chart/__tests__/index.spec.tsx
@@ -109,6 +109,18 @@ describe("ebay-donut-chart rendering", () => {
         expect(callProps.options.chart.type).toBe("pie");
     });
 
+    it("defaults tooltip outside to true", () => {
+        render(<EbayDonutChart series={sampleSeries} />);
+        const callProps = MockChart.mock.calls[0][0];
+        expect(callProps.options.tooltip.outside).toBe(true);
+    });
+
+    it("sets tooltip outside=false when renderTooltipOutside is false", () => {
+        render(<EbayDonutChart series={sampleSeries} renderTooltipOutside={false} />);
+        const callProps = MockChart.mock.calls[0][0];
+        expect(callProps.options.tooltip.outside).toBe(false);
+    });
+
     it("logs a warning when multiple series provided", () => {
         const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
         render(<EbayDonutChart series={[...sampleSeries, ...sampleSeries]} />);

--- a/packages/ebayui-core-react/src/ebay-donut-chart/__tests__/index.stories.tsx
+++ b/packages/ebayui-core-react/src/ebay-donut-chart/__tests__/index.stories.tsx
@@ -71,6 +71,11 @@ import { EbayDonutChart } from "@ebay/ui-core-react/ebay-donut-chart";
             description: "Accessible description passed to the Highcharts plot options for screen readers.",
             control: "text",
         },
+        renderTooltipOutside: {
+            description:
+                "When `true` (default), renders the tooltip outside the chart SVG to prevent clipping. Set to `false` when rendering inside a modal or dialog.",
+            control: "boolean",
+        },
     },
     globals: {
         a11y: {

--- a/packages/ebayui-core-react/src/ebay-donut-chart/donut-chart.tsx
+++ b/packages/ebayui-core-react/src/ebay-donut-chart/donut-chart.tsx
@@ -35,6 +35,7 @@ const EbayDonutChart: FC<EbayDonutChartProps> = ({
     metricLabel,
     series,
     highchartsDescription,
+    renderTooltipOutside = true,
     className,
     ...rest
 }) => {
@@ -87,7 +88,7 @@ const EbayDonutChart: FC<EbayDonutChartProps> = ({
                 padding: 0,
                 borderWidth: 0,
                 borderRadius: 0,
-                outside: true,
+                outside: renderTooltipOutside,
                 shadow: false,
                 shared: true,
                 style: { filter: tooltipShadows, fontSize: "12px" },
@@ -102,7 +103,7 @@ const EbayDonutChart: FC<EbayDonutChartProps> = ({
             series: prepared ? [prepared] : [],
             credits: { enabled: false },
         }),
-        [prepared, colors, highchartsDescription],
+        [prepared, colors, highchartsDescription, renderTooltipOutside],
     );
 
     return (

--- a/packages/ebayui-core-react/src/ebay-donut-chart/types.ts
+++ b/packages/ebayui-core-react/src/ebay-donut-chart/types.ts
@@ -12,4 +12,6 @@ export type EbayDonutChartProps = Omit<ComponentProps<"div">, "title"> & {
     metricLabel?: ReactNode;
     series: DonutSeriesItem[];
     highchartsDescription?: string;
+    /** When true, renders the tooltip outside the chart SVG to prevent clipping. Default: true */
+    renderTooltipOutside?: boolean;
 };

--- a/packages/ebayui-core-react/src/ebay-line-chart/__tests__/index.stories.tsx
+++ b/packages/ebayui-core-react/src/ebay-line-chart/__tests__/index.stories.tsx
@@ -79,7 +79,8 @@ import { EbayLineChart } from "@ebay/ui-core-react/ebay-line-chart";
             control: "boolean",
         },
         renderTooltipOutside: {
-            description: "When `true` (default), renders the tooltip outside the chart SVG to prevent clipping.",
+            description:
+                "When `true` (default), renders the tooltip outside the chart SVG to prevent clipping. Set to `false` when rendering inside a modal or dialog.",
             control: "boolean",
         },
         xAxisLabelFormat: {

--- a/packages/ebayui-core/src/components/ebay-area-chart/area-chart.stories.ts
+++ b/packages/ebayui-core/src/components/ebay-area-chart/area-chart.stories.ts
@@ -79,6 +79,16 @@ export default {
             description:
                 "The type of area chart to display. By default is `spline`. Options are `spline` and `area`",
         },
+        renderTooltipOutside: {
+            type: { name: "boolean", required: false },
+            description:
+                "Defaults to `true`, if set to false the tooltip will render inside the chart container. Set to `false` when rendering in a modal.",
+            table: {
+                defaultValue: {
+                    summary: "true",
+                },
+            },
+        },
         class: {
             type: { name: "string", require: false },
             description:

--- a/packages/ebayui-core/src/components/ebay-area-chart/component.ts
+++ b/packages/ebayui-core/src/components/ebay-area-chart/component.ts
@@ -38,6 +38,7 @@ interface AreaChartInput extends Omit<Marko.HTML.Div, `on${string}`> {
     yLabelFormatter?: (value: string | number) => string;
     areaType?: "areaspline" | "area";
     highchartOptions?: Highcharts.Options;
+    renderTooltipOutside?: boolean;
     "cdn-highcharts"?: string;
     "cdn-highcharts-accessibility"?: string;
     "cdn-highcharts-pattern-fill"?: string;
@@ -336,7 +337,7 @@ class AreaChart extends Marko.Component<Input> {
             backgroundColor: tooltipBackgroundColor,
             borderWidth: 0,
             borderRadius: 10,
-            outside: true,
+            outside: this.input.renderTooltipOutside !== false,
             shadow: false,
             shared: true,
             style: {

--- a/packages/ebayui-core/src/components/ebay-area-chart/marko-tag.json
+++ b/packages/ebayui-core/src/components/ebay-area-chart/marko-tag.json
@@ -18,5 +18,6 @@
     "@xAxisLabelFormat": "string",
     "@xAxisPositioner": "function",
     "@yAxisLabels": "array",
-    "@yAxisPositioner": "function"
+    "@yAxisPositioner": "function",
+    "@renderTooltipOutside": "boolean"
 }

--- a/packages/ebayui-core/src/components/ebay-area-chart/test/test.server.js
+++ b/packages/ebayui-core/src/components/ebay-area-chart/test/test.server.js
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import AreaChart from "../component";
+
+function createAreaChart(input = {}) {
+    const chart = Object.create(AreaChart.prototype);
+    chart.input = input;
+    return chart;
+}
+
+describe("ebay-area-chart tooltip config", () => {
+    it("defaults tooltip outside to true", () => {
+        const chart = createAreaChart();
+
+        expect(chart.getTooltipConfig().outside).toBe(true);
+    });
+
+    it("sets tooltip outside=false when renderTooltipOutside is false", () => {
+        const chart = createAreaChart({ renderTooltipOutside: false });
+
+        expect(chart.getTooltipConfig().outside).toBe(false);
+    });
+});

--- a/packages/ebayui-core/src/components/ebay-bar-chart/bar-chart.stories-ignore.ts
+++ b/packages/ebayui-core/src/components/ebay-bar-chart/bar-chart.stories-ignore.ts
@@ -69,6 +69,16 @@ export default {
                 },
             },
         },
+        renderTooltipOutside: {
+            type: { name: "boolean", required: false },
+            description:
+                "Defaults to `true`, if set to false the tooltip will render inside the chart container. Set to `false` when rendering in a modal.",
+            table: {
+                defaultValue: {
+                    summary: "true",
+                },
+            },
+        },
         class: {
             type: { name: "string", require: false },
             description:

--- a/packages/ebayui-core/src/components/ebay-bar-chart/component.ts
+++ b/packages/ebayui-core/src/components/ebay-bar-chart/component.ts
@@ -43,6 +43,7 @@ interface BarChartInput extends Omit<Marko.HTML.Div, `on${string}` | "title"> {
     "cdn-highcharts-pattern-fill"?: string;
     version?: string;
     stacked?: boolean;
+    renderTooltipOutside?: boolean;
 }
 
 export interface Input extends WithNormalizedProps<BarChartInput> {}
@@ -305,7 +306,7 @@ class BarChart extends Marko.Component<Input> {
             backgroundColor: tooltipBackgroundColor, // sets tooltip background color
             borderWidth: 0, // hide the default border stroke
             borderRadius: 10, // set the border radius of the tooltip
-            outside: true, // used to render the tooltip outside of the main SVG element
+            outside: this.input.renderTooltipOutside !== false, // used to render the tooltip outside of the main SVG element
             shadow: false, // hide the default shadow as it conflicts with designs
             style: {
                 filter: tooltipShadows, // sets tooltip shadows

--- a/packages/ebayui-core/src/components/ebay-bar-chart/marko-tag.json
+++ b/packages/ebayui-core/src/components/ebay-bar-chart/marko-tag.json
@@ -19,5 +19,6 @@
     "@xAxisPositioner": "function",
     "@yAxisLabels": "array",
     "@yAxisPositioner": "function",
-    "@stacked": "boolean"
+    "@stacked": "boolean",
+    "@renderTooltipOutside": "boolean"
 }

--- a/packages/ebayui-core/src/components/ebay-bar-chart/test/test.server.js
+++ b/packages/ebayui-core/src/components/ebay-bar-chart/test/test.server.js
@@ -35,3 +35,17 @@ describe("ebay-bar-chart y-axis config", () => {
         expect(chart.getYAxisConfig(threeSeriesWithSharedX).max).toBe(50);
     });
 });
+
+describe("ebay-bar-chart tooltip config", () => {
+    it("defaults tooltip outside to true", () => {
+        const chart = createBarChart();
+
+        expect(chart.getTooltipConfig().outside).toBe(true);
+    });
+
+    it("sets tooltip outside=false when renderTooltipOutside is false", () => {
+        const chart = createBarChart({ renderTooltipOutside: false });
+
+        expect(chart.getTooltipConfig().outside).toBe(false);
+    });
+});

--- a/packages/ebayui-core/src/components/ebay-donut-chart/component.ts
+++ b/packages/ebayui-core/src/components/ebay-donut-chart/component.ts
@@ -29,6 +29,7 @@ interface DonutChartInput extends Omit<
     version?: string;
     series: SeriesDonutOptions[];
     highchartsDescription?: string;
+    renderTooltipOutside?: boolean;
 }
 
 export interface Input extends WithNormalizedProps<DonutChartInput> {}
@@ -175,7 +176,7 @@ class DonutChart extends Marko.Component<Input> {
             padding: 0,
             borderWidth: 0,
             borderRadius: 0,
-            outside: true,
+            outside: this.input.renderTooltipOutside !== false,
             shadow: false,
             shared: true,
             style: {

--- a/packages/ebayui-core/src/components/ebay-donut-chart/donut-chart.stories.ts
+++ b/packages/ebayui-core/src/components/ebay-donut-chart/donut-chart.stories.ts
@@ -70,6 +70,16 @@ export default {
             type: { name: "string", require: false },
             description: "Highcharts description, not visible on the chart",
         },
+        renderTooltipOutside: {
+            type: { name: "boolean", required: false },
+            description:
+                "Defaults to `true`, if set to false the tooltip will render inside the chart container. Set to `false` when rendering in a modal.",
+            table: {
+                defaultValue: {
+                    summary: "true",
+                },
+            },
+        },
     },
 };
 

--- a/packages/ebayui-core/src/components/ebay-donut-chart/marko-tag.json
+++ b/packages/ebayui-core/src/components/ebay-donut-chart/marko-tag.json
@@ -28,5 +28,6 @@
     },
     "@class": "string",
     "@series": "string",
-    "@description": "string"
+    "@description": "string",
+    "@renderTooltipOutside": "boolean"
 }

--- a/packages/ebayui-core/src/components/ebay-donut-chart/test/test.server.js
+++ b/packages/ebayui-core/src/components/ebay-donut-chart/test/test.server.js
@@ -1,11 +1,18 @@
-import { describe, it } from "vitest";
+import { describe, it, expect } from "vitest";
 
 import { composeStories } from "@storybook/marko";
 import { snapshotHTML } from "../../../common/test-utils/snapshots";
 import * as stories from "../donut-chart.stories";
+import DonutChart from "../component";
 
 const { Standard, TwoValues, FiveValues, NoMetrics } = composeStories(stories);
 const htmlSnap = snapshotHTML(__dirname);
+
+function createDonutChart(input = {}) {
+    const chart = Object.create(DonutChart.prototype);
+    chart.input = input;
+    return chart;
+}
 
 describe("section-title", () => {
     it("renders defaults", async () => {
@@ -22,5 +29,19 @@ describe("section-title", () => {
 
     it("renders with no metrics", async () => {
         await htmlSnap(NoMetrics);
+    });
+});
+
+describe("ebay-donut-chart tooltip config", () => {
+    it("defaults tooltip outside to true", () => {
+        const chart = createDonutChart();
+
+        expect(chart.getTooltipConfig().outside).toBe(true);
+    });
+
+    it("sets tooltip outside=false when renderTooltipOutside is false", () => {
+        const chart = createDonutChart({ renderTooltipOutside: false });
+
+        expect(chart.getTooltipConfig().outside).toBe(false);
     });
 });

--- a/packages/ebayui-core/src/components/ebay-line-chart/test/test.server.js
+++ b/packages/ebayui-core/src/components/ebay-line-chart/test/test.server.js
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import LineChart from "../component";
+
+function createLineChart(input = {}) {
+    const chart = Object.create(LineChart.prototype);
+    chart.input = input;
+    return chart;
+}
+
+describe("ebay-line-chart tooltip config", () => {
+    it("defaults tooltip outside to true", () => {
+        const chart = createLineChart({ series: [] });
+
+        expect(chart.getTooltipConfig().outside).toBe(true);
+    });
+
+    it("sets tooltip outside=false when renderTooltipOutside is false", () => {
+        const chart = createLineChart({
+            renderTooltipOutside: false,
+            series: [],
+        });
+
+        expect(chart.getTooltipConfig().outside).toBe(false);
+    });
+});


### PR DESCRIPTION
<!-- Insert GitHub issue number below. An issue is required for all PRs -->

- Fixes #740

## Description

Adds a `renderTooltipOutside` escape hatch for chart tooltips in both Marko and React so charts can render tooltips inside modal/dialog containers when needed.

- Adds `renderTooltipOutside` to bar, area, and donut charts while preserving the default `true` behavior.
- Keeps existing line chart behavior and updates React Storybook guidance for all chart stories.
- Adds an `EbayBarChart` inside `EbayLightboxDialog` React Storybook story with `renderTooltipOutside: false` for the modal use case.
- Adds tests covering default tooltip outside behavior and `renderTooltipOutside={false}` / `renderTooltipOutside: false`.
- Adds a changeset for `@ebay/ebayui-core` and `@ebay/ui-core-react`.

## Notes

- Use `renderTooltipOutside={false}` when rendering charts inside a modal or dialog to avoid Highcharts tooltip positioning outside the modal context.
- Validation run: focused chart tests, React typecheck, Marko typecheck, and `npm run build`.

## Screenshots

N/A — Storybook coverage was added for the modal usage scenario; no static screenshots captured.

## Checklist

<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->

- [ ] I verify the linked issue has been triaged ("Needs Triage" label removed)
- [ ] I verify all changes are within scope of the linked issue
- [ ] I added/updated/removed testing (Storybook in Skin) coverage as appropriate

<!-- For CSS changes -->

- [ ] I tested the UI in all supported browsers
- [ ] I tested the UI in dark mode and RTL mode
