### PR TITLE
fix(page-notice, section-notice): remove bold font weight from all links

### DIFF
--- a/.changeset/section-page-notice-unbold-links.md
+++ b/.changeset/section-page-notice-unbold-links.md
@@ -1,0 +1,14 @@
+---
+"@ebay/skin": patch
+---
+
+fix(page-notice, section-notice): remove bold font weight from all links
+
+`__main` and `__footer` links/`button.fake-link` elements were still
+rendering bold, left over from a prior fix (#648) that only excluded
+`__cta` links from the bold rule under the assumption that `__main`/
+`__footer` were prose slots. In practice, `__footer` is commonly used
+for a single action link (as the "with action" example demonstrates),
+and no bolded links appear anywhere in the Playbook spec for either
+component. Removes the bold rule entirely so links are normal weight
+regardless of which slot they render in.

--- a/packages/skin/dist/page-notice/page-notice.css
+++ b/packages/skin/dist/page-notice/page-notice.css
@@ -50,12 +50,6 @@ span[role="region"].page-notice {
 .page-notice button.fake-link:hover {
     color: var(--page-notice-color, var(--color-foreground-on-inverse));
 }
-.page-notice__footer a,
-.page-notice__footer button.fake-link,
-.page-notice__main a,
-.page-notice__main button.fake-link {
-    font-weight: 700;
-}
 .page-notice a:focus-visible,
 .page-notice button.fake-link:focus-visible {
     outline: 2px solid var(--color-foreground-on-inverse);

--- a/packages/skin/dist/section-notice/section-notice.css
+++ b/packages/skin/dist/section-notice/section-notice.css
@@ -62,12 +62,6 @@ span[role="region"].section-notice {
         var(--color-foreground-primary)
     );
 }
-.section-notice__footer a,
-.section-notice__footer button.fake-link,
-.section-notice__main a,
-.section-notice__main button.fake-link {
-    font-weight: 700;
-}
 .section-notice .icon {
     vertical-align: top;
 }

--- a/packages/skin/src/sass/page-notice/page-notice.scss
+++ b/packages/skin/src/sass/page-notice/page-notice.scss
@@ -85,14 +85,6 @@ span[role="region"].page-notice {
     );
 }
 
-/* Bold weight is scoped to body slots; __cta links inherit the default normal weight per the design spec. */
-.page-notice__main a,
-.page-notice__main button.fake-link,
-.page-notice__footer a,
-.page-notice__footer button.fake-link {
-    font-weight: bold;
-}
-
 /* Override default outline color to avoid contrast issues */
 /* with the darker background colors in page notices */
 /* For explicit focus only: the `focus-visible` instead of `focus` */

--- a/packages/skin/src/sass/section-notice/section-notice.scss
+++ b/packages/skin/src/sass/section-notice/section-notice.scss
@@ -94,14 +94,6 @@ span[role="region"].section-notice {
     );
 }
 
-/* Bold weight is scoped to body slots; __cta links inherit the default normal weight per the design spec. */
-.section-notice__main a,
-.section-notice__main button.fake-link,
-.section-notice__footer a,
-.section-notice__footer button.fake-link {
-    font-weight: bold;
-}
-
 .section-notice .icon {
     vertical-align: top;
 }


### PR DESCRIPTION
## Summary
- A prior fix (#648, for #616) scoped the bold-link rule in `page-notice`/`section-notice` to `__main`/`__footer`, excluding only `__cta`, under the assumption those two slots held prose while `__cta` was the only "action" area.
- That assumption doesn't hold: `__footer` is commonly used for a single action link — the component's own "with action" Storybook example (`notices-tips-ebay-section-notice--with-action`) puts its action in the `@footer` slot, which still rendered bold.
- No bolded links appear anywhere in the Playbook spec for either component (confirmed against Playbook directly, and previously confirmed with design per the original reporter).
- Removes the bold rule entirely from both `page-notice.scss` and `section-notice.scss` so links render at normal weight regardless of slot (`__main`, `__footer`, or `__cta`).
- Added a changeset (`@ebay/skin`: patch).

Fixes #752

## Test plan
- [x] Verified in Storybook: `page-notice--general-with-link`, `page-notice--information-with-paragraph` (dismiss link), and `section-notice-base--fake-link-cta` all render links at normal weight, not bold.
- [x] `npm run build -w packages/skin` passes lint/build.
- [x] Full monorepo build/smoke tests passed via pre-push hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)