### PR TITLE
chore(deps-dev): bump @ebay/design-tokens from 2.3.2 to 2.4.1

### DIFF
--- a/.changeset/quiet-otters-dance.md
+++ b/.changeset/quiet-otters-dance.md
@@ -1,0 +1,5 @@
+---
+"@ebay/skin": minor
+---
+
+Update DS tokens

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "@docsearch/css": "^4.4.0",
         "@docsearch/js": "^4.4.0",
         "@ebay/browserslist-config": "^2.13.0",
-        "@ebay/design-tokens": "^2.3.2",
+        "@ebay/design-tokens": "^2.4.0",
         "@ebay/skin": "^19",
         "@floating-ui/dom": "^1.7.4",
         "@marko-tags/subscribe": "npm:noist@^1.0.0",
@@ -3102,9 +3102,9 @@
       "license": "MIT"
     },
     "node_modules/@ebay/design-tokens": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/@ebay/design-tokens/-/design-tokens-2.3.2.tgz",
-      "integrity": "sha512-iMSXafDEIUzviKg35ZzfuJ1ShP3hePF4kkP9+w2eaYDjZKYFuJdwnmHgl3ynXsKkSPX2knhsZ1UeYLO6PgI/ZQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@ebay/design-tokens/-/design-tokens-2.4.0.tgz",
+      "integrity": "sha512-t3aEIOuvY364M+seprEZe5SukHVZRH19FQYM+rkzBDSbZTGXQrAXZaay5C5s094xBG/jfPdk9vXrI5cyCeOZuw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "@docsearch/css": "^4.4.0",
         "@docsearch/js": "^4.4.0",
         "@ebay/browserslist-config": "^2.13.0",
-        "@ebay/design-tokens": "^2.4.0",
+        "@ebay/design-tokens": "^2.4.1",
         "@ebay/skin": "^19",
         "@floating-ui/dom": "^1.7.4",
         "@marko-tags/subscribe": "npm:noist@^1.0.0",
@@ -3102,9 +3102,9 @@
       "license": "MIT"
     },
     "node_modules/@ebay/design-tokens": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@ebay/design-tokens/-/design-tokens-2.4.0.tgz",
-      "integrity": "sha512-t3aEIOuvY364M+seprEZe5SukHVZRH19FQYM+rkzBDSbZTGXQrAXZaay5C5s094xBG/jfPdk9vXrI5cyCeOZuw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@ebay/design-tokens/-/design-tokens-2.4.1.tgz",
+      "integrity": "sha512-Q2ziL3fWz9GTBw4LROxJpEglFftbGdgV/gDCExUfNLWOilI7MU4qWXPCSViohp8XFVxeLtWcbvNpveO/RMg8Kw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@docsearch/css": "^4.4.0",
     "@docsearch/js": "^4.4.0",
     "@ebay/browserslist-config": "^2.13.0",
-    "@ebay/design-tokens": "^2.4.0",
+    "@ebay/design-tokens": "^2.4.1",
     "@ebay/skin": "^19",
     "@floating-ui/dom": "^1.7.4",
     "@marko-tags/subscribe": "npm:noist@^1.0.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@docsearch/css": "^4.4.0",
     "@docsearch/js": "^4.4.0",
     "@ebay/browserslist-config": "^2.13.0",
-    "@ebay/design-tokens": "^2.3.2",
+    "@ebay/design-tokens": "^2.4.0",
     "@ebay/skin": "^19",
     "@floating-ui/dom": "^1.7.4",
     "@marko-tags/subscribe": "npm:noist@^1.0.0",

--- a/packages/skin/dist/tokens/evo-core.css
+++ b/packages/skin/dist/tokens/evo-core.css
@@ -200,7 +200,7 @@
     --expressive-theme-coral-medium-foreground: #2f0e04;
     --expressive-theme-depop-background: #e20020;
     --expressive-theme-depop-foreground: #ffffff;
-    --expressive-theme-depop-inverse-background: #ffffff;
+    --expressive-theme-depop-inverse-background: #f7f7f7;
     --expressive-theme-depop-inverse-foreground: #e20020;
     --expressive-theme-dijon-dark-background: #524500;
     --expressive-theme-dijon-dark-foreground: #fcf9de;

--- a/packages/skin/dist/tokens/evo-core.css
+++ b/packages/skin/dist/tokens/evo-core.css
@@ -32,6 +32,7 @@
     --color-blue-650: #003aa5;
     --color-blue-700: #002a69;
     --color-blue-800: #19133a;
+    --color-brand-depop-red: #e20020;
     --color-clear: rgba(255, 255, 255, 0);
     --color-coral-100: #fff7f5;
     --color-coral-200: #ffe1d7;
@@ -199,6 +200,8 @@
     --expressive-theme-coral-medium-foreground: #2f0e04;
     --expressive-theme-depop-background: #e20020;
     --expressive-theme-depop-foreground: #ffffff;
+    --expressive-theme-depop-inverse-background: #ffffff;
+    --expressive-theme-depop-inverse-foreground: #e20020;
     --expressive-theme-dijon-dark-background: #524500;
     --expressive-theme-dijon-dark-foreground: #fcf9de;
     --expressive-theme-dijon-light-background: #f6e016;


### PR DESCRIPTION
## Summary
- Bump `@ebay/design-tokens` from `2.3.2` to `2.4.1`
- Regenerate `packages/skin/dist/tokens/evo-core.css`:
  - 2.4.0 added 3 new tokens: `--color-brand-depop-red`, `--expressive-theme-depop-inverse-background`, `--expressive-theme-depop-inverse-foreground`
  - 2.4.1 corrects `--expressive-theme-depop-inverse-background` from `#ffffff` to `#f7f7f7`
- Add changeset (`@ebay/skin`: minor) since new tokens were added

## Test plan
- [x] `npm run build` passes across all packages (skin, ebayui-core, evo-marko, ebayui-core-react, evo-react)