### PR TITLE
feat(evo-react): add filter chip

### DIFF
--- a/.changeset/bright-chips-filter.md
+++ b/.changeset/bright-chips-filter.md
@@ -1,0 +1,5 @@
+---
+"@evo-web/react": patch
+---
+
+Add EvoFilterChip component.

--- a/.claude/skills/evo-app-migrate-react/SKILL.md
+++ b/.claude/skills/evo-app-migrate-react/SKILL.md
@@ -72,6 +72,7 @@ When migrating a listed component, read the linked file completely and apply the
 | `ebay-character-count`      | [evo-character-count.md](components/evo-character-count.md) |
 | `ebay-details`              | [evo-details.md](components/evo-details.md)                 |
 | `ebay-confirm-dialog`       | [evo-confirm-dialog.md](components/evo-confirm-dialog.md)   |
+| `ebay-filter-chip`          | [evo-filter-chip.md](components/evo-filter-chip.md)         |
 | `ebay-icon-button`          | [evo-icon-button.md](components/evo-icon-button.md)         |
 
 ---

--- a/.claude/skills/evo-app-migrate-react/components/evo-filter-chip.md
+++ b/.claude/skills/evo-app-migrate-react/components/evo-filter-chip.md
@@ -1,0 +1,18 @@
+# ebay-filter-chip → evo-filter-chip
+
+## Import path
+
+```diff
+- import { EbayFilterChip } from "@ebay/ui-core-react/ebay-filter-chip";
++ import { EvoFilterChip } from "@evo-web/react/filter-chip";
+```
+
+## Prop changes
+
+| ebayui-core-react                        | evo-react                                        | Notes                                                                                                 |
+| ---------------------------------------- | ------------------------------------------------ | ----------------------------------------------------------------------------------------------------- |
+| `expanded`                               | `open`                                           | Controlled open state for the menu variant.                                                           |
+| `defaultExpanded`                        | `defaultOpen`                                    | Initial uncontrolled open state for the menu variant.                                                 |
+| `a11ySelectedText`                       | `a11ySelectedText`                               | No longer defaults to `"Filter Applied"` and is required with `href`; pass localized text explicitly. |
+| `onClick(event, { selected, expanded })` | `onClick(event, data)`                           | Menu variants receive `{ open }`; default, expressive, and anchor variants receive `{ selected }`.    |
+| `FilterChipEvent`                        | `FilterChipSelectedEvent \| FilterChipOpenEvent` | Narrow event data using `"selected" in data` or `"open" in data`.                                     |

--- a/packages/evo-react/src/filter-chip/README.md
+++ b/packages/evo-react/src/filter-chip/README.md
@@ -1,0 +1,5 @@
+# EvoFilterChip
+
+## Documentation
+
+[Storybook](https://opensource.ebay.com/evo-web/react/?path=/docs/form-input-evo-filter-chip--documentation)

--- a/packages/evo-react/src/filter-chip/filter-chip.stories.tsx
+++ b/packages/evo-react/src/filter-chip/filter-chip.stories.tsx
@@ -1,0 +1,100 @@
+import type { ComponentType } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { EvoIconSneaker16 } from "../icon/icons/sneaker-16";
+import { EvoFilterChip } from "./filter-chip";
+import type { EvoFilterChipProps } from "./types";
+
+const meta: Meta<EvoFilterChipProps> = {
+  title: "form input/evo-filter-chip",
+  component: EvoFilterChip as ComponentType<EvoFilterChipProps>,
+  tags: ["autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component: `
+A filter control that supports toggle-button, menu-button, expressive, and anchor variants.
+
+## Usage
+
+\`\`\`tsx
+import { EvoFilterChip } from "@evo-web/react/filter-chip";
+\`\`\`
+        `,
+      },
+    },
+  },
+  argTypes: {
+    variant: {
+      control: "select",
+      options: ["default", "expressive", "menu"],
+      description:
+        "Visual and interaction variant. Menu variants toggle open state; all others toggle selected state.",
+    },
+    selected: {
+      control: "boolean",
+      description: "Controlled selected state.",
+    },
+    defaultSelected: {
+      control: "boolean",
+      description: "Initial selected state when uncontrolled.",
+    },
+    open: {
+      control: "boolean",
+      description: "Controlled open state for the menu variant.",
+    },
+    defaultOpen: {
+      control: "boolean",
+      description: "Initial open state for an uncontrolled menu variant.",
+    },
+    disabled: {
+      control: "boolean",
+      description: "Disables interaction.",
+    },
+    href: {
+      control: "text",
+      description:
+        "Link destination. Requires a11ySelectedText and is unavailable for the menu variant.",
+    },
+    a11ySelectedText: {
+      type: "string",
+      control: "text",
+      description:
+        "Localized clipped text announced when an anchor or menu filter is selected. Required with href.",
+    },
+    icon: {
+      control: false,
+      description: "Leading icon rendered by the default variant.",
+    },
+    image: {
+      control: false,
+      description: "Leading image rendered by the expressive variant.",
+    },
+    onClick: {
+      action: "onClick",
+      description:
+        "Triggered with the click event and `{ selected }`, or `{ open }` for menu variants.",
+      table: { category: "Events" },
+    },
+    children: {
+      control: "text",
+      description: "Filter label.",
+    },
+  },
+  args: {
+    children: "Filter",
+    variant: "default",
+    icon: <EvoIconSneaker16 />,
+    image: (
+      <img
+        src="https://ir.ebaystatic.com/cr/v/c01/skin/docs/dog_profile2.png"
+        alt="Category"
+      />
+    ),
+    a11ySelectedText: "Filter Applied",
+  },
+};
+
+export default meta;
+type Story = StoryObj<EvoFilterChipProps>;
+
+export const Default: Story = {};

--- a/packages/evo-react/src/filter-chip/filter-chip.tsx
+++ b/packages/evo-react/src/filter-chip/filter-chip.tsx
@@ -1,0 +1,139 @@
+import { useLayoutEffect, useState } from "react";
+import type { ComponentProps, JSX, MouseEvent, Ref } from "react";
+import classNames from "classnames";
+import { EvoIconChevronDown12 } from "../icon/icons/chevron-down-12";
+import { useRefTee } from "../utils/use-ref-tee";
+import type {
+  AnchorFilterChipProps,
+  EvoFilterChipProps,
+  MenuFilterChipProps,
+  NativeFilterChipProps,
+} from "./types";
+import "@ebay/skin/filter-chip.mjs";
+
+export function EvoFilterChip(props: AnchorFilterChipProps): JSX.Element;
+export function EvoFilterChip(props: MenuFilterChipProps): JSX.Element;
+export function EvoFilterChip(props: NativeFilterChipProps): JSX.Element;
+export function EvoFilterChip({
+  children,
+  selected: selectedProp,
+  defaultSelected = false,
+  open: openProp,
+  defaultOpen = false,
+  variant = "default",
+  icon,
+  image,
+  a11ySelectedText,
+  href,
+  className,
+  onClick,
+  disabled,
+  ref,
+  ...rest
+}: EvoFilterChipProps) {
+  const [uncontrolledSelected, setUncontrolledSelected] =
+    useState(defaultSelected);
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(defaultOpen);
+  const selected =
+    selectedProp !== undefined ? selectedProp : uncontrolledSelected;
+  const open = openProp !== undefined ? openProp : uncontrolledOpen;
+  const isMenu = variant === "menu";
+  const isAnchor = Boolean(href && a11ySelectedText && !isMenu);
+  const [rootRef, internalRootRef] = useRefTee<
+    HTMLAnchorElement | HTMLButtonElement | null
+  >(ref as Ref<HTMLAnchorElement | HTMLButtonElement | null>, null);
+
+  useLayoutEffect(() => {
+    internalRootRef.current?.classList.add("filter-chip--animated");
+  }, [internalRootRef]);
+
+  const rootClassName = classNames(
+    "filter-chip",
+    variant === "expressive" && "filter-chip--expressive",
+    (isAnchor || isMenu) && selected && "filter-chip--selected",
+    className,
+  );
+
+  const content = (
+    <>
+      {variant === "expressive" && (
+        <span className="filter-chip__media">{image}</span>
+      )}
+      {variant === "default" && icon}
+      <span className="filter-chip__text">
+        {children}
+        {selected && (isAnchor || isMenu) && (
+          <span className="clipped"> - {a11ySelectedText}</span>
+        )}
+      </span>
+      {isMenu && <EvoIconChevronDown12 className="filter-chip__trailing" />}
+    </>
+  );
+
+  if (isAnchor) {
+    const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
+      if (disabled) {
+        return;
+      }
+
+      const nextSelected = !selected;
+      if (selectedProp === undefined) {
+        setUncontrolledSelected(nextSelected);
+      }
+      (onClick as AnchorFilterChipProps["onClick"])?.(event, {
+        selected: nextSelected,
+      });
+    };
+
+    return (
+      <a
+        {...(rest as ComponentProps<"a">)}
+        ref={rootRef}
+        className={rootClassName}
+        href={disabled ? undefined : href}
+        onClick={handleClick}
+      >
+        {content}
+      </a>
+    );
+  }
+
+  const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
+    if (disabled) {
+      return;
+    }
+
+    if (isMenu) {
+      const nextOpen = !open;
+      if (openProp === undefined) {
+        setUncontrolledOpen(nextOpen);
+      }
+      (onClick as MenuFilterChipProps["onClick"])?.(event, {
+        open: nextOpen,
+      });
+    } else {
+      const nextSelected = !selected;
+      if (selectedProp === undefined) {
+        setUncontrolledSelected(nextSelected);
+      }
+      (onClick as NativeFilterChipProps["onClick"])?.(event, {
+        selected: nextSelected,
+      });
+    }
+  };
+
+  return (
+    <button
+      {...(rest as ComponentProps<"button">)}
+      ref={rootRef}
+      type="button"
+      disabled={disabled}
+      aria-selected={!isMenu ? (selected ? "true" : "false") : undefined}
+      aria-expanded={isMenu ? (open ? "true" : "false") : undefined}
+      className={rootClassName}
+      onClick={handleClick}
+    >
+      {content}
+    </button>
+  );
+}

--- a/packages/evo-react/src/filter-chip/index.ts
+++ b/packages/evo-react/src/filter-chip/index.ts
@@ -1,0 +1,11 @@
+export { EvoFilterChip } from "./filter-chip";
+export type {
+  AnchorFilterChipProps,
+  EvoFilterChipProps,
+  FilterChipEvent,
+  FilterChipOpenEvent,
+  FilterChipSelectedEvent,
+  FilterChipVariant,
+  MenuFilterChipProps,
+  NativeFilterChipProps,
+} from "./types";

--- a/packages/evo-react/src/filter-chip/test/__snapshots__/test.server.tsx.snap
+++ b/packages/evo-react/src/filter-chip/test/__snapshots__/test.server.tsx.snap
@@ -1,0 +1,17 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`EvoFilterChip SSR > passes HTML attributes to the root 1`] = `"<button data-testid="filter-chip" type="button" aria-selected="false" class="filter-chip custom-class"><span class="filter-chip__text">Filter</span></button>"`;
+
+exports[`EvoFilterChip SSR > renders a disabled anchor without href 1`] = `"<a class="filter-chip"><span class="filter-chip__text">Filter</span></a>"`;
+
+exports[`EvoFilterChip SSR > renders the anchor variant selected 1`] = `"<a class="filter-chip filter-chip--selected" href="/filter"><span class="filter-chip__text">Filter<span class="clipped"> - <!-- -->Filter Applied</span></span></a>"`;
+
+exports[`EvoFilterChip SSR > renders the default variant 1`] = `"<button type="button" aria-selected="false" class="filter-chip"><span class="filter-chip__text">Filter</span></button>"`;
+
+exports[`EvoFilterChip SSR > renders the default variant selected 1`] = `"<button type="button" aria-selected="true" class="filter-chip"><span class="filter-chip__text">Filter</span></button>"`;
+
+exports[`EvoFilterChip SSR > renders the default variant with an icon 1`] = `"<button type="button" aria-selected="false" class="filter-chip"><svg class="icon icon--16" xmlns="http://www.w3.org/2000/svg" focusable="false" aria-hidden="true"><use xlink:href="#icon-sneaker-16"></use><defs><symbol viewBox="0 0 16 16" id="icon-sneaker-16"><path fill-rule="evenodd" d="M4.17 3A3.001 3.001 0 0 1 7 1c1.826 0 2.667 1.549 2.97 2.757l.394 1.575 4.073 2.222A3 3 0 0 1 16 10.187V11a3 3 0 0 1-3 3H2.5A2.5 2.5 0 0 1 0 11.5v-6A2.5 2.5 0 0 1 2.5 3h1.67ZM6 4a1 1 0 0 1 1-1c.629 0 .903.737 1.03 1.243l.263 1.05-1 1a1 1 0 0 0 1.414 1.414l.648-.648c.248.145.505.277.758.414l-.82.82a1 1 0 0 0 1.414 1.414l1.236-1.236 1.536.838a1 1 0 0 1 .521.878V11a1 1 0 0 1-1 1H7v-.5A2.5 2.5 0 0 0 4.5 9H2V8h1.5A2.5 2.5 0 0 0 6 5.5V4Zm-1 8v-.5a.5.5 0 0 0-.5-.5H2v.5a.5.5 0 0 0 .5.5H5ZM2.5 5H4v.5a.5.5 0 0 1-.5.5H2v-.5a.5.5 0 0 1 .5-.5Z" clip-rule="evenodd"/></symbol></defs></svg><span class="filter-chip__text">Filter</span></button>"`;
+
+exports[`EvoFilterChip SSR > renders the expressive variant 1`] = `"<link rel="preload" as="image" href="/category.jpg"/><button type="button" aria-selected="false" class="filter-chip filter-chip--expressive"><span class="filter-chip__media"><img src="/category.jpg" alt="Category"/></span><span class="filter-chip__text">Category</span></button>"`;
+
+exports[`EvoFilterChip SSR > renders the menu variant selected and open 1`] = `"<button type="button" aria-expanded="true" class="filter-chip filter-chip--selected"><span class="filter-chip__text">Price<span class="clipped"> - <!-- -->Filter Applied</span></span><svg class="icon icon--12 filter-chip__trailing" xmlns="http://www.w3.org/2000/svg" focusable="false" aria-hidden="true"><use xlink:href="#icon-chevron-down-12"></use><defs><symbol viewBox="0 0 12 12" id="icon-chevron-down-12"><path fill-rule="evenodd" clip-rule="evenodd" d="M1.808 4.188a.625.625 0 0 1 .884 0L6 7.495l3.308-3.307a.625.625 0 1 1 .884.885l-3.75 3.749a.625.625 0 0 1-.884 0l-3.75-3.749a.626.626 0 0 1 0-.885Z"/></symbol></defs></svg></button>"`;

--- a/packages/evo-react/src/filter-chip/test/test.browser.tsx
+++ b/packages/evo-react/src/filter-chip/test/test.browser.tsx
@@ -1,0 +1,225 @@
+import { createRef } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { userEvent } from "vitest/browser";
+import { render } from "vitest-browser-react";
+import { EvoIconSneaker16 } from "../../icon/icons/sneaker-16";
+import { EvoFilterChip } from "../filter-chip";
+
+describe("evo-filter-chip", () => {
+  let user: ReturnType<typeof userEvent.setup>;
+
+  beforeEach(() => {
+    user = userEvent.setup();
+  });
+
+  afterEach(() => {
+    user.cleanup();
+  });
+
+  describe("default variant", () => {
+    it("toggles uncontrolled selected state and emits selected data", async () => {
+      const onClick = vi.fn();
+      const screen = await render(
+        <EvoFilterChip onClick={onClick}>Filter</EvoFilterChip>,
+      );
+      const button = screen.getByRole("button");
+
+      await expect.element(button).toHaveAttribute("aria-selected", "false");
+      await user.click(button);
+      await expect.element(button).toHaveAttribute("aria-selected", "true");
+      expect(onClick).toHaveBeenLastCalledWith(expect.any(Object), {
+        selected: true,
+      });
+
+      await user.click(button);
+      await expect.element(button).toHaveAttribute("aria-selected", "false");
+      expect(onClick).toHaveBeenLastCalledWith(expect.any(Object), {
+        selected: false,
+      });
+    });
+
+    it("does not change controlled selected state", async () => {
+      const onClick = vi.fn();
+      const screen = await render(
+        <EvoFilterChip selected={false} onClick={onClick}>
+          Filter
+        </EvoFilterChip>,
+      );
+      const button = screen.getByRole("button");
+
+      await user.click(button);
+
+      await expect.element(button).toHaveAttribute("aria-selected", "false");
+      expect(onClick).toHaveBeenCalledWith(expect.any(Object), {
+        selected: true,
+      });
+    });
+
+    it("renders an individual icon component", async () => {
+      const screen = await render(
+        <EvoFilterChip icon={<EvoIconSneaker16 />}>Filter</EvoFilterChip>,
+      );
+      const button = screen.getByRole("button");
+      // Decorative icons are hidden from the accessibility tree.
+      const icon = button.element().querySelector("svg");
+
+      expect(icon).not.toBeNull();
+      await expect.element(icon!).toHaveClass("icon--16");
+    });
+  });
+
+  describe("menu variant", () => {
+    it("toggles uncontrolled open state and emits open data", async () => {
+      const onClick = vi.fn();
+      const screen = await render(
+        <EvoFilterChip variant="menu" onClick={onClick}>
+          Price
+        </EvoFilterChip>,
+      );
+      const button = screen.getByRole("button");
+
+      await expect.element(button).toHaveAttribute("aria-expanded", "false");
+      await expect.element(button).not.toHaveAttribute("aria-selected");
+
+      await user.click(button);
+      await expect.element(button).toHaveAttribute("aria-expanded", "true");
+      expect(onClick).toHaveBeenLastCalledWith(expect.any(Object), {
+        open: true,
+      });
+
+      await user.click(button);
+      await expect.element(button).toHaveAttribute("aria-expanded", "false");
+      expect(onClick).toHaveBeenLastCalledWith(expect.any(Object), {
+        open: false,
+      });
+    });
+
+    it("does not change controlled open state", async () => {
+      const onClick = vi.fn();
+      const screen = await render(
+        <EvoFilterChip variant="menu" open={false} onClick={onClick}>
+          Price
+        </EvoFilterChip>,
+      );
+      const button = screen.getByRole("button");
+
+      await user.click(button);
+
+      await expect.element(button).toHaveAttribute("aria-expanded", "false");
+      expect(onClick).toHaveBeenCalledWith(expect.any(Object), {
+        open: true,
+      });
+    });
+
+    it("renders selected styling and accessibility text", async () => {
+      const screen = await render(
+        <EvoFilterChip
+          variant="menu"
+          selected
+          a11ySelectedText="Filter Applied"
+        >
+          Price
+        </EvoFilterChip>,
+      );
+      const button = screen.getByRole("button");
+
+      await expect.element(button).toHaveClass("filter-chip--selected");
+      await expect
+        .element(screen.getByText("- Filter Applied"))
+        .toBeInTheDocument();
+    });
+  });
+
+  describe("anchor variant", () => {
+    it("toggles selected state and emits selected data", async () => {
+      const onClick = vi.fn((event) => event.preventDefault());
+      const screen = await render(
+        <EvoFilterChip
+          href="/filter"
+          a11ySelectedText="Filter Applied"
+          onClick={onClick}
+        >
+          Filter
+        </EvoFilterChip>,
+      );
+      const link = screen.getByRole("link");
+
+      await user.click(link);
+
+      await expect.element(link).toHaveClass("filter-chip--selected");
+      await expect
+        .element(screen.getByText("- Filter Applied"))
+        .toBeInTheDocument();
+      expect(onClick).toHaveBeenCalledWith(expect.any(Object), {
+        selected: true,
+      });
+    });
+
+    it("removes href and does not emit click when disabled", async () => {
+      const onClick = vi.fn();
+      const screen = await render(
+        <EvoFilterChip
+          href="/filter"
+          a11ySelectedText="Filter Applied"
+          disabled
+          onClick={onClick}
+        >
+          Filter
+        </EvoFilterChip>,
+      );
+      const text = screen.getByText("Filter");
+      const anchor = text.element().closest("a");
+
+      expect(anchor).not.toBeNull();
+      await expect.element(anchor!).not.toHaveAttribute("href");
+      await user.click(text);
+      expect(onClick).not.toHaveBeenCalled();
+    });
+  });
+
+  it("renders expressive media", async () => {
+    const screen = await render(
+      <EvoFilterChip
+        variant="expressive"
+        image={<img src="/category.jpg" alt="Category" />}
+      >
+        Category
+      </EvoFilterChip>,
+    );
+
+    await expect
+      .element(screen.getByRole("img", { name: "Category" }))
+      .toHaveAttribute("src", "/category.jpg");
+  });
+
+  it("passes attributes and ref to the root element", async () => {
+    const ref = createRef<HTMLButtonElement>();
+    const screen = await render(
+      <EvoFilterChip
+        ref={ref}
+        className="custom-class"
+        data-testid="filter-chip"
+      >
+        Filter
+      </EvoFilterChip>,
+    );
+    const button = screen.getByTestId("filter-chip");
+
+    await expect.element(button).toHaveClass("custom-class");
+    await expect.element(button).toHaveClass("filter-chip--animated");
+    expect(ref.current).toBe(button.element());
+  });
+
+  it("does not emit click when disabled", async () => {
+    const onClick = vi.fn();
+    const screen = await render(
+      <EvoFilterChip disabled onClick={onClick}>
+        Filter
+      </EvoFilterChip>,
+    );
+    const button = screen.getByRole("button");
+
+    await expect.element(button).toBeDisabled();
+    expect(onClick).not.toHaveBeenCalled();
+  });
+});

--- a/packages/evo-react/src/filter-chip/test/test.server.tsx
+++ b/packages/evo-react/src/filter-chip/test/test.server.tsx
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { renderToString } from "react-dom/server";
+import { EvoIconSneaker16 } from "../../icon/icons/sneaker-16";
+import { EvoFilterChip } from "../filter-chip";
+
+describe("EvoFilterChip SSR", () => {
+  it("renders the default variant", () => {
+    expect(
+      renderToString(<EvoFilterChip>Filter</EvoFilterChip>),
+    ).toMatchSnapshot();
+  });
+
+  it("renders the default variant selected", () => {
+    expect(
+      renderToString(<EvoFilterChip selected>Filter</EvoFilterChip>),
+    ).toMatchSnapshot();
+  });
+
+  it("renders the default variant with an icon", () => {
+    expect(
+      renderToString(
+        <EvoFilterChip icon={<EvoIconSneaker16 />}>Filter</EvoFilterChip>,
+      ),
+    ).toMatchSnapshot();
+  });
+
+  it("renders the expressive variant", () => {
+    expect(
+      renderToString(
+        <EvoFilterChip
+          variant="expressive"
+          image={<img src="/category.jpg" alt="Category" />}
+        >
+          Category
+        </EvoFilterChip>,
+      ),
+    ).toMatchSnapshot();
+  });
+
+  it("renders the menu variant selected and open", () => {
+    expect(
+      renderToString(
+        <EvoFilterChip
+          variant="menu"
+          selected
+          open
+          a11ySelectedText="Filter Applied"
+        >
+          Price
+        </EvoFilterChip>,
+      ),
+    ).toMatchSnapshot();
+  });
+
+  it("renders the anchor variant selected", () => {
+    expect(
+      renderToString(
+        <EvoFilterChip
+          href="/filter"
+          a11ySelectedText="Filter Applied"
+          selected
+        >
+          Filter
+        </EvoFilterChip>,
+      ),
+    ).toMatchSnapshot();
+  });
+
+  it("renders a disabled anchor without href", () => {
+    expect(
+      renderToString(
+        <EvoFilterChip
+          href="/filter"
+          a11ySelectedText="Filter Applied"
+          disabled
+        >
+          Filter
+        </EvoFilterChip>,
+      ),
+    ).toMatchSnapshot();
+  });
+
+  it("passes HTML attributes to the root", () => {
+    expect(
+      renderToString(
+        <EvoFilterChip className="custom-class" data-testid="filter-chip">
+          Filter
+        </EvoFilterChip>,
+      ),
+    ).toMatchSnapshot();
+  });
+});

--- a/packages/evo-react/src/filter-chip/types.ts
+++ b/packages/evo-react/src/filter-chip/types.ts
@@ -1,0 +1,70 @@
+import type {
+  ComponentProps,
+  MouseEvent,
+  ReactElement,
+  ReactNode,
+} from "react";
+
+export type FilterChipVariant = "default" | "expressive";
+
+export type FilterChipSelectedEvent = {
+  selected: boolean;
+};
+
+export type FilterChipOpenEvent = {
+  open: boolean;
+};
+
+export type FilterChipEvent = FilterChipSelectedEvent | FilterChipOpenEvent;
+
+type BaseFilterChipProps = {
+  children?: ReactNode;
+  selected?: boolean;
+  defaultSelected?: boolean;
+  icon?: ReactElement;
+  image?: ReactElement<ComponentProps<"img">>;
+  a11ySelectedText?: string;
+  disabled?: boolean;
+};
+
+export type AnchorFilterChipProps = Omit<ComponentProps<"a">, "onClick"> &
+  BaseFilterChipProps & {
+    href: string;
+    a11ySelectedText: string;
+    variant?: FilterChipVariant;
+    open?: never;
+    defaultOpen?: never;
+    onClick?: (
+      event: MouseEvent<HTMLAnchorElement>,
+      data: FilterChipSelectedEvent,
+    ) => void;
+  };
+
+export type NativeFilterChipProps = Omit<ComponentProps<"button">, "onClick"> &
+  BaseFilterChipProps & {
+    href?: never;
+    variant?: FilterChipVariant;
+    open?: never;
+    defaultOpen?: never;
+    onClick?: (
+      event: MouseEvent<HTMLButtonElement>,
+      data: FilterChipSelectedEvent,
+    ) => void;
+  };
+
+export type MenuFilterChipProps = Omit<ComponentProps<"button">, "onClick"> &
+  BaseFilterChipProps & {
+    href?: never;
+    variant: "menu";
+    open?: boolean;
+    defaultOpen?: boolean;
+    onClick?: (
+      event: MouseEvent<HTMLButtonElement>,
+      data: FilterChipOpenEvent,
+    ) => void;
+  };
+
+export type EvoFilterChipProps =
+  | AnchorFilterChipProps
+  | NativeFilterChipProps
+  | MenuFilterChipProps;


### PR DESCRIPTION
- Fixes #222 and #225 that closes out #129 

## Description

- Add `EvoFilterChip` with typed overloads for native button, anchor, and menu variants.
- Support controlled and uncontrolled selected/open state with variant-specific `onClick` data.
- Add Storybook documentation, browser coverage, SSR snapshots, migration guidance, and a patch changeset.

## Notes

- `a11ySelectedText` has no default and is required for anchor usage.
- `aria-selected` behavior matches the evo-marko component.

## Screenshots

N/A — this React migration uses the existing Skin filter-chip styles without CSS changes.

## Checklist

- [x] I verify the linked issue has been triaged ("Needs Triage" label removed)
- [x] I verify all changes are within scope of the linked issue
- [x] I added/updated/removed testing (Storybook in Skin) coverage as appropriate