### PR TITLE
fix(filter-chip): pass border-radius through image-treatment mixin argument

### DIFF
--- a/.changeset/seven-plums-cover.md
+++ b/.changeset/seven-plums-cover.md
@@ -1,0 +1,5 @@
+---
+"@ebay/skin": patch
+---
+
+fix(skin/filter-chip): pass border-radius through image-treatment mixin argument

--- a/packages/skin/dist/filter-chip/filter-chip.css
+++ b/packages/skin/dist/filter-chip/filter-chip.css
@@ -116,7 +116,6 @@ button.filter-chip--expressive {
 .filter-chip__media {
     align-items: center;
     border-radius: var(--spacing-400);
-    border-radius: 8px;
     display: flex;
     justify-content: center;
     margin-inline-start: -8px;

--- a/packages/skin/src/sass/filter-chip/filter-chip.scss
+++ b/packages/skin/src/sass/filter-chip/filter-chip.scss
@@ -22,10 +22,9 @@ a.filter-chip--expressive {
 }
 
 .filter-chip__media {
-    border-radius: var(--spacing-400);
     margin-inline-start: -8px;
 
-    @include utility-mixins.image-treatment;
+    @include utility-mixins.image-treatment($border-radius: var(--spacing-400));
 }
 
 .filter-chip__media > img {


### PR DESCRIPTION
Fixes #761 and #707

## Description

Fix filter-chip border-radius by passing it through the image-treatment mixin argument.

## Screenshots

<img width="102" height="51" alt="image" src="https://github.com/user-attachments/assets/a1991bfc-d1a3-49c4-a540-4e2000199035" />

<img width="146" height="69" alt="image" src="https://github.com/user-attachments/assets/e7e34b08-e91a-4bfb-a88e-692f6986e678" />

