### PR TITLE
feat(site): restore theme switcher for Evo/Evo Live

### DIFF
--- a/src/routes/_index/+layout.marko
+++ b/src/routes/_index/+layout.marko
@@ -58,6 +58,13 @@ static declare global {
     </script>
   </head>
   <body class="evo-theme">
+    <html-script>
+      try {
+        if (localStorage.getItem("evo-web-theme") === "evo-live") {
+          document.body.classList.add("evo-theme-live");
+        }
+      } catch {}
+    </html-script>
     <div class="skip-to-main-content">
       <a href="#main" class="clipped clipped--stealth">Skip to main content</a>
     </div>

--- a/src/tags/site-header/index.marko
+++ b/src/tags/site-header/index.marko
@@ -141,7 +141,10 @@ import { components, a11yDocs, urls } from "../../data";
               </a>
             </li>
           </ul>
-          <search/>
+          <div class="nav__controls">
+            <theme-switcher class="theme-switcher--nav"/>
+            <search/>
+          </div>
           <button
             id="mobile-nav-toggle"
             class="app-bar-menu mobile-nav-toggle icon-btn"
@@ -195,6 +198,9 @@ import { components, a11yDocs, urls } from "../../data";
               <use href="#icon-close-20"/>
             </svg>
           </button>
+        </div>
+        <div class="mobile-theme-switcher">
+          <theme-switcher/>
         </div>
         <div class="panel-dialog__main">
           <div id="site-nav-mobile" class="site-nav-mobile">

--- a/src/tags/site-header/style.scss
+++ b/src/tags/site-header/style.scss
@@ -68,6 +68,18 @@ header a {
   font-size: 0;
 }
 
+.nav__controls {
+  align-items: center;
+  display: flex;
+  gap: var(--spacing-200);
+  margin-left: auto;
+  padding-left: var(--spacing-400);
+}
+
+.nav__controls .evo-site-search {
+  margin-left: 0;
+}
+
 .nav__link {
   color: var(--color-foreground-primary);
   font-weight: 600;
@@ -169,6 +181,10 @@ header a {
 .nav__menu-icon {
   height: 1.5rem;
   width: 1.5rem;
+}
+
+.mobile-theme-switcher {
+  margin: 0 var(--spacing-200) var(--spacing-200);
 }
 
 /* Liquid Glass Effect */

--- a/src/tags/site-header/tags/theme-switcher/index.marko
+++ b/src/tags/site-header/tags/theme-switcher/index.marko
@@ -1,0 +1,84 @@
+import "./style.scss";
+
+export interface Input extends Marko.HTML.Div {}
+
+<const/{ class: inputClass, ...htmlInput }=input>
+
+<div ...htmlInput class=["theme-switcher", inputClass]>
+    <span class="listbox-button listbox-button--form">
+        <button
+            class="btn btn--form"
+            type="button"
+            aria-expanded="false"
+            aria-haspopup="listbox">
+            <span class="btn__cell">
+                <span class="btn__label">
+                    Theme:
+                </span>
+                <span class="btn__text">
+                    Evo
+                </span>
+                <svg class="icon icon--12" height="10" width="14" aria-hidden="true">
+                    <icon-symbol name="chevron-down-16"/>
+                </svg>
+            </span>
+        </button>
+        <div class="listbox-button__listbox">
+            <div class="listbox-button__options" role="listbox">
+                <div
+                    class="listbox-button__option"
+                    role="option"
+                    data-value="evo"
+                    aria-selected="true">
+                    <span class="listbox-button__value">
+                        Evo
+                    </span>
+                    <svg class="icon icon--16" height="10" width="14" aria-hidden="true">
+                        <icon-symbol name="tick-16"/>
+                    </svg>
+                </div>
+                <div
+                    class="listbox-button__option"
+                    role="option"
+                    data-value="evo-live"
+                    aria-selected="false">
+                    <span class="listbox-button__value">
+                        Evo Live
+                    </span>
+                    <svg class="icon icon--16" height="10" width="14" aria-hidden="true">
+                        <icon-symbol name="tick-16"/>
+                    </svg>
+                </div>
+            </div>
+        </div>
+    </span>
+    <html-script>
+        (function () {
+            var root = document.currentScript.previousElementSibling;
+            var STORAGE_KEY = "evo-web-theme";
+            var buttonText = root.querySelector(".btn__text");
+            var options = root.querySelectorAll(".listbox-button__option");
+            var stored;
+            try {
+                stored = localStorage.getItem(STORAGE_KEY);
+            } catch (err) {}
+            if (stored === "evo-live") {
+                options.forEach(function (option) {
+                    var isSelected = option.dataset.value === "evo-live";
+                    option.setAttribute("aria-selected", isSelected ? "true" : "false");
+                });
+                buttonText.textContent = "Evo Live";
+            }
+            root.addEventListener("makeup-listbox-button-change", function (e) {
+                var value = e.detail.el.dataset.value;
+                buttonText.textContent = e.detail.el
+                    .querySelector(".listbox-button__value")
+                    .textContent.trim();
+                document.body.classList.toggle("evo-theme-live", value === "evo-live");
+                try {
+                    localStorage.setItem(STORAGE_KEY, value);
+                } catch (err) {}
+            });
+        })();
+    </html-script>
+</div>

--- a/src/tags/site-header/tags/theme-switcher/index.marko
+++ b/src/tags/site-header/tags/theme-switcher/index.marko
@@ -19,12 +19,12 @@ export interface Input extends Marko.HTML.Div {}
                     Evo
                 </span>
                 <svg class="icon icon--12" height="10" width="14" aria-hidden="true">
-                    <icon-symbol name="chevron-down-16"/>
+                    <icon-symbol name="chevron-down-12"/>
                 </svg>
             </span>
         </button>
         <div class="listbox-button__listbox">
-            <div class="listbox-button__options" role="listbox">
+            <div class="listbox-button__options" role="listbox" tabindex="0">
                 <div
                     class="listbox-button__option"
                     role="option"

--- a/src/tags/site-header/tags/theme-switcher/style.scss
+++ b/src/tags/site-header/tags/theme-switcher/style.scss
@@ -1,0 +1,14 @@
+.theme-switcher {
+  align-items: center;
+  display: flex;
+}
+
+.theme-switcher--nav {
+  display: none;
+}
+
+@media (min-width: 768px) {
+  .theme-switcher--nav {
+    display: flex;
+  }
+}


### PR DESCRIPTION
## Summary
- Restores the Evo / Evo Live theme switcher that was removed during the site rebrand (Fixes #624)
- Implemented as vanilla HTML/CSS reusing the site's existing `listbox-button` widget infrastructure (`main.js`'s legacy MakeupJS wiring), rather than the `<evo-listbox-button>` Marko component — that component's source lives outside the root `tsconfig.json`'s `rootDir`, which caused `npm run build`'s type-check step to corrupt unrelated `evo-marko` source files
- Selection persists via `localStorage`, with an inline `<html-script>` in `+layout.marko` applied before paint to avoid a flash of the wrong theme on load
- Two instances render: desktop nav (`.theme-switcher--nav`, hidden below 768px) and the mobile off-canvas panel (`.mobile-theme-switcher`)

## Test plan
- [x] Verified in-browser (desktop + mobile off-canvas instances): opens on first click, closes on selection, updates button text, toggles `evo-theme-live` on `<body>`
- [x] Verified `localStorage` persistence and correct restored state (button text, `aria-selected`, body class) across a reload with no flash of the wrong theme
- [x] Verified bidirectional toggling (Evo ↔ Evo Live) in both instances
- [x] Verified zero console errors throughout
- [x] `npm run build` passes clean (no cross-package rootDir issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)