### PR TITLE
fix(toggle-button): correct minimal layout min-height to 48px

### DIFF
--- a/.changeset/toggle-button-group-min-height.md
+++ b/.changeset/toggle-button-group-min-height.md
@@ -1,0 +1,11 @@
+---
+"@ebay/skin": patch
+---
+
+fix(toggle-button, toggle-button-group): correct minimal layout min-height to 48px
+
+`--toggle-button-height-min` was set to 72px, the same value as
+`--toggle-button-width-min`, causing the default (minimal) layout to
+render at a 72px min-height instead of the design spec's 48px. The
+variable now reflects the correct height for the minimal layout,
+independent of the width floor.

--- a/packages/skin/dist/toggle-button/toggle-button.css
+++ b/packages/skin/dist/toggle-button/toggle-button.css
@@ -1,5 +1,5 @@
 :root {
-    --toggle-button-height-min: 72px;
+    --toggle-button-height-min: 48px;
     --toggle-button-width-min: 72px;
     --toggle-button-width-max: 342px;
     --toggle-button-list-width-min: 224px;

--- a/packages/skin/src/sass/toggle-button/toggle-button.scss
+++ b/packages/skin/src/sass/toggle-button/toggle-button.scss
@@ -1,7 +1,7 @@
 @use "../variables/variables";
 
 :root {
-    --toggle-button-height-min: 72px;
+    --toggle-button-height-min: 48px;
     --toggle-button-width-min: 72px;
     --toggle-button-width-max: 342px;
     --toggle-button-list-width-min: 224px;

--- a/src/data/component-metadata.json
+++ b/src/data/component-metadata.json
@@ -877,7 +877,7 @@
     "component": "toggle-button-group",
     "ds-component": {
       "name": "toggle-button-group",
-      "version": "1.0"
+      "version": "1.1"
     },
     "submodules": ["toggle-button"],
     "markoStorybookPath": "/docs/buttons-ebay-toggle-button-group--documentation",
@@ -888,7 +888,7 @@
     "component": "toggle-button",
     "ds-component": {
       "name": "toggle-button",
-      "version": "1.0.3"
+      "version": "1.1"
     },
     "submodules": ["icon"],
     "markoStorybookPath": "/docs/buttons-ebay-toggle-button--documentation",

--- a/src/routes/_index/components/toggle-button-group/css+page.marko
+++ b/src/routes/_index/components/toggle-button-group/css+page.marko
@@ -2354,7 +2354,7 @@ export const metadata = {
   component: "toggle-button-group",
   "ds-component": {
     name: "toggle-button-group",
-    version: 1,
+    version: "1.1",
   },
   submodules: ["toggle-button"],
 };

--- a/src/routes/_index/components/toggle-button/css+page.marko
+++ b/src/routes/_index/components/toggle-button/css+page.marko
@@ -1219,7 +1219,7 @@ export const metadata = {
   component: "toggle-button",
   "ds-component": {
     name: "toggle-button",
-    version: "1.0.3",
+    version: "1.1",
   },
   submodules: ["icon"],
 };


### PR DESCRIPTION
## Summary
- `--toggle-button-height-min` was hardcoded to 72px (the same value as `--toggle-button-width-min`), causing the default/minimal layout to render at a 72px min-height instead of the v1.1 design spec's 48px.
- Corrected the variable in `toggle-button.scss` (and regenerated `dist/`) so both the standalone `toggle-button` and grouped `toggle-button-group` `<li>` pick up the right floor.
- Bumped `ds-component` version to `1.1` for both `toggle-button` and `toggle-button-group` (in `component-metadata.json` and each component's docs page metadata) to reflect the corrected spec.
- Added a changeset (`@ebay/skin`: patch).

Fixes #647

## Test plan
- [x] Ran `npm run build` for `@ebay/skin` — passes lint/build.
- [x] Verified in Storybook (`skin-toggle-button-minimal-layout--*`) that computed `min-height` is now `48px` / `min-width` stays `72px`.
- [x] Spot-checked List Layout, Gallery Layout, and Toggle Button Group (Minimal + List) stories, toggled-on/off, disabled, and aria-disabled states — no clipping or alignment regressions since content-driven layouts already exceed the new floor.
- [x] Full monorepo build/smoke tests passed via pre-push hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)