### PR TITLE
ci: parallelize CI into per-package jobs with dependency caching

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,43 @@
+name: Setup dependencies
+description: >
+  Restore node_modules from cache (skipping npm ci entirely on a hit) and
+  optionally install the Playwright chromium browser for jobs that run
+  browser tests.
+inputs:
+  playwright:
+    description: Install the Playwright chromium browser ("true"/"false")
+    required: false
+    default: "false"
+runs:
+  using: composite
+  steps:
+    - name: Setup Node.js
+      uses: actions/setup-node@v6
+      with:
+        node-version: 24
+        cache: npm
+    - name: Restore node_modules
+      id: node-modules
+      uses: actions/cache@v4
+      with:
+        path: |
+          node_modules
+          packages/*/node_modules
+        key: node-modules-${{ runner.os }}-node24-${{ hashFiles('package-lock.json') }}
+    - name: Restore Playwright browsers
+      if: inputs.playwright == 'true'
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/ms-playwright
+        key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+    - name: Install dependencies
+      if: steps.node-modules.outputs.cache-hit != 'true'
+      shell: bash
+      env:
+        # Browsers are installed (and cached) separately below, only where needed
+        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
+      run: npm ci --prefer-offline --no-audit --no-fund
+    - name: Install Playwright chromium
+      if: inputs.playwright == 'true'
+      shell: bash
+      run: npx playwright install --with-deps chromium

--- a/.github/actions/skin-dist/action.yml
+++ b/.github/actions/skin-dist/action.yml
@@ -1,0 +1,17 @@
+name: Restore skin build output
+description: >
+  Download and unpack the build output published by the `skin` job, so a
+  package job builds against a freshly built skin rather than whatever is
+  committed to the repo.
+runs:
+  using: composite
+  steps:
+    - uses: actions/download-artifact@v4
+      with:
+        name: skin-dist
+    - name: Unpack skin build output
+      shell: bash
+      run: |
+        set -euo pipefail
+        tar -xzf skin-dist.tar.gz
+        rm skin-dist.tar.gz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,9 @@ env:
   # Everything `npm run build -w packages/skin` produces that another package
   # reads: the compiled CSS, the per-module import stubs consumers resolve
   # `@ebay/skin/<module>` through, and the two icon files the build writes back
-  # into the site.
-  SKIN_BUILD_OUTPUT: >-
+  # into the site. Newline-separated so it works both as an `actions/cache`
+  # path list and as unquoted argv for `tar`.
+  SKIN_BUILD_OUTPUT: |
     packages/skin/dist
     packages/skin/*.mjs
     src/data/icons.json
@@ -33,7 +34,23 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
-      - run: npm run build -w packages/skin
+      # Most PRs do not touch skin, so on a hit this restores the output a
+      # previous run already built and the build below is skipped. The key
+      # covers everything the build reads — sources, scripts, the lint and
+      # formatter configs that shape the output, and the dependency tree.
+      - name: Restore skin build output
+        id: skin-cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.SKIN_BUILD_OUTPUT }}
+          key: skin-dist-${{ runner.os }}-node24-${{ hashFiles('packages/skin/src/**', 'packages/skin/scripts/**', 'packages/skin/*.json', 'packages/skin/*.mjs', 'packages/skin/.stylelintrc', '.stylelintrc', 'package-lock.json') }}
+      - name: Build skin
+        if: steps.skin-cache.outputs.cache-hit != 'true'
+        run: npm run build -w packages/skin
+      # Runs on a hit too, and is still the same assertion: whether skin's
+      # output matches what the PR committed. On a hit it compares against the
+      # restored output rather than a fresh build, so a PR that edits `dist/`
+      # by hand still fails here.
       - name: Check for uncommitted changes
         run: |
           if output=$(git status --porcelain) && [ -z "$output" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,19 +10,23 @@ concurrency:
   group: "${{ github.workflow }}-${{ github.event_name == 'pull_request_target' && github.head_ref || github.ref }}"
   cancel-in-progress: true
 
-jobs:
-  # One job per package (each running the package's own `build` script), plus
-  # `site` for the root-level lint and site typecheck. Together these run
-  # everything `npm run build:ci` ran in a single job, on parallel runners.
-  site:
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    steps:
-      - uses: actions/checkout@v6
-      - uses: ./.github/actions/setup
-      - run: npm run lint
-      - run: npx mtc
+env:
+  # Everything `npm run build -w packages/skin` produces that another package
+  # reads: the compiled CSS, the per-module import stubs consumers resolve
+  # `@ebay/skin/<module>` through, and the two icon files the build writes back
+  # into the site.
+  SKIN_BUILD_OUTPUT: >-
+    packages/skin/dist
+    packages/skin/*.mjs
+    src/data/icons.json
+    src/tags/master-icons.marko
 
+jobs:
+  # `skin` builds first and publishes its build output as an artifact; every
+  # other package job restores that artifact before building. Today skin's
+  # output is also committed, so restoring it is a no-op — the dependency is
+  # wired up ahead of dropping the committed `dist/` from the repo, and to
+  # measure what putting skin on the critical path costs.
   skin:
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -39,23 +43,50 @@ jobs:
             echo "$output"
             exit 1 # Fail the CI run if there are uncommitted changes
           fi
+      # A single tarball: `dist/` alone is ~1500 files, and upload-artifact
+      # pays per-file overhead.
+      - name: Package skin build output
+        run: tar -czf skin-dist.tar.gz $SKIN_BUILD_OUTPUT
+      - uses: actions/upload-artifact@v4
+        with:
+          name: skin-dist
+          path: skin-dist.tar.gz
+          retention-days: 1
+
+  # One job per package (each running the package's own `build` script), plus
+  # `site` for the root-level lint and site typecheck. Together these run
+  # everything `npm run build:ci` ran in a single job, on parallel runners.
+  site:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs: [skin]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup
+      - uses: ./.github/actions/skin-dist
+      - run: npm run lint
+      - run: npx mtc
 
   evo-marko:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    needs: [skin]
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
+      - uses: ./.github/actions/skin-dist
       - run: npm run build -w packages/evo-marko
 
   ebayui-core:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    needs: [skin]
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
         with:
           playwright: "true"
+      - uses: ./.github/actions/skin-dist
       - run: npm run build -w packages/ebayui-core
       - uses: codecov/codecov-action@v5
         with:
@@ -64,19 +95,23 @@ jobs:
   ebayui-core-react:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    needs: [skin]
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
+      - uses: ./.github/actions/skin-dist
       - run: npm run build -w packages/ebayui-core-react
 
   evo-react:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    needs: [skin]
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
         with:
           playwright: "true"
+      - uses: ./.github/actions/skin-dist
       - run: npm run build -w packages/evo-react
 
   # Fan-in for the jobs above, keeping the "build" required-check name that

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,20 +11,25 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  # One job per package (each running the package's own `build` script), plus
+  # `site` for the root-level lint and site typecheck. Together these run
+  # everything `npm run build:ci` ran in a single job, on parallel runners.
+  site:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: npm
-      - run: npm ci
-      - run: npm run build:ci
-      - uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+      - uses: ./.github/actions/setup
+      - run: npm run lint
+      - run: npx mtc
+
+  skin:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup
+      - run: npm run build -w packages/skin
       - name: Check for uncommitted changes
         run: |
           if output=$(git status --porcelain) && [ -z "$output" ]; then
@@ -34,6 +39,58 @@ jobs:
             echo "$output"
             exit 1 # Fail the CI run if there are uncommitted changes
           fi
+
+  evo-marko:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup
+      - run: npm run build -w packages/evo-marko
+
+  ebayui-core:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup
+        with:
+          playwright: "true"
+      - run: npm run build -w packages/ebayui-core
+      - uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+  ebayui-core-react:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup
+      - run: npm run build -w packages/ebayui-core-react
+
+  evo-react:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup
+        with:
+          playwright: "true"
+      - run: npm run build -w packages/evo-react
+
+  # Fan-in for the jobs above, keeping the "build" required-check name that
+  # branch protection and the deploy/release jobs depend on.
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: always()
+    needs: [site, skin, evo-marko, ebayui-core, ebayui-core-react, evo-react]
+    steps:
+      - name: Fail if any CI job failed
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+        run: exit 1
+      - run: echo "All CI jobs passed."
   # Deployment job
   deploy:
     if: github.ref == 'refs/heads/main'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,8 +131,8 @@ jobs:
       - uses: ./.github/actions/skin-dist
       - run: npm run build -w packages/evo-react
 
-  # Fan-in for the jobs above, keeping the "build" required-check name that
-  # branch protection and the deploy/release jobs depend on.
+  # One gate for `deploy` and `release` to depend on. Counts a skipped job as a
+  # failure, so a job skipped by a failing `needs` dependency still fails here.
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -16,7 +16,7 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
-      deployments: read
+      pages: read
     steps:
       - name: Post "updating" status to PR
         uses: actions/github-script@v7
@@ -58,10 +58,30 @@ jobs:
         env:
           BASE_URL: /evo-web/previews/pr-${{ github.event.pull_request.number }}/
 
+      - name: Resolve GitHub Pages base URL
+        id: pages
+        run: |
+          set -euo pipefail
+          # Ask the API where this repo's Pages site is actually served
+          # (custom domain on the real repo, <owner>.github.io on forks) so the
+          # liveness check below and the posted link agree with reality.
+          base=$(curl -fsS --max-time 15 \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${{ github.repository }}/pages" \
+            | jq -r '.html_url') \
+            || { echo "GitHub Pages is not enabled for ${{ github.repository }}; enable it (deploy from the gh-pages branch) to publish previews."; exit 1; }
+          base="${base%/}/"
+          echo "Pages base URL: ${base}"
+          echo "base=${base}" >> "$GITHUB_OUTPUT"
+
       - name: Deploy to gh-pages branch (preview subdirectory)
         id: deploy
         run: |
           set -euo pipefail
+          # Stamp this deploy so the wait step below can verify the preview
+          # that is actually being served is this run's build.
+          echo "${{ github.sha }}" > _site/public/deploy-stamp.txt
           repo_url="https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
           # gh-pages commits in its own temporary clone, so set the identity globally
           # rather than via --user (whose parser rejects the github-actions[bot]
@@ -88,62 +108,38 @@ jobs:
             sleep $((attempt * 3))
           done
           $pushed || { echo "Failed to deploy preview after 3 attempts."; exit 1; }
-          # gh-pages nests its clone under find-cache-dir's path, not directly at
-          # node_modules/.cache/gh-pages, so read the pushed tip back from the
-          # remote rather than relying on that cache layout.
-          echo "sha=$(git ls-remote "$repo_url" gh-pages | cut -f1)" >> "$GITHUB_OUTPUT"
 
-      - name: Wait for GitHub Pages deployment
+      - name: Wait for preview to be live
         run: |
-          set -uo pipefail
-          sha="${{ steps.deploy.outputs.sha }}"
-          api="https://api.github.com/repos/${{ github.repository }}"
-          auth=(-H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -H "Accept: application/vnd.github+json")
-          gh_api() { curl -s --max-time 15 "${auth[@]}" "$@"; }
+          set -euo pipefail
+          expected="${{ github.sha }}"
+          stamp_url="${{ steps.pages.outputs.base }}previews/pr-${{ github.event.pull_request.number }}/deploy-stamp.txt"
 
-          id=""
-          for attempt in $(seq 1 30); do
-            if [ -z "$id" ]; then
-              # Query by exact commit SHA; the legacy /pages/builds/latest endpoint
-              # isn't a reliable per-commit signal.
-              id=$(gh_api "${api}/deployments?sha=${sha}&environment=github-pages" | jq -r 'if type=="array" and length>0 then .[0].id else empty end')
-              if [ -z "$id" ]; then
-                # Some repos (e.g. forks) never record a github-pages deployment
-                # for these pushes; don't burn the full timeout looking for one.
-                if [ "$attempt" -ge 6 ]; then
-                  echo "No GitHub Pages deployment recorded for ${sha} after ${attempt} attempts; posting the link anyway."
-                  exit 0
-                fi
-                echo "No GitHub Pages deployment recorded yet for ${sha} (attempt ${attempt}/6)..."
-                sleep 10
-                continue
-              fi
-            fi
-
-            state=$(gh_api "${api}/deployments/${id}/statuses" | jq -r 'if type=="array" and length>0 then .[0].state else empty end')
-
-            if [ "$state" = "success" ]; then
-              echo "GitHub Pages deployment for ${sha} succeeded."
+          # Poll the deployed site itself rather than the deployments API,
+          # which does not record these pushes on every repo. The unique query
+          # string keeps the CDN from serving a cached stamp.
+          for attempt in $(seq 1 40); do
+            live=$(curl -fsS --max-time 15 "${stamp_url}?cb=${expected}-${attempt}" 2>/dev/null || true)
+            if [ "$live" = "$expected" ]; then
+              echo "Preview is live (deploy stamp ${expected})."
               exit 0
             fi
-            if [ "$state" = "failure" ] || [ "$state" = "error" ]; then
-              echo "GitHub Pages deployment for ${sha} failed (state: ${state})."
-              exit 1
-            fi
-
-            echo "GitHub Pages deployment for ${sha} is ${state:-pending} (attempt ${attempt}/30)..."
+            echo "Preview is not live yet (attempt ${attempt}/40; serving stamp: ${live:-none})..."
             sleep 10
           done
-          echo "GitHub Pages deployment did not confirm within 5 minutes; posting the link anyway."
+          echo "Preview did not go live within ~7 minutes; not posting the link."
+          exit 1
 
       - name: Post preview URL to PR
         uses: actions/github-script@v7
+        env:
+          PAGES_BASE: ${{ steps.pages.outputs.base }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const pr = context.payload.pull_request.number;
             const sha = context.payload.pull_request.head.sha.slice(0, 7);
-            const url = `https://opensource.ebay.com/evo-web/previews/pr-${pr}/`;
+            const url = `${process.env.PAGES_BASE}previews/pr-${pr}/`;
 
             // Find and update an existing bot comment, or create a new one
             const { data: comments } = await github.rest.issues.listComments({

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -50,14 +50,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: npm
-
       - name: Install dependencies
-        run: npm ci
+        uses: ./.github/actions/setup
 
       - name: Build site (preview base URL)
         run: npm run deploy
@@ -114,7 +108,13 @@ jobs:
               # isn't a reliable per-commit signal.
               id=$(gh_api "${api}/deployments?sha=${sha}&environment=github-pages" | jq -r 'if type=="array" and length>0 then .[0].id else empty end')
               if [ -z "$id" ]; then
-                echo "No GitHub Pages deployment recorded yet for ${sha} (attempt ${attempt}/30)..."
+                # Some repos (e.g. forks) never record a github-pages deployment
+                # for these pushes; don't burn the full timeout looking for one.
+                if [ "$attempt" -ge 6 ]; then
+                  echo "No GitHub Pages deployment recorded for ${sha} after ${attempt} attempts; posting the link anyway."
+                  exit 0
+                fi
+                echo "No GitHub Pages deployment recorded yet for ${sha} (attempt ${attempt}/6)..."
                 sleep 10
                 continue
               fi


### PR DESCRIPTION
In theory, this should speed up the CI by a significant amount by caching initial downloads and parallelizing other tasks. Let's test it out!