### PR TITLE
fix(icon-button): remove unwashed border ring on hover/focus/active

### DIFF
--- a/.changeset/icon-button-hover-border-ring.md
+++ b/.changeset/icon-button-hover-border-ring.md
@@ -1,0 +1,19 @@
+---
+"@ebay/skin": patch
+---
+
+fix(icon-button): remove unwashed border ring on hover/focus/active
+
+The base (borderless) `icon-btn`/`icon-link` variant reserves a
+transparent 2px border for consistent sizing across variants, and the
+button's own `background-color` paints straight through it via the
+default `background-clip: border-box`. The hover/focus/active
+state-layer wash, however, was inset to the padding edge, leaving a
+thin ring of unwashed background color visible around the edge on
+hover, focus, and active states.
+
+Extends the wash to cover the full border-box and sets `overflow:
+visible` (the state-layer mixin's `overflow: hidden` was clipping the
+wash back to the padding edge regardless of its own positioning).
+Variants with a visible border (primary/secondary/tertiary) are
+unaffected — their border remains crisp and unwashed as before.

--- a/packages/skin/dist/icon-button/icon-button.css
+++ b/packages/skin/dist/icon-button/icon-button.css
@@ -67,6 +67,30 @@ a.icon-link:not(:focus-visible),
 button.icon-btn:not(:focus-visible) {
     outline: none;
 }
+a.icon-link:not(
+        .icon-link--primary,
+        .icon-link--secondary,
+        .icon-link--tertiary
+    ),
+button.icon-btn:not(
+        .icon-btn--primary,
+        .icon-btn--secondary,
+        .icon-btn--tertiary
+    ) {
+    overflow: visible;
+}
+a.icon-link:not(
+        .icon-link--primary,
+        .icon-link--secondary,
+        .icon-link--tertiary
+    ):after,
+button.icon-btn:not(
+        .icon-btn--primary,
+        .icon-btn--secondary,
+        .icon-btn--tertiary
+    ):after {
+    inset: -2px;
+}
 a.icon-link.icon-link--primary,
 button.icon-btn.icon-btn--primary {
     background-color: var(--color-background-accent);

--- a/packages/skin/src/sass/icon-button/icon-button.scss
+++ b/packages/skin/src/sass/icon-button/icon-button.scss
@@ -39,6 +39,30 @@ a.icon-link {
     }
 }
 
+/* the base variant's border is transparent (reserved space only), but the hover/focus/active
+   state-layer wash is inset to the padding edge, leaving a 2px ring of unwashed background
+   visible around the edge. Extend the wash to the border edge so no ring shows; `overflow: visible`
+   is required too, since `overflow: hidden` (set above via the state-layer mixin) clips descendants
+   at the padding edge regardless of their own inset — the wash's own border-radius (matching the
+   button's) keeps it round without needing that clip. Variants with a visible border
+   (primary/secondary/tertiary) keep the default inset/overflow so their border stays crisp. */
+button.icon-btn:not(
+        .icon-btn--primary,
+        .icon-btn--secondary,
+        .icon-btn--tertiary
+    ),
+a.icon-link:not(
+        .icon-link--primary,
+        .icon-link--secondary,
+        .icon-link--tertiary
+    ) {
+    overflow: visible;
+
+    &::after {
+        inset: -2px;
+    }
+}
+
 button.icon-btn.icon-btn--primary,
 a.icon-link.icon-link--primary {
     background-color: var(--color-background-accent);


### PR DESCRIPTION
## Summary
- The base (borderless) `icon-btn`/`icon-link` variant reserves a transparent 2px border for consistent sizing across variants. The button's own `background-color` paints straight through that transparent border via the default `background-clip: border-box`, giving a solid-looking circle at rest.
- The hover/focus/active state-layer wash (a `::after` overlay) was inset to the *padding* edge instead of the border edge, leaving a thin ring of unwashed background color visible around the edge on hover/focus/active — this is what was reported as "border color isn't being set properly on hover".
- Fix extends the wash to the full border-box and adds `overflow: visible`, since `overflow: hidden` (set by the shared state-layer mixin) was clipping the wash back to the padding edge regardless of its own inset.
- Scoped to only the borderless variants — `primary`/`secondary`/`tertiary` (which have a real, visible border) are unaffected and keep their crisp, unwashed border.
- Added a changeset (`@ebay/skin`: patch).

Fixes #671

## Test plan
- [x] Verified via computed styles and direct pixel sampling (not just visual inspection) that the hover wash now transitions cleanly from the page background straight into the washed fill, with no intermediate unwashed ring band.
- [x] Confirmed `secondary`/`tertiary` variants are unaffected (`overflow: hidden` / `inset: 0` unchanged, border stays crisp on hover).
- [x] Manually spot-checked in the docs site and Storybook.
- [x] Full monorepo build/smoke tests passed via pre-push hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)