### PR TITLE
fix(ci): include hidden Percy metadata files in Storybook artifact upload

### DIFF
--- a/.github/workflows/percy-build.yml
+++ b/.github/workflows/percy-build.yml
@@ -66,3 +66,4 @@ jobs:
           name: storybook-static
           path: packages/skin/_site/public/storybook
           retention-days: 1
+          include-hidden-files: true


### PR DESCRIPTION
## Summary
- Every PR-triggered "Percy Snapshots (PR)" run has been failing since the two-workflow security split introduced in #673 (2026-05-15) — confirmed by checking the last 20 `percy.yml` runs, all `workflow_run`-triggered (PR) runs fail; only `push`-triggered baseline runs on `main` succeed.
- Root cause: `actions/upload-artifact@v4` defaults `include-hidden-files` to `false`, which silently strips dotfiles from the uploaded artifact. The "Percy Build" workflow writes its handoff metadata as dotfiles (`.percy-components`, `.percy-pr-number`, `.percy-commit`, `.percy-branch`) into the Storybook output directory before uploading it as an artifact — those four files were being dropped on every upload.
- The downstream "Percy Snapshots (PR)" job then can't find `.percy-components`, `tr` fails, and because the step runs under `bash -e`, the script aborts before it can write the closing `EOF` marker it already opened in `$GITHUB_OUTPUT` — producing the confusing `Invalid value. Matching delimiter not found 'EOF'` error instead of a clear "file not found."
- Fix: set `include-hidden-files: true` on the "Upload Storybook artifact" step in `percy-build.yml`.

Why this wasn't caught earlier: prior to #673, this all ran in a single `pull_request_target`-triggered job with no artifact boundary at all — the changed-components detection and the Percy run happened in the same job, wired together with an ordinary step output. The #673 refactor split things into two workflows for a legitimate security reason (avoid running untrusted PR code with `PERCY_TOKEN` secret access), which required moving the handoff to an artifact — and that's exactly where this bug was introduced, silently, from day one of that split.

## Test plan
- [ ] Confirm the next PR-triggered Percy Build → Percy Snapshots run completes the "Read Percy metadata" step successfully and actually runs Percy snapshots against the PR's changed components.

🤖 Generated with [Claude Code](https://claude.com/claude-code)