### PR TITLE
feat(character-count): add Evo React component

### DIFF
--- a/.changeset/bright-counters-smile.md
+++ b/.changeset/bright-counters-smile.md
@@ -1,0 +1,6 @@
+---
+"@evo-web/marko": patch
+"@evo-web/react": patch
+---
+
+Add EvoCharacterCount and align its Marko API.

--- a/.claude/skills/evo-app-migrate-react/SKILL.md
+++ b/.claude/skills/evo-app-migrate-react/SKILL.md
@@ -60,18 +60,19 @@ If a component is not listed below, it has **not been migrated yet** — keep us
 
 When migrating a listed component, read the linked file completely and apply the component-specific changes in addition to the global renames from Step 2.
 
-| ebayui-core-react component | Migration details                                         |
-| --------------------------- | --------------------------------------------------------- |
-| `ebay-accordion`            | [evo-accordion.md](components/evo-accordion.md)           |
-| `ebay-alert-dialog`         | [evo-alert-dialog.md](components/evo-alert-dialog.md)     |
-| `ebay-badge`                | [evo-badge.md](components/evo-badge.md)                   |
-| `ebay-breadcrumbs`          | [evo-breadcrumbs.md](components/evo-breadcrumbs.md)       |
-| `ebay-button`               | [evo-button.md](components/evo-button.md)                 |
-| `ebay-calendar`             | [evo-calendar.md](components/evo-calendar.md)             |
-| `ebay-ccd`                  | [evo-ccd.md](components/evo-ccd.md)                       |
-| `ebay-details`              | [evo-details.md](components/evo-details.md)               |
-| `ebay-confirm-dialog`       | [evo-confirm-dialog.md](components/evo-confirm-dialog.md) |
-| `ebay-icon-button`          | [evo-icon-button.md](components/evo-icon-button.md)       |
+| ebayui-core-react component | Migration details                                           |
+| --------------------------- | ----------------------------------------------------------- |
+| `ebay-accordion`            | [evo-accordion.md](components/evo-accordion.md)             |
+| `ebay-alert-dialog`         | [evo-alert-dialog.md](components/evo-alert-dialog.md)       |
+| `ebay-badge`                | [evo-badge.md](components/evo-badge.md)                     |
+| `ebay-breadcrumbs`          | [evo-breadcrumbs.md](components/evo-breadcrumbs.md)         |
+| `ebay-button`               | [evo-button.md](components/evo-button.md)                   |
+| `ebay-calendar`             | [evo-calendar.md](components/evo-calendar.md)               |
+| `ebay-ccd`                  | [evo-ccd.md](components/evo-ccd.md)                         |
+| `ebay-character-count`      | [evo-character-count.md](components/evo-character-count.md) |
+| `ebay-details`              | [evo-details.md](components/evo-details.md)                 |
+| `ebay-confirm-dialog`       | [evo-confirm-dialog.md](components/evo-confirm-dialog.md)   |
+| `ebay-icon-button`          | [evo-icon-button.md](components/evo-icon-button.md)         |
 
 ---
 

--- a/.claude/skills/evo-app-migrate-react/components/evo-character-count.md
+++ b/.claude/skills/evo-app-migrate-react/components/evo-character-count.md
@@ -1,0 +1,7 @@
+# EvoCharacterCount
+
+- Rename string `value` to `text`.
+- Replace numeric `value` with `count`.
+- Rename `clippedText` to `a11yText`; it defaults to `"characters used"` and accepts `null` only when alternative accessibility information is present.
+- Replace `onChange` and its 500ms debounce with `inputRef`; the associated input or textarea receives `aria-live="polite"` when `count > max` and `"off"` otherwise.
+- Automatic counts use grapheme clusters. Use the exported `countCharacters()` utility with custom children when the numeric count is needed for custom text.

--- a/packages/evo-marko/src/tags/evo-character-count/README.md
+++ b/packages/evo-marko/src/tags/evo-character-count/README.md
@@ -7,10 +7,10 @@
     </span>
 </h1>
 
-Button styled with core classes.
+Displays the number of grapheme characters in text relative to a maximum.
 
 ## Examples and Documentation
 
-- [Storybook](https://ebay.github.io/evo-web/ebayui-core/?path=/story/building-blocks-evo-character-count)
-- [Storybook Docs](https://ebay.github.io/evo-web/ebayui-core/?path=/docs/building-blocks-evo-character-count)
-- [Code Examples](https://github.com/eBay/evo-web/tree/main/packages/ebayui-core/src/components/evo-character-count/examples)
+- [Storybook](https://opensource.ebay.com/evo-web/marko/?path=/story/building-blocks-evo-character-count)
+- [Storybook Docs](https://opensource.ebay.com/evo-web/marko/?path=/docs/building-blocks-evo-character-count)
+- [Code Examples](https://github.com/eBay/evo-web/tree/main/packages/evo-marko/src/tags/evo-character-count/examples)

--- a/packages/evo-marko/src/tags/evo-character-count/character-count.stories.ts
+++ b/packages/evo-marko/src/tags/evo-character-count/character-count.stories.ts
@@ -1,7 +1,7 @@
 import { buildExtensionTemplate } from "../../common/storybook/utils";
 import { type Meta } from "@storybook/marko";
 import Readme from "./README.md";
-import CharCount, { type Input } from "./index.marko";
+import CharacterCount, { type Input } from "./index.marko";
 import IsolatedTemplate from "./examples/isolated.marko";
 import IsolatedCode from "./examples/isolated.marko?raw";
 import InFieldTemplate from "./examples/in-field.marko";
@@ -11,7 +11,7 @@ import CustomTextCode from "./examples/custom-text.marko?raw";
 
 export default {
   title: "building blocks/evo-character-count",
-  component: CharCount,
+  component: CharacterCount,
   parameters: {
     docs: {
       description: {
@@ -21,34 +21,39 @@ export default {
   },
 
   argTypes: {
-    string: {
-      type: { name: "string", required: true },
+    text: {
+      type: "string",
       control: "text",
       description:
-        "String to count characters from, or a number representing the current character count",
+        "Text whose grapheme characters are counted. Required unless count is provided.",
     },
     count: {
       type: "number",
       control: "number",
-      description: "Manual count value, used to override string grapheme count",
+      description: "Manual count used instead of calculating from text.",
     },
     max: {
       type: { name: "number", required: true },
       control: "number",
       description:
-        "Maximum number of characters allowed in the input, we allow users to go over this limit but `aria-live` should be set to `polite`.",
+        'Maximum number of characters allowed. The associated input receives `aria-live="polite"` when this value is exceeded.',
     },
     a11yText: {
-      type: "string",
+      type: { name: "string", required: true },
       control: "text",
       description:
-        'Clipped text for screen readers, announced after the character count. Often something like "characters remaining". May be set to `null` only if accessibility is provided through other means.',
+        'Clipped text announced after the count. Often something like "characters used". Pass `null` explicitly only if alternative accessibility information is present.',
+    },
+    inputRef: {
+      control: false,
+      description:
+        "Native input or textarea getter whose aria-live attribute is managed by the character count.",
     },
   },
 } satisfies Meta<Input>;
 
 export const Default = buildExtensionTemplate(IsolatedTemplate, IsolatedCode, {
-  string: "Hello world",
+  text: "Hello world",
   a11yText: "characters remaining",
   max: 120,
 });

--- a/packages/evo-marko/src/tags/evo-character-count/examples/custom-text.marko
+++ b/packages/evo-marko/src/tags/evo-character-count/examples/custom-text.marko
@@ -1,31 +1,36 @@
 export interface Input {
-    value?: string;
-    max?: number;
+  value?: string;
+  max?: number;
 }
 <const/{ max = 120 }=input>
 <let/value=input.value || "">
 
-<evo-character-count/{ count, ariaLive } string=value max=max/>
-
 <span class="field">
-    <label class="field__label field__label--stacked" for="my-input">
-        Field Label
-    </label>
-    <span class="field__control">
-        <evo-input
-            value:=value
-            type="text"
-            aria-describedby="my-input-charcount"
-            class="textbox__control"
-            id="my-input"
-            aria-live=ariaLive
-        />
+  <label class="field__label field__label--stacked" for="my-input">
+    Field Label
+  </label>
+  <span class="field__control">
+    <span class="textbox">
+      <input/inputRef
+        value:=value
+        type="text"
+        aria-describedby="my-input-charcount"
+        class="textbox__control"
+        id="my-input">
     </span>
-    <div class=[
-        "field__description",
-        "field__description--group",
-        count > max && "field__description--attention",
+  </span>
+  <evo-character-count|count|
+    text=value
+    max=max
+    a11yText=null
+    inputRef=inputRef
+    id="my-input-charcount">
+    <span class=[
+      "field__description",
+      "field__description--group",
+      count > max && "field__description--attention",
     ]>
-        <span>${count} of ${max} (${max - count} remaining)</span>
-    </div>
+      ${count} of ${max} (${max - count} remaining)
+    </span>
+  </evo-character-count>
 </span>

--- a/packages/evo-marko/src/tags/evo-character-count/examples/in-field.marko
+++ b/packages/evo-marko/src/tags/evo-character-count/examples/in-field.marko
@@ -1,30 +1,34 @@
 export interface Input {
-    value?: string;
-    max?: number;
-    a11yText?: string | null;
+  value?: string;
+  max?: number;
+  a11yText?: string | null;
 }
-<const/{ max = 120 }=input>
+<const/{ max = 120, a11yText }=input>
 <let/value=input.value || "">
 
-<evo-character-count/{ ariaLive, Display: CharCount } string=value max=max/>
-
 <span class="field">
-    <label class="field__label field__label--stacked" for="my-input">
-        Field Label
-    </label>
-    <span class="field__control">
-        <evo-input
-            value:=value
-            type="text"
-            aria-describedby="my-input-description my-input-charcount"
-            class="textbox__control"
-            id="my-input"
-            aria-live=ariaLive/>
+  <label class="field__label field__label--stacked" for="my-input">
+    Field Label
+  </label>
+  <span class="field__control">
+    <span class="textbox">
+      <input/inputRef
+        value:=value
+        type="text"
+        aria-describedby="my-input-description my-input-charcount"
+        class="textbox__control"
+        id="my-input">
     </span>
-    <div class="field__description field__description--group">
-        <span id="my-input-description">
-            Brief description
-        </span>
-        <CharCount/>
-    </div>
+  </span>
+  <div class="field__description field__description--group">
+    <span id="my-input-description">
+      Brief description
+    </span>
+    <evo-character-count
+      text=value
+      max=max
+      a11yText=a11yText
+      inputRef=inputRef
+      id="my-input-charcount"/>
+  </div>
 </span>

--- a/packages/evo-marko/src/tags/evo-character-count/examples/isolated.marko
+++ b/packages/evo-marko/src/tags/evo-character-count/examples/isolated.marko
@@ -1,5 +1,4 @@
-import type { Input as CharCountInput } from "<evo-character-count>";
-export interface Input extends CharCountInput {}
+import type { Input as CharacterCountInput } from "<evo-character-count>";
+export interface Input extends CharacterCountInput {}
 
-<evo-character-count/{ Display } ...input/>
-<Display/>
+<evo-character-count ...input/>

--- a/packages/evo-marko/src/tags/evo-character-count/index.marko
+++ b/packages/evo-marko/src/tags/evo-character-count/index.marko
@@ -42,20 +42,20 @@ static function countGraphemes(value: string): number {
   const inputElement = inputRef?.();
   if (inputElement) {
     const previousAriaLive = inputElement.getAttribute("aria-live");
+    $signal.onabort = () => {
+      if (previousAriaLive === null) {
+        inputElement.removeAttribute("aria-live");
+      } else {
+        inputElement.setAttribute("aria-live", previousAriaLive);
+      }
+    };
+  }
+</script>
+
+<script>
+  const inputElement = inputRef?.();
+  if (inputElement) {
     inputElement.setAttribute("aria-live", ariaLive);
-    $signal.addEventListener(
-      "abort",
-      () => {
-        if (previousAriaLive === null) {
-          inputElement.removeAttribute("aria-live");
-        } else {
-          inputElement.setAttribute("aria-live", previousAriaLive);
-        }
-      },
-      {
-        once: true,
-      },
-    );
   }
 </script>
 

--- a/packages/evo-marko/src/tags/evo-character-count/index.marko
+++ b/packages/evo-marko/src/tags/evo-character-count/index.marko
@@ -1,44 +1,75 @@
 export interface Input extends Omit<Marko.HTML.Span, "content"> {
-    string: string;
-    count?: number;
-    max: number;
-    /**
-     * Clipped text for screen readers. Often something like `"characters used"`
-     *
-     * Pass `null` explicitly _only_ if alternative accessibility information is present
-     */
-    a11yText?: string | null;
+  text?: string;
+  count?: number;
+  max: number;
+  /**
+   * Clipped text for screen readers. Often something like `"characters used"`.
+   *
+   * Pass `null` explicitly _only_ if alternative accessibility information is present
+   */
+  a11yText?: string | null;
+  inputRef?: () => HTMLInputElement | HTMLTextAreaElement;
+  content?: Marko.Body<[count: number]>;
 }
 static const segmenter = (
-    "Segmenter" in Intl
-        ? new (Intl as any).Segmenter(undefined, { granularity: "grapheme" })
-        : null
+  "Segmenter" in Intl
+    ? new (Intl as any).Segmenter(undefined, { granularity: "grapheme" })
+    : null
 );
 static function countGraphemes(value: string): number {
-    if (segmenter) {
-        return [...segmenter.segment(value)].length;
-    }
-    return [...value].length;
+  if (segmenter) {
+    return [...segmenter.segment(value)].length;
+  }
+  return [...value].length;
 }
 
-<const/{ string, max, a11yText, count: inputCount, ...htmlInput }=input>
+<const/{
+  text,
+  max,
+  a11yText,
+  count: inputCount,
+  inputRef,
+  content,
+  ...htmlInput
+}=input>
 
-<const/count=(inputCount !== undefined ? inputCount : countGraphemes(string))>
+<const/count=(
+  inputCount !== undefined ? inputCount : countGraphemes(text ?? "")
+)>
+<const/ariaLive=(count > max ? "polite" : "off")>
 
-<define/Display>
-    <span ...htmlInput>
-        ${count}/${max}
-        <if=a11yText>
-            ${" "}
-            <span class="clipped">
-                ${a11yText}
-            </span>
-        </if>
-    </span>
-</define>
+<script>
+  const inputElement = inputRef?.();
+  if (inputElement) {
+    const previousAriaLive = inputElement.getAttribute("aria-live");
+    inputElement.setAttribute("aria-live", ariaLive);
+    $signal.addEventListener(
+      "abort",
+      () => {
+        if (previousAriaLive === null) {
+          inputElement.removeAttribute("aria-live");
+        } else {
+          inputElement.setAttribute("aria-live", previousAriaLive);
+        }
+      },
+      {
+        once: true,
+      },
+    );
+  }
+</script>
 
-<return={
-    count,
-    ariaLive: count > max ? "polite" as const : "off" as const,
-    Display,
-}>
+<span ...htmlInput>
+  <if=content>
+    <${content}(count)/>
+  </if>
+  <else>
+    ${count}/${max}
+    <if=a11yText>
+      ${" "}
+      <span class="clipped">
+        ${a11yText}
+      </span>
+    </if>
+  </else>
+</span>

--- a/packages/evo-marko/src/tags/evo-character-count/index.marko
+++ b/packages/evo-marko/src/tags/evo-character-count/index.marko
@@ -38,26 +38,29 @@ static function countGraphemes(value: string): number {
 )>
 <const/ariaLive=(count > max ? "polite" : "off")>
 
-<script>
-  const inputElement = inputRef?.();
-  if (inputElement) {
-    const previousAriaLive = inputElement.getAttribute("aria-live");
-    $signal.onabort = () => {
-      if (previousAriaLive === null) {
-        inputElement.removeAttribute("aria-live");
+<lifecycle<{
+  inputElement?: HTMLInputElement | HTMLTextAreaElement;
+  previousAriaLive?: string | null;
+}>
+  onMount() {
+    this.inputElement = inputRef?.();
+    this.previousAriaLive =
+      this.inputElement?.getAttribute("aria-live") ?? null;
+    this.inputElement?.setAttribute("aria-live", ariaLive);
+  }
+  onUpdate() {
+    this.inputElement?.setAttribute("aria-live", ariaLive);
+  }
+  onDestroy() {
+    if (this.inputElement) {
+      if (this.previousAriaLive == null) {
+        this.inputElement.removeAttribute("aria-live");
       } else {
-        inputElement.setAttribute("aria-live", previousAriaLive);
+        this.inputElement.setAttribute("aria-live", this.previousAriaLive);
       }
-    };
+    }
   }
-</script>
-
-<script>
-  const inputElement = inputRef?.();
-  if (inputElement) {
-    inputElement.setAttribute("aria-live", ariaLive);
-  }
-</script>
+>
 
 <span ...htmlInput>
   <if=content>

--- a/packages/evo-marko/src/tags/evo-character-count/test/__snapshots__/test.server.ts.snap
+++ b/packages/evo-marko/src/tags/evo-character-count/test/__snapshots__/test.server.ts.snap
@@ -1,5 +1,42 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`character-count > renders custom text 1`] = `
+"<span
+  class="field"
+>
+  <label
+    class="field__label field__label--stacked"
+    for="my-input"
+  >
+    Field Label
+  </label>
+  <span
+    class="field__control"
+  >
+    <span
+      class="textbox"
+    >
+      <input
+        aria-describedby="my-input-charcount"
+        class="textbox__control"
+        id="my-input"
+        type="text"
+        value="Custom"
+      />
+    </span>
+  </span>
+  <span
+    id="my-input-charcount"
+  >
+    <span
+      class="field__description field__description--group"
+    >
+      6 of 120 (114 remaining)
+    </span>
+  </span>
+</span>"
+`;
+
 exports[`character-count > renders default 1`] = `
 "<span>
   11/120 
@@ -25,12 +62,10 @@ exports[`character-count > renders in field 1`] = `
     class="field__control"
   >
     <span
-      class="textbox textbox__control"
-      placeholder=""
+      class="textbox"
     >
       <input
-        aria-describedby="MARKO-ID-0 MARKO-ID-1"
-        aria-live="off"
+        aria-describedby="my-input-description my-input-charcount"
         class="textbox__control"
         id="my-input"
         type="text"
@@ -46,7 +81,9 @@ exports[`character-count > renders in field 1`] = `
     >
       Brief description
     </span>
-    <span>
+    <span
+      id="my-input-charcount"
+    >
       0/120
     </span>
   </div>

--- a/packages/evo-marko/src/tags/evo-character-count/test/restore-aria-live.marko
+++ b/packages/evo-marko/src/tags/evo-character-count/test/restore-aria-live.marko
@@ -1,0 +1,9 @@
+export interface Input {
+  text: string;
+  showCount?: boolean;
+}
+
+<input/inputRef aria-label="Example" aria-live="assertive">
+<if=input.showCount !== false>
+  <evo-character-count text=input.text max=1 inputRef=inputRef/>
+</if>

--- a/packages/evo-marko/src/tags/evo-character-count/test/test.browser.ts
+++ b/packages/evo-marko/src/tags/evo-character-count/test/test.browser.ts
@@ -2,6 +2,7 @@ import { composeStories } from "@storybook/marko";
 import { cleanup, fireEvent, render } from "@marko/testing-library";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import * as stories from "../character-count.stories";
+import RestoreAriaLive from "./restore-aria-live.marko";
 
 const { Default, InField, CustomText } = composeStories(stories);
 
@@ -51,6 +52,18 @@ describe("evo-character-count", () => {
         "aria-live",
         "polite",
       );
+    });
+
+    it("restores the initial aria-live value after toggling and cleanup", async () => {
+      component = await render(RestoreAriaLive, { text: "a" });
+      const input = component.getByRole("textbox");
+      expect(input).toHaveAttribute("aria-live", "off");
+
+      await component.rerender({ text: "ab" });
+      expect(input).toHaveAttribute("aria-live", "polite");
+
+      await component.rerender({ text: "ab", showCount: false });
+      expect(input).toHaveAttribute("aria-live", "assertive");
     });
   });
 

--- a/packages/evo-marko/src/tags/evo-character-count/test/test.browser.ts
+++ b/packages/evo-marko/src/tags/evo-character-count/test/test.browser.ts
@@ -1,107 +1,62 @@
 import { composeStories } from "@storybook/marko";
-import { afterEach, beforeEach, describe, it, expect } from "vitest";
-import { render, cleanup } from "@marko/testing-library";
-import * as stories from "../character-count.stories"; // import all stories from the stories file
-const { Default } = composeStories(stories);
+import { cleanup, fireEvent, render } from "@marko/testing-library";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import * as stories from "../character-count.stories";
+
+const { Default, InField, CustomText } = composeStories(stories);
 
 afterEach(cleanup);
 
-/** @type import("@marko/testing-library").RenderResult */
-let component;
+let component: Awaited<ReturnType<typeof render>>;
 
-describe.skip("given a default character count", () => {
-  beforeEach(async () => {
-    component = await render(Default);
+describe("evo-character-count", () => {
+  describe("given the default character count", () => {
+    beforeEach(async () => {
+      component = await render(Default);
+    });
+
+    it("renders the calculated count", () => {
+      expect(component.getByText("11/120")).toBeInTheDocument();
+    });
+
+    it("renders the provided accessibility text", () => {
+      expect(component.getByText("characters remaining")).toBeInTheDocument();
+    });
+
+    it("uses a manual count", async () => {
+      await component.rerender({ ...Default.args, count: 5 });
+
+      expect(component.getByText("5/120")).toBeInTheDocument();
+    });
   });
 
-  describe("when it is rerendered", () => {
+  describe("given a character count associated with an input", () => {
     beforeEach(async () => {
-      await component.rerender(
-        Object.assign({}, Default.args, { value: "hello world" }),
+      component = await render(InField);
+    });
+
+    it("sets aria-live to off while within the limit", () => {
+      expect(component.getByRole("textbox")).toHaveAttribute(
+        "aria-live",
+        "off",
       );
-      await new Promise((resolve) => setTimeout(resolve, 600));
     });
 
-    it("then it emits the event with correct data", async () => {
-      const changeEvents = component.emitted("change");
-      expect(changeEvents).has.length(1);
+    it("sets aria-live to polite when the limit is exceeded", async () => {
+      await fireEvent.input(component.getByRole("textbox"), {
+        target: { value: "a".repeat(121) },
+      });
 
-      const [[changeEvent]] = changeEvents;
-      expect(changeEvent).has.property("count", 11);
-      expect(changeEvent).has.property("inputAriaLive", "off");
-    });
-  });
-
-  describe("when it is rerendered with too many characters", () => {
-    beforeEach(async () => {
-      await component.rerender(
-        Object.assign({}, Default.args, {
-          value: "hello world",
-          max: "5",
-        }),
+      expect(component.getByRole("textbox")).toHaveAttribute(
+        "aria-live",
+        "polite",
       );
-      await new Promise((resolve) => setTimeout(resolve, 600));
-    });
-
-    it("then it emits the event with correct data", async () => {
-      const changeEvents = component.emitted("change");
-      expect(changeEvents).has.length(1);
-
-      const [[changeEvent]] = changeEvents;
-      expect(changeEvent).has.property("count", 11);
-      expect(changeEvent).has.property("inputAriaLive", "polite");
     });
   });
 
-  describe("when it is rerendered with a number value", () => {
-    beforeEach(async () => {
-      await component.rerender(Object.assign({}, Default.args, { value: 12 }));
-      await new Promise((resolve) => setTimeout(resolve, 600));
-    });
+  it("passes the count to custom content", async () => {
+    component = await render(CustomText, { value: "Custom" });
 
-    it("then it emits the event with correct data", async () => {
-      const changeEvents = component.emitted("change");
-      expect(changeEvents).has.length(1);
-
-      const [[changeEvent]] = changeEvents;
-      expect(changeEvent).has.property("count", 12);
-      expect(changeEvent).has.property("inputAriaLive", "off");
-    });
-  });
-
-  describe("when it is rerendered with an invalid value", () => {
-    beforeEach(async () => {
-      await component.rerender(
-        Object.assign({}, Default.args, { value: { object: "123" } }),
-      );
-      await new Promise((resolve) => setTimeout(resolve, 600));
-    });
-
-    it("then it emits the event with correct data", async () => {
-      const changeEvents = component.emitted("change");
-      expect(changeEvents).has.length(1);
-
-      const [[changeEvent]] = changeEvents;
-      expect(changeEvent).has.property("count", 0);
-      expect(changeEvent).has.property("inputAriaLive", "off");
-    });
-  });
-
-  describe("when it is rerendered twice", () => {
-    beforeEach(async () => {
-      await component.rerender(Object.assign({}, Default.args, { value: 3 }));
-      await component.rerender(Object.assign({}, Default.args, { value: 4 }));
-      await component.rerender(Object.assign({}, Default.args, { value: 5 }));
-      await new Promise((resolve) => setTimeout(resolve, 600));
-    });
-
-    it("then it emits the event with correct data", async () => {
-      const changeEvents = component.emitted("change");
-      expect(changeEvents).has.length(1);
-
-      const [[changeEvent]] = changeEvents;
-      expect(changeEvent).has.property("count", 5);
-      expect(changeEvent).has.property("inputAriaLive", "off");
-    });
+    expect(component.getByText("6 of 120 (114 remaining)")).toBeInTheDocument();
   });
 });

--- a/packages/evo-marko/src/tags/evo-character-count/test/test.server.ts
+++ b/packages/evo-marko/src/tags/evo-character-count/test/test.server.ts
@@ -3,13 +3,16 @@ import { describe, it } from "vitest";
 import { composeStories } from "@storybook/marko";
 import { snapshotHTML } from "../../../common/test-utils/snapshots";
 import * as stories from "../character-count.stories"; // import all stories from the stories file
-const { Default, InField } = composeStories(stories);
+const { Default, InField, CustomText } = composeStories(stories);
 
 describe("character-count", () => {
-    it("renders default", async () => {
-        await snapshotHTML(Default);
-    });
-    it("renders in field", async () => {
-        await snapshotHTML(InField);
-    });
+  it("renders default", async () => {
+    await snapshotHTML(Default);
+  });
+  it("renders in field", async () => {
+    await snapshotHTML(InField);
+  });
+  it("renders custom text", async () => {
+    await snapshotHTML(CustomText, { value: "Custom" });
+  });
 });

--- a/packages/evo-react/src/character-count/README.md
+++ b/packages/evo-react/src/character-count/README.md
@@ -1,0 +1,5 @@
+# EvoCharacterCount
+
+## Documentation
+
+[Storybook](https://opensource.ebay.com/evo-web/react/?path=/docs/building-blocks-evo-character-count--documentation)

--- a/packages/evo-react/src/character-count/character-count.stories.tsx
+++ b/packages/evo-react/src/character-count/character-count.stories.tsx
@@ -1,0 +1,76 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { EvoCharacterCount } from "./character-count";
+import { countCharacters } from "./count-characters";
+
+const meta: Meta<typeof EvoCharacterCount> = {
+  title: "building blocks/evo-character-count",
+  component: EvoCharacterCount,
+  tags: ["autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component: `
+Displays the number of grapheme characters in text relative to a maximum.
+
+## Usage
+
+\`\`\`tsx
+import { EvoCharacterCount } from "@evo-web/react/character-count";
+\`\`\`
+        `,
+      },
+    },
+  },
+  argTypes: {
+    text: {
+      control: "text",
+      description:
+        "Text whose grapheme characters are counted. Required unless count is provided.",
+    },
+    count: {
+      control: "number",
+      description: "Manual count used instead of calculating from text.",
+    },
+    max: {
+      control: "number",
+      description: "Maximum number of characters allowed.",
+    },
+    a11yText: {
+      type: { name: "string", required: true },
+      control: "text",
+      description:
+        'Clipped text announced after the count. English default to be overridden is "characters used". Pass `null` explicitly only if alternative accessibility information is present.',
+    },
+    inputRef: {
+      control: false,
+      description:
+        'Reference to the associated input or textarea. Its `aria-live` is set to "polite" when the count exceeds the maximum.',
+    },
+    children: {
+      control: false,
+      description: "Custom content that replaces the default count display.",
+    },
+  },
+  args: {
+    text: "Hello world",
+    max: 120,
+    a11yText: "characters used",
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof EvoCharacterCount>;
+
+export const Default: Story = {};
+
+const customText = "Custom";
+const customCount = countCharacters(customText);
+
+export const CustomContent: Story = {
+  args: {
+    text: undefined,
+    count: customCount,
+    max: 120,
+    children: `${customCount} of 120 (${120 - customCount} remaining)`,
+  },
+};

--- a/packages/evo-react/src/character-count/character-count.tsx
+++ b/packages/evo-react/src/character-count/character-count.tsx
@@ -22,7 +22,6 @@ export function EvoCharacterCount({
     }
 
     const previousAriaLive = input.getAttribute("aria-live");
-    input.setAttribute("aria-live", isOverLimit ? "polite" : "off");
 
     return () => {
       if (previousAriaLive === null) {
@@ -31,6 +30,13 @@ export function EvoCharacterCount({
         input.setAttribute("aria-live", previousAriaLive);
       }
     };
+  }, [inputRef]);
+
+  useEffect(() => {
+    const input = inputRef?.current;
+    if (input) {
+      input.setAttribute("aria-live", isOverLimit ? "polite" : "off");
+    }
   }, [inputRef, isOverLimit]);
 
   return (

--- a/packages/evo-react/src/character-count/character-count.tsx
+++ b/packages/evo-react/src/character-count/character-count.tsx
@@ -1,0 +1,53 @@
+import { useEffect } from "react";
+import { countCharacters } from "./count-characters";
+import type { EvoCharacterCountProps } from "./types";
+import "@ebay/skin/utility.mjs";
+
+export function EvoCharacterCount({
+  text,
+  count: inputCount,
+  max,
+  a11yText = "characters used",
+  inputRef,
+  children,
+  ...rest
+}: EvoCharacterCountProps) {
+  const count = inputCount ?? countCharacters(text ?? "");
+  const isOverLimit = count > max;
+
+  useEffect(() => {
+    const input = inputRef?.current;
+    if (!input) {
+      return;
+    }
+
+    const previousAriaLive = input.getAttribute("aria-live");
+    input.setAttribute("aria-live", isOverLimit ? "polite" : "off");
+
+    return () => {
+      if (previousAriaLive === null) {
+        input.removeAttribute("aria-live");
+      } else {
+        input.setAttribute("aria-live", previousAriaLive);
+      }
+    };
+  }, [isOverLimit]);
+
+  return (
+    <span {...rest}>
+      {children !== undefined ? (
+        children
+      ) : (
+        <>
+          {count}/{max}
+          {a11yText && (
+            <>
+              {" "}
+              <span className="clipped">{a11yText}</span>
+            </>
+          )}
+        </>
+      )}
+    </span>
+  );
+}

--- a/packages/evo-react/src/character-count/character-count.tsx
+++ b/packages/evo-react/src/character-count/character-count.tsx
@@ -31,7 +31,7 @@ export function EvoCharacterCount({
         input.setAttribute("aria-live", previousAriaLive);
       }
     };
-  }, [isOverLimit]);
+  }, [inputRef, isOverLimit]);
 
   return (
     <span {...rest}>

--- a/packages/evo-react/src/character-count/count-characters.ts
+++ b/packages/evo-react/src/character-count/count-characters.ts
@@ -1,0 +1,18 @@
+const segmenter =
+  "Segmenter" in Intl
+    ? new (
+        Intl as typeof Intl & {
+          Segmenter: new (
+            locales?: string | string[],
+            options?: { granularity: "grapheme" },
+          ) => { segment: (value: string) => Iterable<unknown> };
+        }
+      ).Segmenter(undefined, { granularity: "grapheme" })
+    : null;
+
+export function countCharacters(text: string): number {
+  if (segmenter) {
+    return [...segmenter.segment(text)].length;
+  }
+  return [...text].length;
+}

--- a/packages/evo-react/src/character-count/index.ts
+++ b/packages/evo-react/src/character-count/index.ts
@@ -1,0 +1,3 @@
+export { EvoCharacterCount } from "./character-count";
+export { countCharacters } from "./count-characters";
+export type { CharacterCountInputRef, EvoCharacterCountProps } from "./types";

--- a/packages/evo-react/src/character-count/test/__snapshots__/test.server.tsx.snap
+++ b/packages/evo-react/src/character-count/test/__snapshots__/test.server.tsx.snap
@@ -1,0 +1,11 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`EvoCharacterCount SSR > omits accessibility text when explicitly null 1`] = `"<span>5<!-- -->/<!-- -->10</span>"`;
+
+exports[`EvoCharacterCount SSR > passes HTML attributes to the root span 1`] = `"<span class="custom-class" data-testid="character-count">5<!-- -->/<!-- -->10<!-- --> <span class="clipped">characters used</span></span>"`;
+
+exports[`EvoCharacterCount SSR > renders a manual count 1`] = `"<span>5<!-- -->/<!-- -->120<!-- --> <span class="clipped">characters used</span></span>"`;
+
+exports[`EvoCharacterCount SSR > renders custom content 1`] = `"<span>6 of 120 (114 remaining)</span>"`;
+
+exports[`EvoCharacterCount SSR > renders the calculated count 1`] = `"<span>11<!-- -->/<!-- -->120<!-- --> <span class="clipped">characters used</span></span>"`;

--- a/packages/evo-react/src/character-count/test/test.browser.tsx
+++ b/packages/evo-react/src/character-count/test/test.browser.tsx
@@ -123,16 +123,23 @@ describe("evo-character-count", () => {
     await expect.element(secondInput).toHaveAttribute("aria-live", "polite");
   });
 
-  it("restores the previous aria-live value when unmounted", async () => {
+  it("restores the initial aria-live value after toggling and unmounting", async () => {
     function Example() {
+      const [text, setText] = useState("a");
       const [showCount, setShowCount] = useState(true);
       const inputRef = useRef<HTMLInputElement>(null);
 
       return (
         <>
-          <input ref={inputRef} aria-label="Example" aria-live="assertive" />
+          <input
+            ref={inputRef}
+            aria-label="Example"
+            aria-live="assertive"
+            value={text}
+            onChange={(event) => setText(event.currentTarget.value)}
+          />
           {showCount && (
-            <EvoCharacterCount text="a" max={1} inputRef={inputRef} />
+            <EvoCharacterCount text={text} max={1} inputRef={inputRef} />
           )}
           <button onClick={() => setShowCount(false)}>Remove count</button>
         </>
@@ -142,6 +149,9 @@ describe("evo-character-count", () => {
     const screen = await render(<Example />);
     const input = screen.getByRole("textbox", { name: "Example" });
     await expect.element(input).toHaveAttribute("aria-live", "off");
+
+    await user.type(input, "b");
+    await expect.element(input).toHaveAttribute("aria-live", "polite");
 
     await user.click(screen.getByRole("button", { name: "Remove count" }));
 

--- a/packages/evo-react/src/character-count/test/test.browser.tsx
+++ b/packages/evo-react/src/character-count/test/test.browser.tsx
@@ -1,0 +1,119 @@
+import { useRef, useState } from "react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { userEvent } from "vitest/browser";
+import { render } from "vitest-browser-react";
+import { EvoCharacterCount } from "../character-count";
+import { countCharacters } from "../count-characters";
+
+describe("evo-character-count", () => {
+  let user: ReturnType<typeof userEvent.setup>;
+
+  beforeEach(() => {
+    user = userEvent.setup();
+  });
+
+  afterEach(() => {
+    user.cleanup();
+  });
+
+  it("counts grapheme characters", async () => {
+    const screen = await render(
+      <EvoCharacterCount text="Hello world" max={120} />,
+    );
+
+    await expect.element(screen.getByText("11/120")).toBeInTheDocument();
+    await expect
+      .element(screen.getByText("characters used"))
+      .toBeInTheDocument();
+  });
+
+  it("uses a manual count instead of calculating from text", async () => {
+    const screen = await render(
+      <EvoCharacterCount text="Hello world" count={5} max={120} />,
+    );
+
+    await expect.element(screen.getByText("5/120")).toBeInTheDocument();
+  });
+
+  it("renders custom content", async () => {
+    const screen = await render(
+      <EvoCharacterCount count={6} max={120}>
+        6 of 120 (114 remaining)
+      </EvoCharacterCount>,
+    );
+
+    await expect
+      .element(screen.getByText("6 of 120 (114 remaining)"))
+      .toBeInTheDocument();
+  });
+
+  it("passes HTML attributes to the root span", async () => {
+    const screen = await render(
+      <EvoCharacterCount
+        text="Hello"
+        max={10}
+        className="custom-class"
+        data-testid="character-count"
+      />,
+    );
+
+    const characterCount = screen.getByTestId("character-count");
+    await expect.element(characterCount).toHaveClass("custom-class");
+  });
+
+  it("updates aria-live on the associated input", async () => {
+    function Example() {
+      const [text, setText] = useState("a");
+      const inputRef = useRef<HTMLInputElement>(null);
+
+      return (
+        <>
+          <input
+            ref={inputRef}
+            aria-label="Example"
+            value={text}
+            onChange={(event) => setText(event.currentTarget.value)}
+          />
+          <EvoCharacterCount text={text} max={1} inputRef={inputRef} />
+        </>
+      );
+    }
+
+    const screen = await render(<Example />);
+    const input = screen.getByRole("textbox", { name: "Example" });
+    await expect.element(input).toHaveAttribute("aria-live", "off");
+
+    await user.type(input, "b");
+
+    await expect.element(input).toHaveAttribute("aria-live", "polite");
+  });
+
+  it("restores the previous aria-live value when unmounted", async () => {
+    function Example() {
+      const [showCount, setShowCount] = useState(true);
+      const inputRef = useRef<HTMLInputElement>(null);
+
+      return (
+        <>
+          <input ref={inputRef} aria-label="Example" aria-live="assertive" />
+          {showCount && (
+            <EvoCharacterCount text="a" max={1} inputRef={inputRef} />
+          )}
+          <button onClick={() => setShowCount(false)}>Remove count</button>
+        </>
+      );
+    }
+
+    const screen = await render(<Example />);
+    const input = screen.getByRole("textbox", { name: "Example" });
+    await expect.element(input).toHaveAttribute("aria-live", "off");
+
+    await user.click(screen.getByRole("button", { name: "Remove count" }));
+
+    await expect.element(input).toHaveAttribute("aria-live", "assertive");
+  });
+
+  it("counts extended grapheme clusters as one character", () => {
+    expect(countCharacters("👨‍👩‍👧‍👦")).toBe(1);
+  });
+});

--- a/packages/evo-react/src/character-count/test/test.browser.tsx
+++ b/packages/evo-react/src/character-count/test/test.browser.tsx
@@ -88,6 +88,41 @@ describe("evo-character-count", () => {
     await expect.element(input).toHaveAttribute("aria-live", "polite");
   });
 
+  it("updates aria-live when the associated input ref changes", async () => {
+    function Example() {
+      const [useSecondInput, setUseSecondInput] = useState(false);
+      const firstInputRef = useRef<HTMLInputElement>(null);
+      const secondInputRef = useRef<HTMLInputElement>(null);
+
+      return (
+        <>
+          <input ref={firstInputRef} aria-label="First input" />
+          <input ref={secondInputRef} aria-label="Second input" />
+          <EvoCharacterCount
+            text="ab"
+            max={1}
+            inputRef={useSecondInput ? secondInputRef : firstInputRef}
+          />
+          <button onClick={() => setUseSecondInput(true)}>
+            Use second input
+          </button>
+        </>
+      );
+    }
+
+    const screen = await render(<Example />);
+    const firstInput = screen.getByRole("textbox", { name: "First input" });
+    const secondInput = screen.getByRole("textbox", { name: "Second input" });
+
+    await expect.element(firstInput).toHaveAttribute("aria-live", "polite");
+    await expect.element(secondInput).not.toHaveAttribute("aria-live");
+
+    await user.click(screen.getByRole("button", { name: "Use second input" }));
+
+    await expect.element(firstInput).not.toHaveAttribute("aria-live");
+    await expect.element(secondInput).toHaveAttribute("aria-live", "polite");
+  });
+
   it("restores the previous aria-live value when unmounted", async () => {
     function Example() {
       const [showCount, setShowCount] = useState(true);

--- a/packages/evo-react/src/character-count/test/test.server.tsx
+++ b/packages/evo-react/src/character-count/test/test.server.tsx
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { renderToString } from "react-dom/server";
+import { EvoCharacterCount } from "../character-count";
+
+describe("EvoCharacterCount SSR", () => {
+  it("renders the calculated count", () => {
+    expect(
+      renderToString(<EvoCharacterCount text="Hello world" max={120} />),
+    ).toMatchSnapshot();
+  });
+
+  it("renders a manual count", () => {
+    expect(
+      renderToString(<EvoCharacterCount count={5} max={120} />),
+    ).toMatchSnapshot();
+  });
+
+  it("renders custom content", () => {
+    expect(
+      renderToString(
+        <EvoCharacterCount count={6} max={120}>
+          6 of 120 (114 remaining)
+        </EvoCharacterCount>,
+      ),
+    ).toMatchSnapshot();
+  });
+
+  it("omits accessibility text when explicitly null", () => {
+    expect(
+      renderToString(
+        <EvoCharacterCount text="Hello" max={10} a11yText={null} />,
+      ),
+    ).toMatchSnapshot();
+  });
+
+  it("passes HTML attributes to the root span", () => {
+    expect(
+      renderToString(
+        <EvoCharacterCount
+          text="Hello"
+          max={10}
+          className="custom-class"
+          data-testid="character-count"
+        />,
+      ),
+    ).toMatchSnapshot();
+  });
+});

--- a/packages/evo-react/src/character-count/types.ts
+++ b/packages/evo-react/src/character-count/types.ts
@@ -1,0 +1,27 @@
+import type { ComponentProps, RefObject } from "react";
+
+type CharacterCountSource =
+  | {
+      text: string;
+      count?: number;
+    }
+  | {
+      text?: never;
+      count: number;
+    };
+
+export type CharacterCountInputRef = RefObject<
+  HTMLInputElement | HTMLTextAreaElement | null
+>;
+
+export type EvoCharacterCountProps = ComponentProps<"span"> &
+  CharacterCountSource & {
+    max: number;
+    /**
+     * Clipped text for screen readers. English default to be overridden is
+     * `"characters used"`. Pass `null` explicitly _only_ if alternative
+     * accessibility information is present.
+     */
+    a11yText?: string | null;
+    inputRef?: CharacterCountInputRef;
+  };


### PR DESCRIPTION
<!-- Insert GitHub issue number below. An issue is required for all PRs -->

- Fixes #

## Description

- add `EvoCharacterCount` to `@evo-web/react` with grapheme-aware counting, custom content, and input `aria-live` management
- align the experimental Evo Marko API around `text`, numeric count overrides, tag parameters, and native input references
- add React and Marko stories, browser tests, SSR tests, migration guidance, and package changesets

## Notes

- Forwarding native input references through `evo-input` and `evo-textarea` is intentionally out of scope pending guidance from the Marko team.

## Screenshots

N/A — no CSS visual changes.

## Checklist

- [ ] I verify the linked issue has been triaged ("Needs Triage" label removed)
- [ ] I verify all changes are within scope of the linked issue
- [ ] I added/updated/removed testing (Storybook in Skin) coverage as appropriate
