### PR TITLE
fix(ebay-tourtip): give the region role an accessible name

### DIFF
--- a/.changeset/tame-ravens-jump.md
+++ b/.changeset/tame-ravens-jump.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ui-core-react": patch
+---
+
+fix(ebay-tourtip): give the region role an accessible name via aria-labelledby on the overlay, linked to the heading

--- a/packages/ebayui-core-react/src/common/tooltip-utils/tooltip-content.tsx
+++ b/packages/ebayui-core-react/src/common/tooltip-utils/tooltip-content.tsx
@@ -13,6 +13,7 @@ export type TooltipContentProps = {
     pointer?: PointerDirection;
     showCloseButton?: boolean;
     a11yCloseText?: string;
+    ariaLabelledBy?: string;
     onClose?: () => void;
     children?: ReactNode;
     overlayRef?: (node: HTMLElement | null) => void;
@@ -28,6 +29,7 @@ const TooltipContent: FC<TooltipContentProps> = ({
     type = "tooltip",
     showCloseButton,
     a11yCloseText,
+    ariaLabelledBy,
     onClose,
     overlayRef,
     arrowRef,
@@ -38,7 +40,14 @@ const TooltipContent: FC<TooltipContentProps> = ({
     const allChildrenExceptFooter = excludeComponent(children, TooltipFooter);
 
     return (
-        <span className={`${type}__overlay`} id={id} role={TYPE_ROLES[type] || null} style={style} ref={overlayRef}>
+        <span
+            className={`${type}__overlay`}
+            id={id}
+            role={TYPE_ROLES[type] || null}
+            aria-labelledby={ariaLabelledBy}
+            style={style}
+            ref={overlayRef}
+        >
             <span className={`${type}__pointer ${type}__pointer--${pointer}`} ref={arrowRef} style={arrowStyle} />
             <span className={`${type}__mask`}>
                 <span className={`${type}__cell`}>

--- a/packages/ebayui-core-react/src/ebay-tourtip/__tests__/index.spec.tsx
+++ b/packages/ebayui-core-react/src/ebay-tourtip/__tests__/index.spec.tsx
@@ -142,4 +142,66 @@ describe("<EbayTourtip>", () => {
             checkIsExpanded(wrapper);
         });
     });
+
+    describe("on region accessible name", () => {
+        it("should assign each simultaneously-rendered tourtip a unique, non-empty heading id", () => {
+            const wrapper = render(
+                <>
+                    <EbayTourtip a11yCloseText="close" pointer="bottom">
+                        <EbayTourtipHost>
+                            <EbayButton>First</EbayButton>
+                        </EbayTourtipHost>
+                        <EbayTourtipHeading type="tourtip">First title</EbayTourtipHeading>
+                        <EbayTourtipContent>
+                            <p>First content</p>
+                        </EbayTourtipContent>
+                    </EbayTourtip>
+                    <EbayTourtip a11yCloseText="close" pointer="bottom">
+                        <EbayTourtipHost>
+                            <EbayButton>Second</EbayButton>
+                        </EbayTourtipHost>
+                        <EbayTourtipHeading type="tourtip">Second title</EbayTourtipHeading>
+                        <EbayTourtipContent>
+                            <p>Second content</p>
+                        </EbayTourtipContent>
+                    </EbayTourtip>
+                </>,
+            );
+
+            const headingIds = Array.from(wrapper.container.querySelectorAll(".tourtip__heading")).map((el) =>
+                el.getAttribute("id"),
+            );
+            expect(headingIds).toHaveLength(2);
+            headingIds.forEach((id) => expect(id).toBeTruthy());
+            expect(new Set(headingIds).size).toBe(headingIds.length);
+
+            const overlays = wrapper.container.querySelectorAll(".tourtip__overlay");
+            overlays.forEach((overlay, i) => {
+                expect(overlay).toHaveAttribute("aria-labelledby", headingIds[i]);
+            });
+        });
+
+        it("should respect a consumer-supplied heading id instead of overriding it", () => {
+            const wrapper = render(
+                <EbayTourtip a11yCloseText="close" pointer="bottom">
+                    <EbayTourtipHost>
+                        <EbayButton>Info</EbayButton>
+                    </EbayTourtipHost>
+                    <EbayTourtipHeading type="tourtip" id="custom-heading-id">
+                        Title
+                    </EbayTourtipHeading>
+                    <EbayTourtipContent>
+                        <p>Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
+                    </EbayTourtipContent>
+                </EbayTourtip>,
+            );
+
+            const heading = wrapper.container.querySelector(".tourtip__heading");
+            expect(heading).toHaveAttribute("id", "custom-heading-id");
+            expect(wrapper.container.querySelector(".tourtip__overlay")).toHaveAttribute(
+                "aria-labelledby",
+                "custom-heading-id",
+            );
+        });
+    });
 });

--- a/packages/ebayui-core-react/src/ebay-tourtip/__tests__/render.spec.tsx
+++ b/packages/ebayui-core-react/src/ebay-tourtip/__tests__/render.spec.tsx
@@ -70,6 +70,9 @@ describe("ebay-tourtip rendering", () => {
 
         const heading = overlay.querySelector(".tourtip__heading");
         expect(heading).toHaveTextContent("Title");
+        expect(heading).toHaveAttribute("id");
+        expect(overlay).toHaveAttribute("aria-labelledby", heading.getAttribute("id"));
+        expect(screen.getByRole("region", { name: "Title" })).toBe(overlay);
 
         const footer: HTMLElement = overlay.querySelector(".tourtip__footer");
         expect(footer.querySelector(".tourtip__index")).toHaveTextContent("1 of 3");

--- a/packages/ebayui-core-react/src/ebay-tourtip/ebay-tourtip.tsx
+++ b/packages/ebayui-core-react/src/ebay-tourtip/ebay-tourtip.tsx
@@ -81,9 +81,12 @@ const EbayTourtip: FC<TourtipProps> = ({
     const heading = findComponent(children, EbayTourtipHeading);
     const footer = findComponent(children, EbayTourtipFooter);
 
-    const headingId = useRandomId();
-    const labelId = heading ? `tourtip-label-${headingId}` : undefined;
-    const labelledHeading = heading ? cloneElement(heading, { id: labelId }) : heading;
+    const generatedHeadingId = useRandomId();
+    const existingHeadingId = heading?.props.id;
+    const labelId = !heading
+        ? undefined
+        : (existingHeadingId ?? (generatedHeadingId ? `tourtip-label-${generatedHeadingId}` : undefined));
+    const labelledHeading = heading && labelId && !existingHeadingId ? cloneElement(heading, { id: labelId }) : heading;
 
     return (
         <Tooltip {...rest} className={className} type="tourtip" isExpanded={isExpanded} ref={containerRef}>

--- a/packages/ebayui-core-react/src/ebay-tourtip/ebay-tourtip.tsx
+++ b/packages/ebayui-core-react/src/ebay-tourtip/ebay-tourtip.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties, FC, useRef } from "react";
+import React, { CSSProperties, FC, cloneElement, useRef } from "react";
 import { findComponent } from "../common/component-utils";
 import {
     Tooltip,
@@ -14,6 +14,7 @@ import EbayTourtipHost from "./ebay-tourtip-host";
 import EbayTourtipFooter from "./ebay-tourtip-footer";
 import EbayTourtipHeading from "./ebay-tourtip-heading";
 import { useFloatingTooltip } from "../common/floating-ui";
+import { useRandomId } from "../common/random-id";
 
 export type TourtipProps = Omit<TooltipProps, "ref"> & {
     a11yCloseText: string;
@@ -80,12 +81,17 @@ const EbayTourtip: FC<TourtipProps> = ({
     const heading = findComponent(children, EbayTourtipHeading);
     const footer = findComponent(children, EbayTourtipFooter);
 
+    const headingId = useRandomId();
+    const labelId = heading ? `tourtip-label-${headingId}` : undefined;
+    const labelledHeading = heading ? cloneElement(heading, { id: labelId }) : heading;
+
     return (
         <Tooltip {...rest} className={className} type="tourtip" isExpanded={isExpanded} ref={containerRef}>
             <TooltipHost {...host.props} forwardedRef={hostRef} aria-label={ariaLabel} aria-expanded={isExpanded} />
             <TooltipContent
                 {...contentProps}
                 a11yCloseText={a11yCloseText}
+                ariaLabelledBy={labelId}
                 onClose={collapseTooltip}
                 pointer={pointer}
                 showCloseButton
@@ -95,7 +101,7 @@ const EbayTourtip: FC<TourtipProps> = ({
                 arrowRef={refs.arrow}
                 arrowStyle={arrowStyles}
             >
-                {heading}
+                {labelledHeading}
                 {contentChildren}
                 {footer && <TooltipFooter type="tourtip">{footer}</TooltipFooter>}
             </TooltipContent>


### PR DESCRIPTION
## Summary

The tour tip's overlay already renders `role="region"` (`TYPE_ROLES.tourtip = "region"` in `common/tooltip-utils/constants.ts`), but a `region` landmark only becomes meaningful to assistive tech once it has an accessible name — and nothing wired one up. That's the actual gap behind this issue: the role attribute is present, but unlabelled, so it isn't identifiable to screen readers in practice.

Confirmed by comparing all three implementations of this component:
- **Skin** (canonical markup): `<div class="tourtip__overlay" role="region" aria-labelledby="tourtip-label">` paired with `<h2 id="tourtip-label">`
- **Marko** (`ebay-tooltip-overlay/index.marko`): already wires `aria-labelledby` on the overlay to a scoped id on the heading
- **React**: sets `role` but never sets `aria-labelledby`, and the heading component never received an id to point to

This PR ports Marko's existing behavior into React:
- `common/tooltip-utils/tooltip-content.tsx`: adds an optional `ariaLabelledBy` prop, rendered on the `${type}__overlay` span alongside the existing `role`. Purely additive — `ebay-tooltip` and `ebay-infotip` (the other two consumers of `TooltipContent`) are unaffected since they don't pass it.
- `ebay-tourtip/ebay-tourtip.tsx`: generates an id via the existing `useRandomId()` utility (same pattern already used in `ebay-section-notice`), clones the heading to carry that id, and passes it through to `TooltipContent` as `ariaLabelledBy`.
- `ebay-tourtip/__tests__/render.spec.tsx`: extends the existing heading test case to assert the region now has an accessible name tied to the heading.

Only `tourtip` is affected. `tooltip`/`infotip` use `role="tooltip"`, which gets its accessible name from the triggering element via `aria-describedby` (already handled in `Tooltip.tsx`), not from `aria-labelledby` on the popup itself.

Fixes #108

## Test plan
- [x] `npx vitest run` (scoped to `ebay-tourtip`, `ebay-tooltip`, `ebay-infotip`) — 57 tests passing, including the updated assertions
- [x] `npm run build` in `packages/ebayui-core-react` — type-check, vite build, and React 16/18/19 smoke tests all green
- [x] Changeset added (`patch` bump for `@ebay/ui-core-react`)
- [ ] Manual check of the `FooterAndHeadingTourtip` story's accessibility tree in Storybook (region name = "Title")

🤖 Generated with [Claude Code](https://claude.com/claude-code)