### PR TITLE
fix(video): use time formatting for aria in scrubber

### DIFF
--- a/.changeset/cool-mugs-act.md
+++ b/.changeset/cool-mugs-act.md
@@ -1,0 +1,7 @@
+---
+"@ebay/ui-core-react": patch
+"@ebay/ebayui-core": patch
+"@ebay/skin": patch
+---
+
+Fix a11y issues with shaka player

--- a/packages/ebayui-core-react/src/ebay-video/controls/current-time-control.tsx
+++ b/packages/ebayui-core-react/src/ebay-video/controls/current-time-control.tsx
@@ -52,6 +52,7 @@ export const CurrentTimeControl: FC<CurrentTimeControlProps> = ({ a11ySkipToLive
         <button
             className="shaka-current-time"
             disabled={!isLive}
+            aria-hidden={!isLive || undefined}
             onClick={handleClick}
             aria-label={isLive ? a11ySkipToLiveText || "Skip to live" : undefined}
         >

--- a/packages/ebayui-core-react/src/ebay-video/controls/remaining-time-control.tsx
+++ b/packages/ebayui-core-react/src/ebay-video/controls/remaining-time-control.tsx
@@ -25,10 +25,5 @@ export const RemainingTimeControl: FC = () => {
 
     if (!container) return null;
 
-    return createPortal(
-        <button className="shaka-remaining-time" disabled>
-            {timeText}
-        </button>,
-        container,
-    );
+    return createPortal(<span className="shaka-remaining-time">{timeText}</span>, container);
 };

--- a/packages/ebayui-core-react/src/ebay-video/controls/total-time-control.tsx
+++ b/packages/ebayui-core-react/src/ebay-video/controls/total-time-control.tsx
@@ -3,13 +3,8 @@ import { createPortal } from "react-dom";
 import { useShakaControl } from "./use-shaka-control";
 import { buildTimeString } from "./time-utils";
 
-type TotalTimeControlProps = {
-    a11ySkipToLiveText?: string;
-};
-
-export const TotalTimeControl: FC<TotalTimeControlProps> = ({ a11ySkipToLiveText }) => {
+export const TotalTimeControl: FC = () => {
     const [timeText, setTimeText] = useState("");
-    const [isLive, setIsLive] = useState(false);
 
     const { container } = useShakaControl("total_time", {
         onTimeAndSeekRangeUpdated: ({ seekRange }) => {
@@ -20,21 +15,9 @@ export const TotalTimeControl: FC<TotalTimeControlProps> = ({ a11ySkipToLiveText
                 setTimeText(buildTimeString(seekRangeSize, showHour));
             }
         },
-        onTracksChanged: ({ isLive }) => {
-            setIsLive(isLive);
-        },
     });
 
     if (!container) return null;
 
-    return createPortal(
-        <button
-            className="shaka-current-time"
-            disabled
-            aria-label={isLive ? a11ySkipToLiveText || "Skip to live" : undefined}
-        >
-            {timeText}
-        </button>,
-        container,
-    );
+    return createPortal(<span className="shaka-current-time">{timeText}</span>, container);
 };

--- a/packages/ebayui-core-react/src/ebay-video/video.tsx
+++ b/packages/ebayui-core-react/src/ebay-video/video.tsx
@@ -29,6 +29,7 @@ import { CaptionsControl } from "./controls/captions-control";
 import { EbayEventHandler } from "../common/event-utils/types";
 import { EbayIconPlayFilled64Colored } from "../ebay-icon/icons/ebay-icon-play-filled-64-colored";
 import { EbayIconAttention64 } from "../ebay-icon/icons/ebay-icon-attention-64";
+import { buildTimeString } from "./controls/time-utils";
 
 export type PlayEventProps = {
     player: Player;
@@ -210,6 +211,30 @@ const EbayVideo: FC<EbayVideoProps> = ({
         if (document?.documentElement?.lang) {
             uiRef.current.getControls().getLocalization().changeLocale([document.documentElement.lang]);
         }
+
+        // Keep aria-valuetext on the seek bar <input type="range"> in sync with
+        // the current playback position so screen readers announce time in
+        // x:xx format rather than the raw decimal number that Shaka sets as
+        // the numeric value.
+        uiRef.current.getControls().addEventListener("timeandseekrangeupdated", () => {
+            const controls = uiRef.current?.getControls();
+            const player = uiRef.current?.getControls().getPlayer();
+            if (!controls || !player) return;
+
+            const seekRange = player.seekRange() as { start: number; end: number };
+            const seekRangeSize = seekRange.end - seekRange.start;
+            if (!isFinite(seekRangeSize) || player.isLive()) return;
+
+            const displayTime = controls.getDisplayTime();
+            const currentTime = Math.max(0, displayTime - seekRange.start);
+            const showHour = seekRangeSize >= 3600;
+            const valueText = buildTimeString(currentTime, showHour);
+
+            const seekBar = container.querySelector<HTMLInputElement>(".shaka-seek-bar");
+            if (seekBar) {
+                seekBar.setAttribute("aria-valuetext", valueText);
+            }
+        });
 
         // See ebayui-core/ebay-video/component.ts for full explanation.
         // Shaka's compiled dist uses closed-over module functions internally,

--- a/packages/ebayui-core-react/src/ebay-video/video.tsx
+++ b/packages/ebayui-core-react/src/ebay-video/video.tsx
@@ -435,7 +435,7 @@ const EbayVideo: FC<EbayVideoProps> = ({
             )}
             <CurrentTimeControl a11ySkipToLiveText={a11ySkipToLiveText} />
             <RemainingTimeControl />
-            <TotalTimeControl a11ySkipToLiveText={a11ySkipToLiveText} />
+            <TotalTimeControl />
             <MuteButtonControl a11yMuteText={a11yMuteText} a11yUnmuteText={a11yUnmuteText} />
             <FullscreenButtonControl
                 a11yFullscreenText={a11yFullscreenText}

--- a/packages/ebayui-core/src/components/ebay-video/elements.ts
+++ b/packages/ebayui-core/src/components/ebay-video/elements.ts
@@ -81,6 +81,7 @@ function getElements(self: EbayVideo) {
             this.currentTime_ = document.createElement("button");
             this.currentTime_.classList.add("shaka-current-time");
             this.currentTime_.disabled = true;
+            this.currentTime_.setAttribute("aria-hidden", "true");
             this.setValue_("0:00");
             this.parent.appendChild(this.currentTime_);
             this.eventManager.listen(this.currentTime_, "click", () => {
@@ -157,9 +158,11 @@ function getElements(self: EbayVideo) {
         }
         onTracksChanged_() {
             if (this.player.isLive()) {
-                const ariaLabel = self.shaka.ui.Locales.Ids.SKIP_TO_LIVE;
-                this.currentTime_.ariaLabel =
-                    this.localization.resolve(ariaLabel);
+                this.currentTime_.disabled = false;
+                this.currentTime_.removeAttribute("aria-hidden");
+                this.currentTime_.ariaLabel = this.localization.resolve(
+                    self.shaka.ui.Locales.Ids.SKIP_TO_LIVE,
+                );
             }
         }
     };
@@ -172,10 +175,9 @@ function getElements(self: EbayVideo) {
     const TotalTime = class extends self.shaka.ui.Element {
         constructor(parent: HTMLElement, controls: any) {
             super(parent, controls);
-            /** Button element for displaying total time */
-            this.currentTime_ = document.createElement("button");
+            /** Element for displaying total time */
+            this.currentTime_ = document.createElement("span");
             this.currentTime_.classList.add("shaka-current-time");
-            this.currentTime_.disabled = true;
             this.parent.appendChild(this.currentTime_);
             this.eventManager.listen(
                 this.controls,
@@ -184,9 +186,6 @@ function getElements(self: EbayVideo) {
                     this.updateTime_();
                 },
             );
-            this.eventManager.listen(this.player, "trackschanged", () => {
-                this.onTracksChanged_();
-            });
         }
 
         setValue_(value: string) {
@@ -204,14 +203,6 @@ function getElements(self: EbayVideo) {
             if (isFinite(seekRangeSize) && seekRangeSize) {
                 const showHour = seekRangeSize >= 3600;
                 this.setValue_(buildTimeString(seekRangeSize, showHour));
-            }
-        }
-
-        onTracksChanged_() {
-            if (this.player.isLive()) {
-                const ariaLabel = self.shaka.ui.Locales.Ids.SKIP_TO_LIVE;
-                this.currentTime_.ariaLabel =
-                    this.localization.resolve(ariaLabel);
             }
         }
     };
@@ -327,10 +318,9 @@ function getElements(self: EbayVideo) {
     const RemainingTime = class extends self.shaka.ui.Element {
         constructor(parent: HTMLElement, controls: any) {
             super(parent, controls);
-            /** Button element for displaying remaining time */
-            this.remainingTime_ = document.createElement("button");
+            /** Element for displaying remaining time */
+            this.remainingTime_ = document.createElement("span");
             this.remainingTime_.classList.add("shaka-remaining-time");
-            this.remainingTime_.disabled = true;
             this.setValue_("0:00");
             this.parent.appendChild(this.remainingTime_);
             this.eventManager.listen(

--- a/packages/ebayui-core/src/components/ebay-video/elements.ts
+++ b/packages/ebayui-core/src/components/ebay-video/elements.ts
@@ -145,6 +145,14 @@ function getElements(self: EbayVideo) {
                 const currentTime = Math.max(0, displayTime - seekRange.start);
                 let value = buildTimeString(currentTime, showHour);
                 this.setValue_(value);
+                // Keep aria-valuetext on the seek bar in sync so screen readers
+                // announce time in x:xx format rather than the raw decimal number.
+                const seekBar = self.el?.querySelector<HTMLInputElement>(
+                    ".shaka-seek-bar",
+                );
+                if (seekBar) {
+                    seekBar.setAttribute("aria-valuetext", value);
+                }
             }
         }
         onTracksChanged_() {

--- a/packages/skin/dist/video/video.css
+++ b/packages/skin/dist/video/video.css
@@ -78,9 +78,12 @@
     border-radius: 50%;
     margin: 0 5px;
 }
-.video-player--compact
-    .shaka-controls-button-panel
-    button.shaka-remaining-time {
+.video-player .shaka-controls-button-panel span.shaka-current-time,
+.video-player .shaka-controls-button-panel span.shaka-remaining-time {
+    align-items: center;
+    display: inline-flex;
+}
+.video-player--compact .shaka-controls-button-panel .shaka-remaining-time {
     border-radius: 16px;
     font-size: var(--font-size-medium);
     min-width: 80px;

--- a/packages/skin/src/sass/video/video.scss
+++ b/packages/skin/src/sass/video/video.scss
@@ -100,9 +100,13 @@
     margin: 0 5px;
 }
 
-.video-player--compact
-    .shaka-controls-button-panel
-    button.shaka-remaining-time {
+.video-player .shaka-controls-button-panel span.shaka-current-time,
+.video-player .shaka-controls-button-panel span.shaka-remaining-time {
+    align-items: center;
+    display: inline-flex;
+}
+
+.video-player--compact .shaka-controls-button-panel .shaka-remaining-time {
     border-radius: 16px;
     font-size: var(--font-size-medium);
     min-width: 80px;


### PR DESCRIPTION
Since `shaka-player` uses `<input type="range">` for the video time scrubber, time was being displayed to SR as `[seconds].[fraction]`. This doesn't make much sense for a video player, as `hh:mm:ss` is preferred. Here, we patch the player to add `aria-valuetext` which uses proper displayTime.

In addition, start/end time had improper a11y semantics. Current time is now hidden for a11y since it is always visible through the scrubber, and end time is presented as a `<span>` instead of a disabled button when it is non-interactive.