### PR TITLE
fix(carousel): don't crash when index is out of range for item count

### DIFF
--- a/.changeset/carousel-single-item-index-crash.md
+++ b/.changeset/carousel-single-item-index-crash.md
@@ -1,0 +1,13 @@
+---
+"@ebay/ui-core-react": patch
+---
+
+fix(carousel): don't crash when `index` is out of range for the item count
+
+`getOffset` indexed directly into the measured items array with
+whatever `index` was passed, with no bounds check. A carousel with a
+single item, given an `index` prop of 1 or higher (e.g. left over from
+a previous render with more items, or just an out-of-range default),
+threw `Cannot read properties of undefined (reading 'left')` during
+mount. Falls back to the last available item when the requested index
+is out of range instead of crashing.

--- a/packages/ebayui-core-react/src/ebay-carousel/__tests__/helpers.spec.ts
+++ b/packages/ebayui-core-react/src/ebay-carousel/__tests__/helpers.spec.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { getOffset } from "../helpers";
+import { ListItemRef } from "../types";
+
+const makeItem = (left: number, right: number): ListItemRef => ({
+    element: null,
+    left,
+    right,
+    fullyVisible: true,
+});
+
+describe("getOffset", () => {
+    const items = [makeItem(0, 100), makeItem(100, 200), makeItem(200, 300)];
+
+    it("returns the offset for a valid index", () => {
+        expect(getOffset(items, 1, 500)).toBe(0);
+    });
+
+    it("clamps to the last item when index is too large", () => {
+        expect(getOffset(items, 10, 500)).toBe(getOffset(items, 2, 500));
+    });
+
+    it("clamps to the first item when index is negative", () => {
+        expect(getOffset(items, -1, 500)).toBe(getOffset(items, 0, 500));
+    });
+
+    it("returns 0 when there are no items", () => {
+        expect(getOffset([], -1, 500)).toBe(0);
+    });
+});

--- a/packages/ebayui-core-react/src/ebay-carousel/__tests__/index.spec.tsx
+++ b/packages/ebayui-core-react/src/ebay-carousel/__tests__/index.spec.tsx
@@ -136,5 +136,15 @@ describe("ebay-carousel rendering", () => {
 
             expect(screen.getByText("Item 1")).toBeInTheDocument();
         });
+
+        it("does not throw when the index prop is negative", () => {
+            render(
+                <EbayCarousel index={-1}>
+                    <EbayCarouselItem>Item 1</EbayCarouselItem>
+                </EbayCarousel>,
+            );
+
+            expect(screen.getByText("Item 1")).toBeInTheDocument();
+        });
     });
 });

--- a/packages/ebayui-core-react/src/ebay-carousel/__tests__/index.spec.tsx
+++ b/packages/ebayui-core-react/src/ebay-carousel/__tests__/index.spec.tsx
@@ -115,4 +115,26 @@ describe("ebay-carousel rendering", () => {
             expect(secondItem.closest("li")).toHaveAttribute("aria-hidden", "false");
         });
     });
+
+    describe("single item", () => {
+        it("renders without throwing when there is only one item", () => {
+            render(
+                <EbayCarousel>
+                    <EbayCarouselItem>Item 1</EbayCarouselItem>
+                </EbayCarousel>,
+            );
+
+            expect(screen.getByText("Item 1")).toBeInTheDocument();
+        });
+
+        it("does not throw when the index prop is out of range for a single item", () => {
+            render(
+                <EbayCarousel index={1}>
+                    <EbayCarouselItem>Item 1</EbayCarouselItem>
+                </EbayCarousel>,
+            );
+
+            expect(screen.getByText("Item 1")).toBeInTheDocument();
+        });
+    });
 });

--- a/packages/ebayui-core-react/src/ebay-carousel/helpers.ts
+++ b/packages/ebayui-core-react/src/ebay-carousel/helpers.ts
@@ -30,7 +30,8 @@ export const getOffset = (items: ListItemRef[], index: number, slideWidth: numbe
         return 0;
     }
 
-    return Math.min(items[index].left, getMaxOffset(items, slideWidth)) || 0;
+    const item = items[index] || items[items.length - 1];
+    return Math.min(item.left, getMaxOffset(items, slideWidth)) || 0;
 };
 
 export const alterChildren = (

--- a/packages/ebayui-core-react/src/ebay-carousel/helpers.ts
+++ b/packages/ebayui-core-react/src/ebay-carousel/helpers.ts
@@ -30,8 +30,8 @@ export const getOffset = (items: ListItemRef[], index: number, slideWidth: numbe
         return 0;
     }
 
-    const item = items[index] || items[items.length - 1];
-    return Math.min(item.left, getMaxOffset(items, slideWidth)) || 0;
+    const clampedIndex = Math.min(Math.max(index, 0), items.length - 1);
+    return Math.min(items[clampedIndex].left, getMaxOffset(items, slideWidth)) || 0;
 };
 
 export const alterChildren = (


### PR DESCRIPTION
## Summary
- `getOffset` (in `@ebay/ui-core-react`'s `EbayCarousel`) indexed directly into the measured items array using whatever `index` was passed, with no bounds check: `items[index].left`.
- Reproduced with a test: `<EbayCarousel index={1}><EbayCarouselItem>Item 1</EbayCarouselItem></EbayCarousel>` throws `Cannot read properties of undefined (reading 'left')` during mount, matching the exact stack shape in the issue (`getOffset` → `commitHookEffectListMount` → `commitPassiveMountOnFiber`).
- The carousel doesn't clamp/reset its internal `activeIndex` when the `index` prop (or item count) makes it invalid, so any consumer passing an `index` that isn't valid for the current children (e.g. a stale index left over from when there were more items, or just a nonzero default on a single-image listing) crashes on mount.
- Fix: `getOffset` falls back to the last available item when the requested index is out of range, instead of crashing.
- Added regression tests for the single-item case (default index, and out-of-range index).
- Added a changeset (`@ebay/ui-core-react`: patch).

Fixes #397

## Test plan
- [x] New tests reproduce the exact crash pre-fix and pass post-fix.
- [x] Full existing `ebay-carousel` test suite still passes (6/6).
- [x] Full monorepo build/smoke tests passed via pre-push hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)