### PR TITLE
feat(input): add Evo React input and textarea components

### DIFF
--- a/.changeset/tidy-input-groups.md
+++ b/.changeset/tidy-input-groups.md
@@ -1,0 +1,5 @@
+---
+"@evo-web/react": patch
+---
+
+Add EvoInput and EvoTextarea components.

--- a/.claude/skills/evo-app-migrate-react/SKILL.md
+++ b/.claude/skills/evo-app-migrate-react/SKILL.md
@@ -60,19 +60,20 @@ If a component is not listed below, it has **not been migrated yet** — keep us
 
 When migrating a listed component, read the linked file completely and apply the component-specific changes in addition to the global renames from Step 2.
 
-| ebayui-core-react component | Migration details                                           |
-| --------------------------- | ----------------------------------------------------------- |
-| `ebay-accordion`            | [evo-accordion.md](components/evo-accordion.md)             |
-| `ebay-alert-dialog`         | [evo-alert-dialog.md](components/evo-alert-dialog.md)       |
-| `ebay-badge`                | [evo-badge.md](components/evo-badge.md)                     |
-| `ebay-breadcrumbs`          | [evo-breadcrumbs.md](components/evo-breadcrumbs.md)         |
-| `ebay-button`               | [evo-button.md](components/evo-button.md)                   |
-| `ebay-calendar`             | [evo-calendar.md](components/evo-calendar.md)               |
-| `ebay-ccd`                  | [evo-ccd.md](components/evo-ccd.md)                         |
-| `ebay-character-count`      | [evo-character-count.md](components/evo-character-count.md) |
-| `ebay-details`              | [evo-details.md](components/evo-details.md)                 |
-| `ebay-confirm-dialog`       | [evo-confirm-dialog.md](components/evo-confirm-dialog.md)   |
-| `ebay-icon-button`          | [evo-icon-button.md](components/evo-icon-button.md)         |
+| ebayui-core-react component | Migration details                                                                       |
+| --------------------------- | --------------------------------------------------------------------------------------- |
+| `ebay-accordion`            | [evo-accordion.md](components/evo-accordion.md)                                         |
+| `ebay-alert-dialog`         | [evo-alert-dialog.md](components/evo-alert-dialog.md)                                   |
+| `ebay-badge`                | [evo-badge.md](components/evo-badge.md)                                                 |
+| `ebay-breadcrumbs`          | [evo-breadcrumbs.md](components/evo-breadcrumbs.md)                                     |
+| `ebay-button`               | [evo-button.md](components/evo-button.md)                                               |
+| `ebay-calendar`             | [evo-calendar.md](components/evo-calendar.md)                                           |
+| `ebay-ccd`                  | [evo-ccd.md](components/evo-ccd.md)                                                     |
+| `ebay-character-count`      | [evo-character-count.md](components/evo-character-count.md)                             |
+| `ebay-details`              | [evo-details.md](components/evo-details.md)                                             |
+| `ebay-confirm-dialog`       | [evo-confirm-dialog.md](components/evo-confirm-dialog.md)                               |
+| `ebay-icon-button`          | [evo-icon-button.md](components/evo-icon-button.md)                                     |
+| `ebay-textbox`              | [evo-input.md](components/evo-input.md) / [evo-textarea.md](components/evo-textarea.md) |
 
 ---
 

--- a/.claude/skills/evo-app-migrate-react/components/evo-input.md
+++ b/.claude/skills/evo-app-migrate-react/components/evo-input.md
@@ -1,0 +1,31 @@
+# ebay-textbox → evo-input
+
+Use `EvoInput` for single-line textboxes. Use `EvoTextarea` when the old textbox has `multiline`.
+
+```tsx
+import { EvoInput } from "@evo-web/react/input";
+
+<EvoInput
+  prefix={{ content: "$", icon: <EvoIconSearch16 /> }}
+  postfix={{
+    content: "/mo",
+    icon: <EvoIconClear16 />,
+    buttonProps: { a11yText: "Clear", onClick: handleClear },
+  }}
+/>;
+```
+
+**Prop changes:**
+
+| ebayui-core-react               | evo-react                      | Notes                                                                                 |
+| ------------------------------- | ------------------------------ | ------------------------------------------------------------------------------------- |
+| `inputSize="default"`           | `inputSize="regular"`          | The default size name changed.                                                        |
+| Prefix/postfix child components | `prefix`/`postfix` objects     | Move text to `content`, icons to `icon`, and span attributes onto the object.         |
+| `buttonAriaLabel`               | `postfix.buttonProps.a11yText` | The action uses `EvoIconButton`.                                                      |
+| `onButtonClick`                 | `postfix.buttonProps.onClick`  | Receives the native click event only.                                                 |
+| `onInputChange`                 | `onChange`                     | `onChange` now follows native React input semantics and fires as the value changes.   |
+| Legacy event callbacks          | Native React callbacks         | Remove the second `{ value }` callback argument and read `event.currentTarget.value`. |
+| `forwardedRef` / `inputRef`     | `ref`                          | React 19 forwards the native input ref directly.                                      |
+| `multiline`                     | `EvoTextarea`                  | Import from `@evo-web/react/textarea`.                                                |
+| `opaqueLabel`                   | `EvoTextarea.opaqueLabel`      | Only supported by the textarea component.                                             |
+| `onFloatingLabelInit`           | Removed                        | No initialization callback is needed.                                                 |

--- a/.claude/skills/evo-app-migrate-react/components/evo-textarea.md
+++ b/.claude/skills/evo-app-migrate-react/components/evo-textarea.md
@@ -1,0 +1,11 @@
+# ebay-textbox → evo-textarea
+
+Use `EvoTextarea` when an `EbayTextbox` has `multiline`.
+
+```tsx
+import { EvoTextarea } from "@evo-web/react/textarea";
+
+<EvoTextarea floatingLabel="Description" opaqueLabel />;
+```
+
+Apply the event, ref, size, and floating-label changes documented in [evo-input.md](evo-input.md). Prefix and postfix decorations are not supported by `EvoTextarea`, matching evo-marko.

--- a/packages/evo-react/src/character-count/character-count.stories.tsx
+++ b/packages/evo-react/src/character-count/character-count.stories.tsx
@@ -1,9 +1,9 @@
 import { useRef, useState } from "react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { EvoInput } from "../input";
 import { EvoCharacterCount } from "./character-count";
 import { countCharacters } from "./count-characters";
 import "@ebay/skin/field.mjs";
-import "@ebay/skin/textbox.mjs";
 
 const meta: Meta<typeof EvoCharacterCount> = {
   title: "building blocks/evo-character-count",
@@ -85,17 +85,14 @@ export const InField: Story = {
           Field Label
         </label>
         <span className="field__control">
-          <span className="textbox">
-            <input
-              ref={inputRef}
-              value={text}
-              type="text"
-              aria-describedby="character-count-description character-count-value"
-              className="textbox__control"
-              id="character-count-input"
-              onChange={(event) => setText(event.currentTarget.value)}
-            />
-          </span>
+          <EvoInput
+            ref={inputRef}
+            value={text}
+            type="text"
+            aria-describedby="character-count-description character-count-value"
+            id="character-count-input"
+            onChange={(event) => setText(event.currentTarget.value)}
+          />
         </span>
         <div className="field__description field__description--group">
           <span id="character-count-description">Brief description</span>

--- a/packages/evo-react/src/input/README.md
+++ b/packages/evo-react/src/input/README.md
@@ -1,0 +1,5 @@
+# EvoInput
+
+## Documentation
+
+[Storybook](https://opensource.ebay.com/evo-web/react/?path=/docs/form-input-evo-input--documentation)

--- a/packages/evo-react/src/input/index.ts
+++ b/packages/evo-react/src/input/index.ts
@@ -1,0 +1,7 @@
+export { EvoInput } from "./input";
+export type {
+  EvoInputAffixProps,
+  EvoInputPostfixProps,
+  EvoInputProps,
+  InputSize,
+} from "./types";

--- a/packages/evo-react/src/input/input.stories.tsx
+++ b/packages/evo-react/src/input/input.stories.tsx
@@ -1,0 +1,176 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { action } from "storybook/actions";
+import { EvoIconClear24 } from "../icon/icons/clear-24";
+import { EvoIconMail24 } from "../icon/icons/mail-24";
+import { EvoIconProfile24 } from "../icon/icons/profile-24";
+import { EvoInput } from "./input";
+import "@ebay/skin/field.mjs";
+
+const meta: Meta<typeof EvoInput> = {
+  title: "form input/evo-input",
+  component: EvoInput,
+  tags: ["autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component: `
+A single-line text input with optional floating label and prefix or postfix content.
+
+## Usage
+
+\`\`\`tsx
+import { EvoInput } from "@evo-web/react/input";
+\`\`\`
+        `,
+      },
+    },
+  },
+  argTypes: {
+    inputSize: {
+      control: "select",
+      options: ["regular", "large"],
+      description: "Input size.",
+    },
+    fluid: {
+      control: "boolean",
+      description: "Makes the input fill its container.",
+    },
+    invalid: {
+      control: "boolean",
+      description: "Indicates a field-level error.",
+    },
+    floatingLabel: {
+      control: "text",
+      description: "Text displayed as a floating label.",
+    },
+    floatingLabelStatic: {
+      control: "boolean",
+      description: "Keeps the floating label raised.",
+    },
+    prefix: {
+      control: false,
+      description:
+        "Optional content and icon displayed before the input. Native span attributes are applied to the content element.",
+    },
+    postfix: {
+      control: false,
+      description:
+        "Optional content and icon displayed after the input. Supply buttonProps to make the icon actionable.",
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof EvoInput>;
+
+export const Default: Story = {
+  args: {
+    "aria-label": "Example input",
+  },
+};
+
+export const WithLabel: Story = {
+  render: (args) => (
+    <span className="field">
+      <label className="field__label field__label--start" htmlFor="textbox">
+        Email address
+      </label>
+      <EvoInput {...args} id="textbox" value="test" />
+    </span>
+  ),
+};
+
+export const Disabled: Story = {
+  render: (args) => (
+    <span className="field">
+      <label
+        className="field__label field__label--start field__label--disabled"
+        htmlFor="disabled-textbox"
+      >
+        Email address
+      </label>
+      <EvoInput {...args} disabled id="disabled-textbox" value="test" />
+    </span>
+  ),
+};
+
+export const FloatingLabel: Story = {
+  args: {
+    floatingLabel: "Email address",
+  },
+};
+
+export const FloatingLabelAutocomplete: Story = {
+  render: (args) => (
+    <>
+      <EvoInput
+        {...args}
+        autoComplete="given-name"
+        floatingLabel="First Name"
+      />
+      <EvoInput
+        {...args}
+        autoComplete="family-name"
+        floatingLabel="Last Name"
+      />
+      <EvoInput
+        {...args}
+        autoComplete="email"
+        floatingLabel="Email address"
+        placeholder="valid email address"
+      />
+    </>
+  ),
+};
+
+export const WithPrefixIcon: Story = {
+  args: {
+    "aria-label": "Email",
+    placeholder: "email",
+    prefix: {
+      icon: <EvoIconMail24 />,
+    },
+  },
+};
+
+export const WithPostfixIcon: Story = {
+  args: {
+    "aria-label": "Name",
+    placeholder: "name",
+    postfix: {
+      icon: <EvoIconProfile24 />,
+    },
+  },
+};
+
+export const WithBothIcons: Story = {
+  args: {
+    "aria-label": "Name",
+    placeholder: "name",
+    prefix: {
+      icon: <EvoIconProfile24 />,
+    },
+    postfix: {
+      icon: <EvoIconClear24 />,
+      buttonProps: {
+        a11yText: "Clear",
+        onClick: action("clear"),
+      },
+    },
+  },
+};
+
+export const FullyDecorated: Story = {
+  args: {
+    "aria-label": "Monthly price",
+    placeholder: "0.00",
+    prefix: {
+      content: "$",
+      icon: <EvoIconMail24 />,
+    },
+    postfix: {
+      content: "/mo",
+      icon: <EvoIconClear24 />,
+    },
+  },
+};

--- a/packages/evo-react/src/input/input.tsx
+++ b/packages/evo-react/src/input/input.tsx
@@ -1,0 +1,160 @@
+import { useId, useState } from "react";
+import classNames from "classnames";
+import { EvoIconButton } from "../icon-button";
+import { useFloatingLabel } from "../utils/use-floating-label";
+import type { EvoInputProps } from "./types";
+import "@ebay/skin/textbox.mjs";
+
+function hasContent(content: unknown) {
+  return (
+    content !== undefined && content !== null && typeof content !== "boolean"
+  );
+}
+
+function joinIds(...values: Array<string | undefined>) {
+  const ids = values.flatMap((value) => value?.trim().split(/\s+/) ?? []);
+  return [...new Set(ids)].filter(Boolean).join(" ") || undefined;
+}
+
+export function EvoInput({
+  "aria-describedby": ariaDescribedBy,
+  "aria-invalid": ariaInvalid,
+  className,
+  defaultValue,
+  disabled,
+  floatingLabel: floatingLabelText,
+  floatingLabelStatic,
+  fluid,
+  id,
+  inputSize = "regular",
+  invalid,
+  onBlur,
+  onChange,
+  onFocus,
+  placeholder,
+  postfix,
+  prefix,
+  readOnly,
+  ref,
+  style,
+  value,
+  ...rest
+}: EvoInputProps) {
+  const generatedInputId = useId();
+  const generatedPrefixId = useId();
+  const generatedPostfixId = useId();
+  const [focused, setFocused] = useState(false);
+  const [uncontrolledValue, setUncontrolledValue] = useState(defaultValue);
+
+  const {
+    content: prefixContent,
+    icon: prefixIcon,
+    id: customPrefixId,
+    ...prefixTextProps
+  } = prefix ?? {};
+  const {
+    buttonProps: postfixButtonProps,
+    content: postfixContent,
+    icon: postfixIcon,
+    id: customPostfixId,
+    ...postfixTextProps
+  } = postfix ?? {};
+
+  const hasPrefixContent = hasContent(prefixContent);
+  const hasPostfixContent = hasContent(postfixContent);
+  const prefixId = customPrefixId || generatedPrefixId;
+  const postfixId = customPostfixId || generatedPostfixId;
+  const inputId = id ?? (floatingLabelText ? generatedInputId : undefined);
+  const currentValue = value !== undefined ? value : uncontrolledValue;
+  const floatingLabel = useFloatingLabel({
+    alwaysUp: floatingLabelStatic,
+    containerTagName: fluid ? "div" : "span",
+    disabled,
+    focused,
+    invalid,
+    size: inputSize,
+    text: floatingLabelText,
+    value: currentValue,
+  });
+  const describedBy = joinIds(
+    ariaDescribedBy,
+    hasPrefixContent ? prefixId : undefined,
+    hasPostfixContent ? postfixId : undefined,
+  );
+
+  const handleChange: NonNullable<EvoInputProps["onChange"]> = (event) => {
+    if (value === undefined) {
+      setUncontrolledValue(event.currentTarget.value);
+    }
+    onChange?.(event);
+  };
+
+  const handleFocus: NonNullable<EvoInputProps["onFocus"]> = (event) => {
+    setFocused(true);
+    onFocus?.(event);
+  };
+
+  const handleBlur: NonNullable<EvoInputProps["onBlur"]> = (event) => {
+    setFocused(false);
+    onBlur?.(event);
+  };
+
+  const Wrapper = fluid ? "div" : "span";
+
+  return (
+    <floatingLabel.Container {...floatingLabel.containerProps}>
+      <floatingLabel.Label {...floatingLabel.labelProps} htmlFor={inputId} />
+      <Wrapper
+        className={classNames(
+          "textbox",
+          disabled && "textbox--disabled",
+          invalid && "textbox--invalid",
+          readOnly && "textbox--readonly",
+          inputSize === "large" && "textbox--large",
+          fluid && "textbox--fluid",
+          className,
+        )}
+        style={style}
+      >
+        {prefixIcon}
+        {hasPrefixContent && (
+          <span {...prefixTextProps} id={prefixId}>
+            {prefixContent}
+          </span>
+        )}
+        <input
+          {...rest}
+          id={inputId}
+          ref={ref}
+          className="textbox__control"
+          aria-describedby={describedBy}
+          aria-invalid={invalid ? "true" : ariaInvalid}
+          defaultValue={defaultValue}
+          disabled={disabled}
+          onBlur={handleBlur}
+          onChange={handleChange}
+          onFocus={handleFocus}
+          placeholder={floatingLabel.showPlaceholder ? placeholder : undefined}
+          readOnly={readOnly}
+          value={value}
+        />
+        {hasPostfixContent && (
+          <span {...postfixTextProps} id={postfixId}>
+            {postfixContent}
+          </span>
+        )}
+        {postfixIcon && postfixButtonProps ? (
+          <EvoIconButton
+            {...postfixButtonProps}
+            disabled={disabled || postfixButtonProps.disabled}
+            transparent
+          >
+            {postfixIcon}
+          </EvoIconButton>
+        ) : (
+          postfixIcon
+        )}
+      </Wrapper>
+    </floatingLabel.Container>
+  );
+}

--- a/packages/evo-react/src/input/test/__snapshots__/test.server.tsx.snap
+++ b/packages/evo-react/src/input/test/__snapshots__/test.server.tsx.snap
@@ -1,0 +1,11 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`EvoInput SSR > renders a floating label 1`] = `"<span class="floating-label"><label class="floating-label__label floating-label__label--animate floating-label__label--inline" for="_R_0_">Email address</label><span class="textbox"><input id="_R_0_" class="textbox__control"/></span></span>"`;
+
+exports[`EvoInput SSR > renders an actionable postfix icon 1`] = `"<span class="textbox"><input aria-label="Search" class="textbox__control"/><button type="button" aria-label="Clear search" class="icon-btn icon-btn--transparent"><svg class="icon icon--16" xmlns="http://www.w3.org/2000/svg" focusable="false" aria-hidden="true"><use xlink:href="#icon-clear-16"></use><defs><symbol viewBox="0 0 16 16" id="icon-clear-16"><path d="M8 0a8 8 0 1 0 0 16A8 8 0 0 0 8 0Zm3.71 10.29a1 1 0 1 1-1.41 1.41L8 9.41l-2.29 2.3A1 1 0 0 1 4.3 10.3L6.59 8l-2.3-2.29a1.004 1.004 0 0 1 1.42-1.42L8 6.59l2.29-2.29a1 1 0 0 1 1.41 1.41L9.41 8l2.3 2.29Z"/></symbol></defs></svg></button></span>"`;
+
+exports[`EvoInput SSR > renders and associates affix content 1`] = `"<span class="textbox"><span id="prefix-id">$</span><input aria-label="Amount" class="textbox__control" aria-describedby="error-id prefix-id postfix-id"/><span id="postfix-id">USD</span></span>"`;
+
+exports[`EvoInput SSR > renders defaults 1`] = `"<span class="textbox"><input aria-label="Input" class="textbox__control"/></span>"`;
+
+exports[`EvoInput SSR > renders input states 1`] = `"<div class="textbox textbox--invalid textbox--readonly textbox--large textbox--fluid"><input aria-label="Input" class="textbox__control" aria-invalid="true" readOnly=""/></div>"`;

--- a/packages/evo-react/src/input/test/test.browser.tsx
+++ b/packages/evo-react/src/input/test/test.browser.tsx
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-react";
+import { userEvent } from "vitest/browser";
+import { createRef, useState } from "react";
+import { EvoIconClear16 } from "../../icon/icons/clear-16";
+import { EvoIconSearch16 } from "../../icon/icons/search-16";
+import { EvoInput } from "../input";
+
+describe("evo-input", () => {
+  let user: ReturnType<typeof userEvent.setup>;
+
+  beforeEach(() => {
+    user = userEvent.setup();
+  });
+
+  afterEach(() => {
+    user.cleanup();
+  });
+
+  it("passes native change events through", async () => {
+    const onChange = vi.fn();
+    const screen = await render(
+      <EvoInput aria-label="Search" onChange={onChange} />,
+    );
+
+    await user.type(screen.getByRole("textbox", { name: "Search" }), "camera");
+
+    expect(onChange).toHaveBeenCalledTimes(6);
+  });
+
+  it("associates prefix and postfix content with the input", async () => {
+    const screen = await render(
+      <>
+        <p id="input-error">Enter a valid amount.</p>
+        <EvoInput
+          aria-label="Amount"
+          aria-describedby="input-error"
+          prefix={{ content: "$", className: "currency" }}
+          postfix={{ content: "USD", "data-testid": "currency-code" }}
+        />
+      </>,
+    );
+    const input = screen.getByRole("textbox", { name: "Amount" });
+    const ids = input.element().getAttribute("aria-describedby")!.split(" ");
+
+    expect(ids[0]).toBe("input-error");
+    expect(ids).toHaveLength(3);
+    expect(ids.every((id) => document.getElementById(id))).toBe(true);
+    await expect.element(screen.getByText("$")).toHaveClass("currency");
+    await expect
+      .element(screen.getByTestId("currency-code"))
+      .toHaveTextContent("USD");
+  });
+
+  it("does not add description IDs for icon-only affixes", async () => {
+    const screen = await render(
+      <EvoInput
+        aria-label="Search"
+        prefix={{ content: false, icon: <EvoIconSearch16 /> }}
+      />,
+    );
+
+    await expect
+      .element(screen.getByRole("textbox", { name: "Search" }))
+      .not.toHaveAttribute("aria-describedby");
+  });
+
+  it("renders an actionable postfix icon with EvoIconButton", async () => {
+    const onClick = vi.fn();
+    const screen = await render(
+      <EvoInput
+        aria-label="Search"
+        postfix={{
+          icon: <EvoIconClear16 />,
+          buttonProps: { a11yText: "Clear search", onClick },
+        }}
+      />,
+    );
+    const button = screen.getByRole("button", { name: "Clear search" });
+
+    await expect.element(button).toHaveClass("icon-btn--transparent");
+    await user.click(button);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("animates a stable floating label and manages the placeholder", async () => {
+    const screen = await render(
+      <EvoInput floatingLabel="Email address" placeholder="name@example.com" />,
+    );
+    const input = screen.getByRole("textbox", { name: "Email address" });
+    const label = screen.getByText("Email address");
+    const labelElement = label.element();
+
+    await expect.element(label).toHaveClass("floating-label__label--inline");
+    await expect.element(input).not.toHaveAttribute("placeholder");
+
+    await user.click(input);
+
+    expect(screen.getByText("Email address").element()).toBe(labelElement);
+    await expect
+      .element(label)
+      .toHaveClass(
+        "floating-label__label--animate",
+        "floating-label__label--focus",
+      );
+    await expect
+      .element(label)
+      .not.toHaveClass("floating-label__label--inline");
+    await expect
+      .element(input)
+      .toHaveAttribute("placeholder", "name@example.com");
+
+    await user.tab();
+
+    expect(screen.getByText("Email address").element()).toBe(labelElement);
+    await expect.element(label).toHaveClass("floating-label__label--inline");
+    await expect.element(input).not.toHaveAttribute("placeholder");
+  });
+
+  it("refreshes the same floating label after controlled value updates", async () => {
+    function ControlledInput() {
+      const [value, setValue] = useState("");
+
+      return (
+        <EvoInput
+          floatingLabel="Email address"
+          value={value}
+          onChange={(event) => setValue(event.currentTarget.value)}
+        />
+      );
+    }
+
+    const screen = await render(<ControlledInput />);
+    const input = screen.getByRole("textbox", { name: "Email address" });
+    const label = screen.getByText("Email address");
+    const labelElement = label.element();
+
+    await user.type(input, "a");
+    await user.tab();
+
+    expect(screen.getByText("Email address").element()).toBe(labelElement);
+    await expect
+      .element(label)
+      .not.toHaveClass("floating-label__label--inline");
+  });
+
+  it("forwards ref to the native input", async () => {
+    const ref = createRef<HTMLInputElement>();
+    await render(<EvoInput aria-label="Search" ref={ref} />);
+
+    expect(ref.current).toBeInstanceOf(HTMLInputElement);
+  });
+});

--- a/packages/evo-react/src/input/test/test.server.tsx
+++ b/packages/evo-react/src/input/test/test.server.tsx
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { renderToString } from "react-dom/server";
+import { EvoIconClear16 } from "../../icon/icons/clear-16";
+import { EvoInput } from "../input";
+
+describe("EvoInput SSR", () => {
+  it("renders defaults", () => {
+    expect(renderToString(<EvoInput aria-label="Input" />)).toMatchSnapshot();
+  });
+
+  it("renders input states", () => {
+    expect(
+      renderToString(
+        <EvoInput
+          aria-label="Input"
+          fluid
+          inputSize="large"
+          invalid
+          readOnly
+        />,
+      ),
+    ).toMatchSnapshot();
+  });
+
+  it("renders and associates affix content", () => {
+    expect(
+      renderToString(
+        <EvoInput
+          aria-label="Amount"
+          aria-describedby="error-id"
+          prefix={{ content: "$", id: "prefix-id" }}
+          postfix={{ content: "USD", id: "postfix-id" }}
+        />,
+      ),
+    ).toMatchSnapshot();
+  });
+
+  it("renders an actionable postfix icon", () => {
+    expect(
+      renderToString(
+        <EvoInput
+          aria-label="Search"
+          postfix={{
+            icon: <EvoIconClear16 />,
+            buttonProps: { a11yText: "Clear search" },
+          }}
+        />,
+      ),
+    ).toMatchSnapshot();
+  });
+
+  it("renders a floating label", () => {
+    expect(
+      renderToString(<EvoInput floatingLabel="Email address" />),
+    ).toMatchSnapshot();
+  });
+});

--- a/packages/evo-react/src/input/types.ts
+++ b/packages/evo-react/src/input/types.ts
@@ -1,0 +1,31 @@
+import type { ComponentProps, ReactNode } from "react";
+import type { NativeIconButtonProps } from "../icon-button";
+
+export type InputSize = "regular" | "large";
+
+type DataAttributes = {
+  [key: `data-${string}`]: string | number | boolean | undefined;
+};
+
+export type EvoInputAffixProps = Omit<
+  ComponentProps<"span">,
+  "children" | "content"
+> &
+  DataAttributes & {
+    content?: ReactNode;
+    icon?: ReactNode;
+  };
+
+export type EvoInputPostfixProps = EvoInputAffixProps & {
+  buttonProps?: NativeIconButtonProps;
+};
+
+export type EvoInputProps = Omit<ComponentProps<"input">, "prefix"> & {
+  fluid?: boolean;
+  floatingLabel?: string;
+  floatingLabelStatic?: boolean;
+  inputSize?: InputSize;
+  invalid?: boolean;
+  postfix?: EvoInputPostfixProps;
+  prefix?: EvoInputAffixProps;
+};

--- a/packages/evo-react/src/textarea/README.md
+++ b/packages/evo-react/src/textarea/README.md
@@ -1,0 +1,5 @@
+# EvoTextarea
+
+## Documentation
+
+[Storybook](https://opensource.ebay.com/evo-web/react/?path=/docs/form-input-evo-textarea--documentation)

--- a/packages/evo-react/src/textarea/index.ts
+++ b/packages/evo-react/src/textarea/index.ts
@@ -1,0 +1,2 @@
+export { EvoTextarea } from "./textarea";
+export type { EvoTextareaProps, InputSize } from "./types";

--- a/packages/evo-react/src/textarea/test/__snapshots__/test.server.tsx.snap
+++ b/packages/evo-react/src/textarea/test/__snapshots__/test.server.tsx.snap
@@ -1,0 +1,9 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`EvoTextarea SSR > renders a controlled value 1`] = `"<span class="textbox textbox--readonly"><textarea aria-label="Description" class="textbox__control" readOnly="">Details</textarea></span>"`;
+
+exports[`EvoTextarea SSR > renders a floating label 1`] = `"<span class="floating-label floating-label--opaque"><label class="floating-label__label floating-label__label--animate floating-label__label--inline" for="_R_0_">Description</label><span class="textbox"><textarea id="_R_0_" class="textbox__control"></textarea></span></span>"`;
+
+exports[`EvoTextarea SSR > renders defaults 1`] = `"<span class="textbox"><textarea aria-label="Description" class="textbox__control"></textarea></span>"`;
+
+exports[`EvoTextarea SSR > renders textarea states 1`] = `"<div class="textbox textbox--invalid textbox--readonly textbox--large textbox--fluid"><textarea aria-label="Description" class="textbox__control" aria-invalid="true" readOnly=""></textarea></div>"`;

--- a/packages/evo-react/src/textarea/test/test.browser.tsx
+++ b/packages/evo-react/src/textarea/test/test.browser.tsx
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-react";
+import { userEvent } from "vitest/browser";
+import { createRef } from "react";
+import { EvoTextarea } from "../textarea";
+
+describe("evo-textarea", () => {
+  let user: ReturnType<typeof userEvent.setup>;
+
+  beforeEach(() => {
+    user = userEvent.setup();
+  });
+
+  afterEach(() => {
+    user.cleanup();
+  });
+
+  it("passes native change events through", async () => {
+    const onChange = vi.fn();
+    const screen = await render(
+      <EvoTextarea aria-label="Description" onChange={onChange} />,
+    );
+
+    await user.type(
+      screen.getByRole("textbox", { name: "Description" }),
+      "Details",
+    );
+
+    expect(onChange).toHaveBeenCalledTimes(7);
+  });
+
+  it("applies textarea states to the Skin wrapper and control", async () => {
+    const screen = await render(
+      <EvoTextarea aria-label="Description" fluid inputSize="large" invalid />,
+    );
+    const textarea = screen.getByRole("textbox", { name: "Description" });
+    const wrapper = textarea.element().closest(".textbox");
+
+    await expect.element(textarea).toHaveAttribute("aria-invalid", "true");
+    expect(wrapper).toHaveClass(
+      "textbox--fluid",
+      "textbox--large",
+      "textbox--invalid",
+    );
+  });
+
+  it("raises a floating label when text is entered", async () => {
+    const screen = await render(
+      <EvoTextarea floatingLabel="Description" opaqueLabel />,
+    );
+    const textarea = screen.getByRole("textbox", { name: "Description" });
+    const label = screen.getByText("Description");
+
+    await expect.element(label).toHaveClass("floating-label__label--inline");
+    await user.type(textarea, "Details");
+    await user.tab();
+    await expect
+      .element(label)
+      .not.toHaveClass("floating-label__label--inline");
+    expect(label.element().closest(".floating-label")).toHaveClass(
+      "floating-label--opaque",
+    );
+  });
+
+  it("forwards ref to the native textarea", async () => {
+    const ref = createRef<HTMLTextAreaElement>();
+    await render(<EvoTextarea aria-label="Description" ref={ref} />);
+
+    expect(ref.current).toBeInstanceOf(HTMLTextAreaElement);
+  });
+});

--- a/packages/evo-react/src/textarea/test/test.server.tsx
+++ b/packages/evo-react/src/textarea/test/test.server.tsx
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { renderToString } from "react-dom/server";
+import { EvoTextarea } from "../textarea";
+
+describe("EvoTextarea SSR", () => {
+  it("renders defaults", () => {
+    expect(
+      renderToString(<EvoTextarea aria-label="Description" />),
+    ).toMatchSnapshot();
+  });
+
+  it("renders textarea states", () => {
+    expect(
+      renderToString(
+        <EvoTextarea
+          aria-label="Description"
+          fluid
+          inputSize="large"
+          invalid
+          readOnly
+        />,
+      ),
+    ).toMatchSnapshot();
+  });
+
+  it("renders a floating label", () => {
+    expect(
+      renderToString(<EvoTextarea floatingLabel="Description" opaqueLabel />),
+    ).toMatchSnapshot();
+  });
+
+  it("renders a controlled value", () => {
+    expect(
+      renderToString(
+        <EvoTextarea aria-label="Description" value="Details" readOnly />,
+      ),
+    ).toMatchSnapshot();
+  });
+});

--- a/packages/evo-react/src/textarea/textarea.stories.tsx
+++ b/packages/evo-react/src/textarea/textarea.stories.tsx
@@ -1,0 +1,82 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
+import { EvoButton } from "../button";
+import { EvoTextarea } from "./textarea";
+
+const meta: Meta<typeof EvoTextarea> = {
+  title: "form input/evo-textarea",
+  component: EvoTextarea,
+  tags: ["autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component: `
+A multi-line text input with optional floating-label styling.
+
+## Usage
+
+\`\`\`tsx
+import { EvoTextarea } from "@evo-web/react/textarea";
+\`\`\`
+        `,
+      },
+    },
+  },
+  argTypes: {
+    inputSize: {
+      control: "select",
+      options: ["regular", "large"],
+      description: "Textarea size.",
+    },
+    fluid: {
+      control: "boolean",
+      description: "Makes the textarea fill its container.",
+    },
+    invalid: {
+      control: "boolean",
+      description: "Indicates a field-level error.",
+    },
+    floatingLabel: {
+      control: "text",
+      description: "Text displayed as a floating label.",
+    },
+    floatingLabelStatic: {
+      control: "boolean",
+      description: "Keeps the floating label raised.",
+    },
+    opaqueLabel: {
+      control: "boolean",
+      description: "Adds an opaque background behind the floating label.",
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof EvoTextarea>;
+
+export const Default: Story = {
+  args: {
+    "aria-label": "Example textarea",
+  },
+};
+
+function ControlledExample(args: Story["args"]) {
+  const [value, setValue] = useState("");
+
+  return (
+    <>
+      <EvoTextarea
+        {...args}
+        aria-label="Controlled textarea"
+        value={value}
+        onChange={(event) => setValue(event.currentTarget.value)}
+      />
+      <pre>{value}</pre>
+      <EvoButton onClick={() => setValue("")}>Clear</EvoButton>
+    </>
+  );
+}
+
+export const Controlled: Story = {
+  render: (args) => <ControlledExample {...args} />,
+};

--- a/packages/evo-react/src/textarea/textarea.tsx
+++ b/packages/evo-react/src/textarea/textarea.tsx
@@ -1,0 +1,98 @@
+import { useId, useState } from "react";
+import classNames from "classnames";
+import { useFloatingLabel } from "../utils/use-floating-label";
+import type { EvoTextareaProps } from "./types";
+import "@ebay/skin/textbox.mjs";
+
+export function EvoTextarea({
+  "aria-invalid": ariaInvalid,
+  className,
+  defaultValue,
+  disabled,
+  floatingLabel: floatingLabelText,
+  floatingLabelStatic,
+  fluid,
+  id,
+  inputSize = "regular",
+  invalid,
+  onBlur,
+  onChange,
+  onFocus,
+  opaqueLabel,
+  placeholder,
+  readOnly,
+  ref,
+  style,
+  value,
+  ...rest
+}: EvoTextareaProps) {
+  const generatedId = useId();
+  const [focused, setFocused] = useState(false);
+  const [uncontrolledValue, setUncontrolledValue] = useState(defaultValue);
+  const textareaId = id ?? (floatingLabelText ? generatedId : undefined);
+  const currentValue = value !== undefined ? value : uncontrolledValue;
+  const floatingLabel = useFloatingLabel({
+    alwaysUp: floatingLabelStatic,
+    containerTagName: fluid ? "div" : "span",
+    disabled,
+    focused,
+    invalid,
+    opaque: opaqueLabel,
+    size: inputSize,
+    text: floatingLabelText,
+    value: currentValue,
+  });
+
+  const handleChange: NonNullable<EvoTextareaProps["onChange"]> = (event) => {
+    if (value === undefined) {
+      setUncontrolledValue(event.currentTarget.value);
+    }
+    onChange?.(event);
+  };
+
+  const handleFocus: NonNullable<EvoTextareaProps["onFocus"]> = (event) => {
+    setFocused(true);
+    onFocus?.(event);
+  };
+
+  const handleBlur: NonNullable<EvoTextareaProps["onBlur"]> = (event) => {
+    setFocused(false);
+    onBlur?.(event);
+  };
+
+  const Wrapper = fluid ? "div" : "span";
+
+  return (
+    <floatingLabel.Container {...floatingLabel.containerProps}>
+      <floatingLabel.Label {...floatingLabel.labelProps} htmlFor={textareaId} />
+      <Wrapper
+        className={classNames(
+          "textbox",
+          disabled && "textbox--disabled",
+          invalid && "textbox--invalid",
+          readOnly && "textbox--readonly",
+          inputSize === "large" && "textbox--large",
+          fluid && "textbox--fluid",
+          className,
+        )}
+        style={style}
+      >
+        <textarea
+          {...rest}
+          id={textareaId}
+          ref={ref}
+          className="textbox__control"
+          aria-invalid={invalid ? "true" : ariaInvalid}
+          defaultValue={defaultValue}
+          disabled={disabled}
+          onBlur={handleBlur}
+          onChange={handleChange}
+          onFocus={handleFocus}
+          placeholder={floatingLabel.showPlaceholder ? placeholder : undefined}
+          readOnly={readOnly}
+          value={value}
+        />
+      </Wrapper>
+    </floatingLabel.Container>
+  );
+}

--- a/packages/evo-react/src/textarea/types.ts
+++ b/packages/evo-react/src/textarea/types.ts
@@ -1,0 +1,12 @@
+import type { ComponentProps } from "react";
+
+export type InputSize = "regular" | "large";
+
+export type EvoTextareaProps = ComponentProps<"textarea"> & {
+  fluid?: boolean;
+  floatingLabel?: string;
+  floatingLabelStatic?: boolean;
+  inputSize?: InputSize;
+  invalid?: boolean;
+  opaqueLabel?: boolean;
+};

--- a/packages/evo-react/src/utils/use-floating-label.tsx
+++ b/packages/evo-react/src/utils/use-floating-label.tsx
@@ -1,0 +1,87 @@
+import type { ComponentProps } from "react";
+import classNames from "classnames";
+import "@ebay/skin/floating-label.mjs";
+
+type FloatingLabelContainerProps = ComponentProps<"div"> &
+  ComponentProps<"span">;
+type FloatingLabelLabelProps = ComponentProps<"label">;
+
+type UseFloatingLabelProps = {
+  alwaysUp?: boolean;
+  containerClassName?: string;
+  containerTagName?: "div" | "span";
+  disabled?: boolean;
+  focused?: boolean;
+  invalid?: boolean;
+  labelClassName?: string;
+  opaque?: boolean;
+  size?: "regular" | "large";
+  text?: string;
+  value?: unknown;
+};
+
+function FragmentContainer({ children }: FloatingLabelContainerProps) {
+  return <>{children}</>;
+}
+
+function EmptyLabel() {
+  return null;
+}
+
+function hasValue(value: unknown) {
+  if (Array.isArray(value)) {
+    return value.length > 0;
+  }
+
+  return value !== undefined && value !== null && String(value).length > 0;
+}
+
+export function useFloatingLabel({
+  alwaysUp,
+  containerClassName,
+  containerTagName = "span",
+  disabled,
+  focused,
+  invalid,
+  labelClassName,
+  opaque,
+  size,
+  text,
+  value,
+}: UseFloatingLabelProps) {
+  const isFloating = hasValue(value) || focused || alwaysUp;
+  const Container = text ? containerTagName : FragmentContainer;
+  const Label: "label" | ((props: FloatingLabelLabelProps) => null) = text
+    ? "label"
+    : EmptyLabel;
+
+  return {
+    Container,
+    Label,
+    containerProps: text
+      ? {
+          className: classNames(
+            "floating-label",
+            size === "large" && "floating-label--large",
+            opaque && "floating-label--opaque",
+            containerClassName,
+          ),
+        }
+      : {},
+    labelProps: text
+      ? {
+          children: text,
+          className: classNames(
+            "floating-label__label",
+            "floating-label__label--animate",
+            disabled && "floating-label__label--disabled",
+            invalid && "floating-label__label--invalid",
+            !isFloating && "floating-label__label--inline",
+            isFloating && "floating-label__label--focus",
+            labelClassName,
+          ),
+        }
+      : {},
+    showPlaceholder: !text || Boolean(isFloating),
+  };
+}


### PR DESCRIPTION
<!-- Insert GitHub issue number below. An issue is required for all PRs -->

- Fixes #

## Description

Adds `EvoInput` and `EvoTextarea` to `@evo-web/react`, following the evo-marko structure and React 19 conventions.

- Supports floating labels using declarative React logic shared by input and textarea.
- Supports SSR-safe prefix and postfix text associations through `aria-describedby`.
- Renders actionable postfix icons with `EvoIconButton`.
- Adds browser, SSR, snapshot, and matching evo-marko Storybook coverage.
- Updates the character-count story to use `EvoInput`.
- Documents application migration from `EbayTextbox` and adds a patch changeset.

## Notes

### API designs considered

#### Compound components

```tsx
<EvoInputGroup>
  <EvoInputGroupPrefixIcon />

  <EvoInputGroupPrefixText>
    prefix text
  </EvoInputGroupPrefixText>

  <EvoInputGroupInput />

  <EvoInputGroupPostfixText>
    postfix text
  </EvoInputGroupPostfixText>

  <EvoInputGroupPostfixIcon />
</EvoInputGroup>
```

This provides the most layout freedom and a composable API. However, without child scanning or client-side registration, the input cannot reliably know during SSR whether prefix or postfix text exists. That prevents it from safely controlling `aria-describedby` without potentially producing missing or dangling references.

#### Separate decoration props

```tsx
<EvoInput
  prefixText={{ id: "", text: "" }}
  prefixIcon={<EvoIcon />}
  postfixIcon={{
    icon: <EvoIcon />,
    buttonProps: { a11yText: "Clear" },
  }}
  postfixText={{ id: "", text: "" }}
/>
```

This is less verbose than compound components and lets the parent control accessibility associations. However, it expands the top-level prop surface and is less extensible. For example, making the prefix icon actionable later would require changing `prefixIcon` from a React node to a new object shape.

#### Selected grouped decoration API

```tsx
<EvoInput
  prefix={{
    content: "",
    icon: <EvoIcon />,
    ...spanProps,
  }}
  postfix={{
    content: "",
    icon: <EvoIcon />,
    buttonProps: { a11yText: "Clear" },
    ...spanProps,
  }}
/>
```

We selected this approach because it is compact, keeps related decoration options together, and lets `EvoInput` generate and merge description IDs only when content is present. It also remains extensible: `buttonProps` can be added to `prefix` later without changing the top-level API shape.

### Verification

- `npm run build:storybook -w packages/evo-react`
- `npm run build -w packages/evo-react` — 407 tests passed
- `CI=1 npm run build`

## Screenshots

N/A — the new visual scenarios are available through the added Storybook stories.

## Checklist

<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->

- [ ] I verify the linked issue has been triaged ("Needs Triage" label removed)
- [ ] I verify all changes are within scope of the linked issue
- [ ] I added/updated/removed testing (Storybook in Skin) coverage as appropriate

<!-- For CSS changes -->

- [ ] I tested the UI in all supported browsers
- [ ] I tested the UI in dark mode and RTL mode
