### PR TITLE
docs(evo-react): add prop JSDoc

### DIFF
--- a/.changeset/evo-react-prop-jsdoc.md
+++ b/.changeset/evo-react-prop-jsdoc.md
@@ -1,0 +1,5 @@
+---
+"@evo-web/react": patch
+---
+
+Expose component prop descriptions through generated TypeScript and Storybook documentation.

--- a/.claude/skills/evo-migrate-react/SKILL.md
+++ b/.claude/skills/evo-migrate-react/SKILL.md
@@ -41,7 +41,7 @@ packages/evo-react/src/{name}/
   index.ts                  ← named re-exports only (no default exports)
   {name}.tsx                ← main component
   {subcomponent-name}.tsx   ← sub-components if present (named after actual sub-component, e.g. button-cell.tsx)
-  types.ts                  ← all exported types
+  types.ts                  ← all exported types + prop JSDoc descriptions
   context.ts                ← React context + accessor hook (only if component uses context)
   README.md                 ← component name + Documentation section with Storybook link only
   {name}.stories.tsx        ← Storybook stories (co-located, NOT in __tests__/)
@@ -52,7 +52,7 @@ packages/evo-react/src/{name}/
 
 **Key difference from ebayui-core-react:** tests live in `test/` (not `__tests__/`), stories co-located with source (not inside `__tests__/`).
 
-**README.md format** — keep it minimal, just a Storybook link (props and usage docs live in the story):
+**README.md format** — keep it minimal, just a Storybook link (prop docs come from type JSDoc and usage docs live in Storybook):
 
 ```md
 # EvoButton
@@ -264,17 +264,40 @@ Do not guess — get alignment before migrating this pattern.
 
 Keep all custom types in `types.ts`. Export them from `index.ts`. Do not inline complex types inside the component file.
 
-Do **not** add JSDoc comments to `types.ts`. Type names and the TypeScript type system are self-documenting; prose descriptions belong in Storybook `argTypes`.
+Add JSDoc directly above every custom public prop and every field of a public object type. Prop descriptions in `types.ts` are the source of truth: they are included in generated declarations and Storybook reads them through `react-docgen-typescript`. Migrate existing Storybook `argTypes.description` text into JSDoc, then remove the duplicate story description.
+
+Describe behavior, constraints, relationships to other props, and defaults when relevant. For union props declared in multiple branches, repeat the complete consumer-facing description on every usable declaration so docgen does not expose incomplete branch-specific prose.
 
 ```ts
 // types.ts
 export type Priority = "primary" | "secondary" | "tertiary" | "none";
+
+type BaseButtonProps = {
+  /** Button priority level. */
+  priority?: Priority;
+  /** Full-width button. */
+  fluid?: boolean;
+};
+
+export type AnchorButtonProps = ComponentProps<"a"> &
+  BaseButtonProps & {
+    /** Link URL. Its presence renders the button as an anchor. */
+    href: string;
+  };
+
 export type EvoButtonProps = AnchorButtonProps | NativeButtonProps;
 
 // index.ts
 export { EvoButton } from "./button";
 export type { EvoButtonProps, Priority } from "./types";
 ```
+
+Do not add or redeclare a prop solely to attach documentation. For inherited native React props, prop-name collisions, or union branches that docgen resolves to `never`, keep `argTypes.description` as a targeted fallback if Storybook cannot extract the JSDoc. Verify fallbacks with a production Storybook build rather than guessing.
+
+Accessibility prop JSDoc must follow the repository conventions:
+
+- State the English default with the exact phrase: **English default to be overridden is `"{default}"`**.
+- For `string | null`, include the exact phrase: **Pass `null` explicitly _only_ if alternative accessibility information is present**.
 
 ---
 
@@ -410,7 +433,8 @@ describe("EvoButton SSR", () => {
   ```
 
 - `title` must mirror the ebayui-core-react story title with `ebay` replaced by `evo`.
-- Description format: one-sentence summary followed by a `## Usage` section with the import snippet.
+- Component description format: one-sentence summary followed by a `## Usage` section with the import snippet.
+- Put prop descriptions in type JSDoc, not `argTypes.description`. Storybook `argTypes` should normally contain only controls, options, event actions, table metadata, and docgen fallbacks described in **Types**.
 - **`subcomponents`**: If the component has sub-components (e.g. `EvoAvatarImage` alongside `EvoAvatar`), declare them in the meta using the `subcomponents` field. This causes Storybook's autodocs to render a props table for each sub-component as a separate tab.
 
 ```tsx
@@ -439,7 +463,7 @@ import { EvoButton } from "@evo-web/react/button";
     },
   },
   argTypes: {
-    // one entry per custom prop with control type + description
+    // controls/options/table metadata only; descriptions come from type JSDoc
   },
   args: {
     // sensible defaults
@@ -487,6 +511,9 @@ Keep component entries concise. App owners read these files, not component autho
 - [ ] Individual `EvoIcon*` components used (no `<EbayIcon name="..." />`)
 - [ ] Optional callbacks use `?.` (no `= () => {}` defaults)
 - [ ] Props cross-checked against evo-marko — missing props added, unnecessary props removed or queried
+- [ ] Every custom public prop and public object field has a JSDoc description in `types.ts`
+- [ ] Duplicate `argTypes.description` entries removed; only verified docgen fallbacks remain
+- [ ] Production Storybook build confirms JSDoc descriptions appear in generated prop tables
 - [ ] `aria-label` prop replaced with `a11yText` if evo-marko uses it (mapped internally to `aria-label`); asked if naming is unclear
 - [ ] No `React.Children`, `findComponent`, or child-scanning — asked if encountered
 - [ ] `test/test.browser.tsx` uses `vitest-browser-react`

--- a/packages/evo-react/src/accordion/accordion.stories.tsx
+++ b/packages/evo-react/src/accordion/accordion.stories.tsx
@@ -51,31 +51,23 @@ import {
     size: {
       control: "select",
       options: ["regular", "large"],
-      description: "Size of the accordion",
       table: { defaultValue: { summary: "regular" } },
     },
     a11yText: {
       type: { name: "string", required: true },
       control: "text",
-      description:
-        "Localized role description to announce the component role for a11y users.",
       table: { defaultValue: { summary: "accordion" } },
     },
     open: {
       control: "object",
-      description:
-        "Controlled id or ids of the open items. Use a string for single-open mode or a string array for multi-open mode.",
       table: { type: { summary: "string | string[]" } },
     },
     defaultOpen: {
       control: "object",
-      description:
-        "Initial uncontrolled id or ids of the open items. Use an empty string array for uncontrolled multi-open mode.",
       table: { type: { summary: "string | string[]" } },
     },
     onOpenChange: {
       action: "onOpenChange",
-      description: "Fired when the open item id or ids change",
       table: { category: "Events" },
     },
   },

--- a/packages/evo-react/src/accordion/types.ts
+++ b/packages/evo-react/src/accordion/types.ts
@@ -13,20 +13,28 @@ export type MultipleOpenValue = AccordionId[];
 export type OpenValue = SingleOpenValue | MultipleOpenValue;
 
 type BaseAccordionProps = Omit<ComponentProps<"ul">, "aria-roledescription"> & {
+  /** Size of the accordion. */
   size?: Size;
+  /** Localized role description announced to a11y users. English default to be overridden is `"accordion"`. */
   a11yText?: string;
   children?: ReactNode;
 };
 
 export type SingleAccordionProps = BaseAccordionProps & {
+  /** Controlled id or ids of the open items. Use a string for single-open mode or a string array for multi-open mode. */
   open?: SingleOpenValue;
+  /** Initial uncontrolled id or ids of the open items. Use an empty string array for uncontrolled multi-open mode. */
   defaultOpen?: SingleOpenValue;
+  /** Fired when the open item id or ids change. */
   onOpenChange?: (open: SingleOpenValue) => void;
 };
 
 export type MultipleAccordionProps = BaseAccordionProps & {
+  /** Controlled id or ids of the open items. Use a string for single-open mode or a string array for multi-open mode. */
   open?: MultipleOpenValue;
+  /** Initial uncontrolled id or ids of the open items. Use an empty string array for uncontrolled multi-open mode. */
   defaultOpen?: MultipleOpenValue;
+  /** Fired when the open item id or ids change. */
   onOpenChange?: (open: MultipleOpenValue) => void;
 };
 

--- a/packages/evo-react/src/alert-dialog/alert-dialog.stories.tsx
+++ b/packages/evo-react/src/alert-dialog/alert-dialog.stories.tsx
@@ -45,19 +45,13 @@ import {
   argTypes: {
     open: {
       control: "boolean",
-      description:
-        "Controlled open state. When provided the consumer manages it via `onOpenChange`.",
     },
     defaultOpen: {
       control: "boolean",
-      description:
-        "Initial open state for uncontrolled usage. Ignored when `open` is provided.",
       table: { defaultValue: { summary: "false" } },
     },
     onOpenChange: {
       action: "onOpenChange",
-      description:
-        "Callback fired when the dialog requests to change its open state. Receives the new boolean value.",
       table: { category: "Events" },
     },
     onCancel: {

--- a/packages/evo-react/src/alert-dialog/types.ts
+++ b/packages/evo-react/src/alert-dialog/types.ts
@@ -18,8 +18,11 @@ export type EvoAlertDialogProps = Omit<
   ComponentProps<"dialog">,
   "open" | "role" | "aria-labelledby" | "aria-modal" | "closedby"
 > & {
+  /** Controlled open state. When provided, the consumer manages it via `onOpenChange`. */
   open?: boolean;
+  /** Initial open state for uncontrolled usage. Ignored when `open` is provided. */
   defaultOpen?: boolean;
+  /** Callback fired when the dialog requests to change its open state. Receives the new boolean value. */
   onOpenChange?: (open: boolean) => void;
   children?: ReactNode;
 };

--- a/packages/evo-react/src/avatar/avatar.stories.tsx
+++ b/packages/evo-react/src/avatar/avatar.stories.tsx
@@ -26,7 +26,6 @@ import { EvoAvatar, EvoAvatarImage } from "@evo-web/react/avatar";
     size: {
       control: "select",
       options: ["32", "40", "48", "56", "64", "96", "128"],
-      description: "The pixel size of the avatar. Only specific sizes are supported.",
       table: { defaultValue: { summary: "48" } },
     },
     color: {
@@ -37,19 +36,13 @@ import { EvoAvatar, EvoAvatarImage } from "@evo-web/react/avatar";
     },
     username: {
       control: "text",
-      description:
-        "The username to display. Determines the background color (via hash) and shows the first letter when no image child is present. Omit to show the signed-out icon.",
     },
     knownAspectRatio: {
       control: "number",
-      description:
-        "Optional pre-known image aspect ratio to prevent a flash of incorrectly styled content before the image loads.",
     },
     a11yText: {
       type: { name: "string", required: true },
       control: "text",
-      description:
-        'Accessible label for the avatar (`aria-label`). English default is `"avatar"`. Pass `null` explicitly only if alternative accessibility information is present.',
     },
   },
   args: {

--- a/packages/evo-react/src/avatar/types.ts
+++ b/packages/evo-react/src/avatar/types.ts
@@ -12,16 +12,17 @@ export type Color =
   | "pink";
 
 export type EvoAvatarProps = Omit<ComponentProps<"div">, "role"> & {
+  /** The pixel size of the avatar. Only specific sizes are supported. */
   size?: Size | `${Size}`;
+  /** Background color override for the initials variant. When omitted, color is derived from the username hash. */
   color?: Color;
+  /** The username to display. Determines the background color and first letter. Omit to show the signed-out icon. */
   username?: string;
+  /** Optional pre-known image aspect ratio that prevents a flash of incorrectly styled content before load. */
   knownAspectRatio?: number;
   /**
-   * The `aria-label` of the avatar.
-   *
-   * English default to be overridden is `"avatar"`
-   *
-   * Pass `null` explicitly _only_ if alternative accessibility information is present
+   * Accessible label for the avatar (`aria-label`). English default to be overridden is `"avatar"`.
+   * Pass `null` explicitly _only_ if alternative accessibility information is present.
    */
   a11yText?: string | null;
 };

--- a/packages/evo-react/src/badge/badge.stories.tsx
+++ b/packages/evo-react/src/badge/badge.stories.tsx
@@ -23,19 +23,14 @@ import { EvoBadge } from "@evo-web/react/badge";
   argTypes: {
     number: {
       control: "number",
-      description: "Used as the number to be placed in the badge",
     },
     type: {
       control: "inline-radio",
       options: ["menu", "icon"],
-      description:
-        "The badge type. Omit for the default image badge (role='img').",
     },
     a11yText: {
       type: { name: "string", required: true },
       control: "text",
-      description:
-        'A descriptive label of what the badge represents (e.g. "5 unread items"). Pass `null` explicitly _only_ if alternative accessibility information is present.',
     },
   },
   args: {

--- a/packages/evo-react/src/badge/types.ts
+++ b/packages/evo-react/src/badge/types.ts
@@ -3,7 +3,15 @@ import type { ComponentProps } from "react";
 export type BadgeType = "menu" | "icon";
 
 export type EvoBadgeProps = Omit<ComponentProps<"span">, "role" | "aria-label" | "children"> & {
+  /** Number displayed in the badge. */
   number?: number | string;
+  /** Badge type. Omit for the default image badge (`role="img"`). */
   type?: BadgeType;
+  /**
+   * Descriptive label for what the badge represents, such as `"5 unread items"`.
+   * English default to be overridden is `"notification"` when `number` is omitted,
+   * or `"{number} notifications"` otherwise. Pass `null` explicitly _only_ if
+   * alternative accessibility information is present.
+   */
   a11yText: string | null;
 };

--- a/packages/evo-react/src/breadcrumbs/breadcrumbs.stories.tsx
+++ b/packages/evo-react/src/breadcrumbs/breadcrumbs.stories.tsx
@@ -23,18 +23,12 @@ import { EvoBreadcrumbs } from "@evo-web/react/breadcrumbs";
   argTypes: {
     a11yHeadingText: {
       control: "text",
-      description:
-        'Clipped heading text that labels the breadcrumb navigation region. English default is `"Page navigation"`.',
     },
     a11yHeadingTag: {
       control: "text",
-      description:
-        "HTML heading tag used for the clipped heading. Defaults to `h2`.",
     },
     items: {
       control: "object",
-      description:
-        "List of breadcrumb items. Each item renders as `<a>` when `href` is present, or `<button>` otherwise. Use `as` to render via a framework Link component.",
     },
   },
   args: {

--- a/packages/evo-react/src/breadcrumbs/types.ts
+++ b/packages/evo-react/src/breadcrumbs/types.ts
@@ -4,8 +4,11 @@ type DataAttributes = Record<`data-${string}`, string>;
 
 export type AnchorItem = Omit<ComponentProps<"a">, "children"> &
   DataAttributes & {
+    /** Link destination. Its presence renders the item as an anchor. */
     href: string;
+    /** Custom component used in place of the native anchor, such as a framework Link. */
     as?: ComponentType<ComponentProps<"a">>;
+    /** Breadcrumb item content. */
     content: ReactNode;
   };
 
@@ -13,14 +16,18 @@ export type ButtonItem = Omit<ComponentProps<"button">, "children"> &
   DataAttributes & {
     href?: never;
     as?: never;
+    /** Breadcrumb item content. */
     content: ReactNode;
   };
 
 export type BreadcrumbItem = AnchorItem | ButtonItem;
 
 export type EvoBreadcrumbsProps = Omit<ComponentProps<"nav">, "role"> & {
+  /** Clipped heading text that labels the breadcrumb navigation region. English default to be overridden is `"Page navigation"`. */
   a11yHeadingText?: string;
+  /** HTML heading tag used for the clipped heading. Defaults to `h2`. */
   a11yHeadingTag?: keyof HTMLElementTagNameMap;
+  /** List of items rendered as anchors when `href` is present or buttons otherwise. */
   items: BreadcrumbItem[] | undefined;
   a11yMenuButtonText?: string;
 };

--- a/packages/evo-react/src/button/button.stories.tsx
+++ b/packages/evo-react/src/button/button.stories.tsx
@@ -29,55 +29,43 @@ import { EvoButton } from "@evo-web/react/button";
     priority: {
       control: "select",
       options: ["primary", "secondary", "tertiary", "none"],
-      description: "Button priority level",
     },
     variant: {
       control: "select",
       options: ["standard", "destructive", "form"],
-      description: "Button variant style",
     },
     size: {
       control: "select",
       options: ["small", "large"],
-      description: "Button size",
     },
     bodyState: {
       control: "select",
       options: ["loading", "expand", "reset", "none"],
-      description: "Button body state",
     },
     split: {
       control: "select",
       options: ["start", "end"],
-      description: "Split button position",
     },
     fluid: {
       control: "boolean",
-      description: "Full width button",
     },
     disabled: {
       control: "boolean",
-      description: "Disabled state",
     },
     partiallyDisabled: {
       control: "boolean",
-      description: "Partially disabled (aria-disabled)",
     },
     transparent: {
       control: "boolean",
-      description: "Transparent background",
     },
     borderless: {
       control: "boolean",
-      description: "No border",
     },
     fixedHeight: {
       control: "boolean",
-      description: "Fixed height",
     },
     truncate: {
       control: "boolean",
-      description: "Truncate text with ellipsis",
     },
     href: {
       control: "text",
@@ -85,8 +73,6 @@ import { EvoButton } from "@evo-web/react/button";
     },
     as: {
       control: false,
-      description:
-        "Override the anchor element with a custom component (e.g. React Router's `Link`). Only applies when `href` is provided.",
     },
     children: {
       control: "text",

--- a/packages/evo-react/src/button/types.ts
+++ b/packages/evo-react/src/button/types.ts
@@ -7,24 +7,38 @@ export type BodyState = "loading" | "expand" | "reset" | "none";
 export type Split = "start" | "end";
 
 type BaseButtonProps = {
+  /** Full-width button. */
   fluid?: boolean;
+  /** Partially disabled state (`aria-disabled`). */
   partiallyDisabled?: boolean;
+  /** Truncates text with an ellipsis. */
   truncate?: boolean;
+  /** Button priority level. */
   priority?: Priority;
+  /** Button variant style. */
   variant?: Variant;
+  /** Button size. */
   size?: Size;
+  /** Button body state. */
   bodyState?: BodyState;
+  /** Split button position. */
   split?: Split;
+  /** Transparent background. */
   transparent?: boolean;
+  /** Removes the border. */
   borderless?: boolean;
+  /** Applies a fixed height. */
   fixedHeight?: boolean;
 };
 
 export type AnchorButtonProps = ComponentProps<"a"> &
   BaseButtonProps & {
+    /** Link URL. Its presence renders the button as an anchor. */
     href: string;
+    /** Custom component used in place of the native anchor. Only applies when `href` is provided. */
     as?: ComponentType<ComponentProps<"a">>;
     onEscape?: (e: KeyboardEvent<HTMLAnchorElement>) => void;
+    /** Disabled state. */
     disabled?: boolean;
   };
 

--- a/packages/evo-react/src/calendar/calendar.stories.tsx
+++ b/packages/evo-react/src/calendar/calendar.stories.tsx
@@ -26,102 +26,68 @@ import { EvoCalendar } from "@evo-web/react/calendar";
     selectMode: {
       control: "select",
       options: ["day", "range"],
-      description:
-        'When set, day cells render as `<button>` elements for date selection. `"day"` selects a single date; `"range"` selects a start/end range. Omit for a non-interactive calendar.',
     },
     locale: {
       type: "string",
       control: "text",
-      description:
-        "[BCP 47 language tag](https://developer.mozilla.org/en-US/docs/Glossary/BCP_47_language_tag) used for month and weekday labels.",
       table: { defaultValue: { summary: "navigator.language || 'en-US'" } },
     },
     today: {
       type: "string",
       control: "text",
-      description:
-        "Override the date the calendar treats as today (`YYYY-MM-DD`). Defaults to the current local date.",
     },
     selected: {
       control: "object",
-      description:
-        "The selected date. Accepts a single `DayISO` string in day mode or a `{ from: DayISO; to: DayISO }` range object in range mode.",
     },
     defaultSelected: {
       control: "object",
-      description:
-        "Initial uncontrolled selected value. Accepts a single `DayISO` string in day mode or a `{ from: DayISO; to: DayISO }` range object in range mode.",
     },
     visibleMonthCount: {
       type: "number",
       control: "number",
-      description: "Number of months to display simultaneously.",
       table: { defaultValue: { summary: "1" } },
     },
     visibleMonth: {
       type: "string",
       control: "text",
-      description:
-        "Controlled first displayed month (`YYYY-MM`). Defaults to the month containing `today`.",
     },
     defaultVisibleMonth: {
       type: "string",
       control: "text",
-      description: "Initial uncontrolled first displayed month (`YYYY-MM`).",
     },
     disable: {
       control: "object",
-      description:
-        "Config for disabling dates: `{ before?: DayISO, after?: DayISO, weekdays?: number[], list?: DayISO[], callback?: (iso) => boolean }`. Weekdays: 0=Sun … 6=Sat.",
     },
     getDayHref: {
       control: false,
-      description:
-        "Function `(iso: DayISO) => string | false | null | undefined` that marks native anchor days when `selectMode` is not set. A falsy return renders a `<span>`; omit `getDayHref` if `dayLinkAs` should render every non-disabled day.",
     },
     dayLinkAs: {
       control: false,
-      description:
-        "Custom component for static day links. Receives `{ iso, href, className, children }`, so routing links can derive their destination from `iso` or use `href` from `getDayHref`. When paired with `getDayHref`, only days with a truthy `getDayHref` result use `dayLinkAs`.",
     },
     a11yNavigateText: {
       control: false,
-      description:
-        "Function `(monthName: string, dir: 'next' | 'prev') => string` returning an accessible label for the prev/next navigation buttons. Its presence enables the navigation header.",
     },
     a11yTodayText: {
       type: "string",
       control: "text",
-      description:
-        "Clipped text appended to today's cell for screen readers in non-interactive calendars.",
     },
     a11yDisabledText: {
       type: "string",
       control: "text",
-      description:
-        "Clipped text appended to disabled cells for screen readers in non-interactive calendars.",
     },
     a11ySelectedText: {
       type: "string",
       control: "text",
-      description:
-        "Clipped text appended to selected cells for screen readers in non-interactive calendars.",
     },
     a11yRangeText: {
       control: "object",
-      description:
-        "Clipped text for range cells. Object with `start`, `end`, and `in` keys. Required when a range is or will be selected.",
     },
     onSelectedChange: {
       action: "onSelectedChange",
-      description:
-        "Triggered when an interactive calendar selects a day or range.",
       table: { category: "Events" },
     },
     onVisibleMonthChange: {
       action: "onVisibleMonthChange",
-      description:
-        "Triggered when month navigation changes the first displayed month.",
       table: { category: "Events" },
     },
   },

--- a/packages/evo-react/src/calendar/types.ts
+++ b/packages/evo-react/src/calendar/types.ts
@@ -4,71 +4,111 @@ export type DayISO = `${number}-${number}-${number}`;
 export type MonthISO = `${number}-${number}`;
 
 export type Disable = {
+  /** Disables dates before this date. */
   before?: DayISO;
+  /** Disables dates after this date. */
   after?: DayISO;
+  /** Disables weekdays by index, where 0 is Sunday and 6 is Saturday. */
   weekdays?: number[];
+  /** Disables the listed dates. */
   list?: DayISO[];
+  /** Disables dates for which the callback returns true. */
   callback?: (iso: DayISO) => boolean;
 };
 
 export type DateRange = {
+  /** Start of the selected date range. */
   from?: DayISO;
+  /** End of the selected date range. */
   to?: DayISO;
 };
 
 export type A11yRangeText = {
+  /** Clipped text for the start of a range. */
   start: string;
+  /** Clipped text for the end of a range. */
   end: string;
+  /** Clipped text for a date within a range. */
   in: string;
 };
 
 export type DayLinkAsProps = {
+  /** ISO date represented by the day link. */
   iso: DayISO;
+  /** Link destination returned by `getDayHref`. */
   href?: string;
+  /** Skin class names for the day link. */
   className?: string;
+  /** Day label content. */
   children?: ReactNode;
 };
 
 export type DayLinkAs = ComponentType<DayLinkAsProps>;
 
 type BaseCalendarProps = Omit<ComponentProps<"div">, "onSelect"> & {
+  /** Number of months to display simultaneously. */
   visibleMonthCount?: number;
+  /** [BCP 47 language tag](https://developer.mozilla.org/en-US/docs/Glossary/BCP_47_language_tag) for month and weekday labels. */
   locale?: string;
+  /** Date treated as today (`YYYY-MM-DD`). Defaults to the current local date. */
   today?: DayISO;
+  /** Config for disabling dates: `{ before?: DayISO, after?: DayISO, weekdays?: number[], list?: DayISO[], callback?: (iso) => boolean }`. Weekdays: 0=Sun … 6=Sat. */
   disable?: Disable;
+  /** Controlled first displayed month (`YYYY-MM`). Defaults to the month containing `today`. */
   visibleMonth?: MonthISO;
+  /** Initial uncontrolled first displayed month (`YYYY-MM`). */
   defaultVisibleMonth?: MonthISO;
+  /** Triggered when navigation changes the first displayed month. */
   onVisibleMonthChange?: (visibleMonth: MonthISO) => void;
+  /** Function `(monthName: string, dir: 'next' | 'prev') => string` returning an accessible label for the prev/next navigation buttons. Its presence enables the navigation header. */
   a11yNavigateText?: (monthName: string, dir: "next" | "prev") => string;
 };
 
 type StaticBaseCalendarProps = BaseCalendarProps & {
+  /** When set, day cells render as `<button>` elements for date selection. `"day"` selects a single date; `"range"` selects a start/end range. Omit for a non-interactive calendar. */
   selectMode?: undefined;
+  /** Function `(iso: DayISO) => string | false | null | undefined` that marks native anchor days when `selectMode` is not set. A falsy return renders a `<span>`; omit `getDayHref` if `dayLinkAs` should render every non-disabled day. */
   getDayHref?: (iso: DayISO) => string | false | null | undefined;
+  /** Custom component for static day links. Receives `{ iso, href, className, children }`, so routing links can derive their destination from `iso` or use `href` from `getDayHref`. When paired with `getDayHref`, only days with a truthy `getDayHref` result use `dayLinkAs`. */
   dayLinkAs?: DayLinkAs;
+  /** Clipped text appended to today's cell for screen readers. */
   a11yTodayText?: string;
+  /** Clipped text appended to disabled cells for screen readers. */
   a11yDisabledText?: string;
+  /** Clipped text appended to selected cells for screen readers. */
   a11ySelectedText?: string;
 };
 
 export type StaticSingleCalendarProps = StaticBaseCalendarProps & {
+  /** The selected date. Accepts a single `DayISO` string in day mode or a `{ from: DayISO; to: DayISO }` range object in range mode. */
   selected?: DayISO;
+  /** Initial uncontrolled selected value. Accepts a single `DayISO` string in day mode or a `{ from: DayISO; to: DayISO }` range object in range mode. */
   defaultSelected?: DayISO;
+  /** Triggered when an interactive calendar selects a day or range. */
   onSelectedChange?: (selected: DayISO) => void;
+  /** Clipped text for range cells. Required when a range is or will be selected. */
   a11yRangeText?: A11yRangeText;
 };
 
 export type StaticSelectedRangeCalendarProps = StaticBaseCalendarProps & {
+  /** The selected date. Accepts a single `DayISO` string in day mode or a `{ from: DayISO; to: DayISO }` range object in range mode. */
   selected: DateRange;
+  /** Initial uncontrolled selected value. Accepts a single `DayISO` string in day mode or a `{ from: DayISO; to: DayISO }` range object in range mode. */
   defaultSelected?: DateRange;
+  /** Triggered when an interactive calendar selects a day or range. */
   onSelectedChange?: (selected: DateRange) => void;
+  /** Clipped text for range cells. Required when a range is or will be selected. */
   a11yRangeText: A11yRangeText;
 };
 
 export type StaticDefaultRangeCalendarProps = StaticBaseCalendarProps & {
+  /** The selected date. Accepts a single `DayISO` string in day mode or a `{ from: DayISO; to: DayISO }` range object in range mode. */
   selected?: DateRange;
+  /** Initial uncontrolled selected value. Accepts a single `DayISO` string in day mode or a `{ from: DayISO; to: DayISO }` range object in range mode. */
   defaultSelected: DateRange;
+  /** Triggered when an interactive calendar selects a day or range. */
   onSelectedChange?: (selected: DateRange) => void;
+  /** Clipped text for range cells. Required when a range is or will be selected. */
   a11yRangeText: A11yRangeText;
 };
 
@@ -78,18 +118,28 @@ export type StaticCalendarProps =
   | StaticDefaultRangeCalendarProps;
 
 export type DayCalendarProps = BaseCalendarProps & {
+  /** When set, day cells render as `<button>` elements for date selection. `"day"` selects a single date; `"range"` selects a start/end range. Omit for a non-interactive calendar. */
   selectMode: "day";
+  /** The selected date. Accepts a single `DayISO` string in day mode or a `{ from: DayISO; to: DayISO }` range object in range mode. */
   selected?: DayISO;
+  /** Initial uncontrolled selected value. Accepts a single `DayISO` string in day mode or a `{ from: DayISO; to: DayISO }` range object in range mode. */
   defaultSelected?: DayISO;
+  /** Triggered when an interactive calendar selects a day or range. */
   onSelectedChange?: (selected: DayISO) => void;
+  /** Clipped text for range cells. Required when a range is or will be selected. */
   a11yRangeText?: A11yRangeText;
 };
 
 export type RangeCalendarProps = BaseCalendarProps & {
+  /** When set, day cells render as `<button>` elements for date selection. `"day"` selects a single date; `"range"` selects a start/end range. Omit for a non-interactive calendar. */
   selectMode: "range";
+  /** The selected date. Accepts a single `DayISO` string in day mode or a `{ from: DayISO; to: DayISO }` range object in range mode. */
   selected?: DateRange;
+  /** Initial uncontrolled selected value. Accepts a single `DayISO` string in day mode or a `{ from: DayISO; to: DayISO }` range object in range mode. */
   defaultSelected?: DateRange;
+  /** Triggered when an interactive calendar selects a day or range. */
   onSelectedChange?: (selected: DateRange) => void;
+  /** Clipped text for range cells. Required when a range is or will be selected. */
   a11yRangeText: A11yRangeText;
 };
 

--- a/packages/evo-react/src/ccd/ccd.stories.tsx
+++ b/packages/evo-react/src/ccd/ccd.stories.tsx
@@ -23,33 +23,24 @@ import { EvoCCD } from "@evo-web/react/ccd";
     argTypes: {
         max: {
             control: "text",
-            description:
-                "The maximum power range value. When both min and max are unset the description figure is hidden.",
         },
         min: {
             control: "text",
-            description:
-                "The minimum power range value. When both min and max are unset the description figure is hidden.",
         },
         chargerIcon: {
             control: "select",
             options: ["included", "not-included"],
-            description: "Shows a charger icon indicating whether a charger is included or not.",
         },
         units: {
             control: "text",
-            description: "The unit label displayed beneath the power range.",
             table: { defaultValue: { summary: "W" } },
         },
         secondaryType: {
             control: "select",
             options: ["usbpd"],
-            description: 'When set to "usbpd", displays the "USB PD" secondary label.',
         },
         a11yText: {
             control: "text",
-            description:
-                'Accessible label for the figure. Pass `null` explicitly only if alternative accessibility information is present. English default: "Charger included. {min} - {max} Watts. USB PD"',
             type: { name: "string", required: true },
         },
     },

--- a/packages/evo-react/src/ccd/types.ts
+++ b/packages/evo-react/src/ccd/types.ts
@@ -4,10 +4,20 @@ export type ChargerIcon = "included" | "not-included";
 export type SecondaryType = "usbpd";
 
 export type EvoCCDProps = Omit<ComponentProps<"div">, "aria-label"> & {
+    /** Maximum power range value. When both `min` and `max` are unset, the description figure is hidden. */
     max?: string;
+    /** Minimum power range value. When both `min` and `max` are unset, the description figure is hidden. */
     min?: string;
+    /** Shows whether a charger is included. */
     chargerIcon?: ChargerIcon;
+    /** Unit label displayed beneath the power range. */
     units?: string;
+    /** Displays the `"USB PD"` secondary label when set to `"usbpd"`. */
     secondaryType?: SecondaryType;
+    /**
+     * Accessible label for the figure. English default to be overridden is
+     * `"Charger included. {min} - {max} Watts. USB PD"`. Pass `null` explicitly
+     * _only_ if alternative accessibility information is present.
+     */
     a11yText: string | null;
 };

--- a/packages/evo-react/src/character-count/character-count.stories.tsx
+++ b/packages/evo-react/src/character-count/character-count.stories.tsx
@@ -27,27 +27,19 @@ import { EvoCharacterCount } from "@evo-web/react/character-count";
   argTypes: {
     text: {
       control: "text",
-      description:
-        "Text whose grapheme characters are counted. Required unless count is provided.",
     },
     count: {
       control: "number",
-      description: "Manual count used instead of calculating from text.",
     },
     max: {
       control: "number",
-      description: "Maximum number of characters allowed.",
     },
     a11yText: {
       type: { name: "string", required: true },
       control: "text",
-      description:
-        'Clipped text announced after the count. English default to be overridden is "characters used". Pass `null` explicitly only if alternative accessibility information is present.',
     },
     inputRef: {
       control: false,
-      description:
-        'Reference to the associated input or textarea. Its `aria-live` is set to "polite" when the count exceeds the maximum.',
     },
     children: {
       control: false,

--- a/packages/evo-react/src/character-count/types.ts
+++ b/packages/evo-react/src/character-count/types.ts
@@ -2,11 +2,14 @@ import type { ComponentProps, RefObject } from "react";
 
 type CharacterCountSource =
   | {
+      /** Text whose grapheme characters are counted. Required unless `count` is provided. */
       text: string;
+      /** Manual count used instead of calculating from `text`. */
       count?: number;
     }
   | {
       text?: never;
+      /** Manual count used instead of calculating from `text`. */
       count: number;
     };
 
@@ -16,12 +19,14 @@ export type CharacterCountInputRef = RefObject<
 
 export type EvoCharacterCountProps = ComponentProps<"span"> &
   CharacterCountSource & {
+    /** Maximum number of characters allowed. */
     max: number;
     /**
-     * Clipped text for screen readers. English default to be overridden is
-     * `"characters used"`. Pass `null` explicitly _only_ if alternative
+     * Clipped text announced after the count. English default to be overridden
+     * is `"characters used"`. Pass `null` explicitly _only_ if alternative
      * accessibility information is present.
      */
     a11yText?: string | null;
+    /** Reference to the associated input or textarea. Its `aria-live` becomes `"polite"` above the maximum. */
     inputRef?: CharacterCountInputRef;
   };

--- a/packages/evo-react/src/confirm-dialog/confirm-dialog.stories.tsx
+++ b/packages/evo-react/src/confirm-dialog/confirm-dialog.stories.tsx
@@ -45,19 +45,13 @@ import {
   argTypes: {
     open: {
       control: "boolean",
-      description:
-        "Controlled open state. When provided the consumer manages it via `onOpenChange`.",
     },
     defaultOpen: {
       control: "boolean",
-      description:
-        "Initial open state for uncontrolled usage. Ignored when `open` is provided.",
       table: { defaultValue: { summary: "false" } },
     },
     onOpenChange: {
       action: "onOpenChange",
-      description:
-        "Callback fired when the dialog requests to change its open state. Receives the new boolean value.",
       table: { category: "Events" },
     },
     onCancel: {

--- a/packages/evo-react/src/confirm-dialog/types.ts
+++ b/packages/evo-react/src/confirm-dialog/types.ts
@@ -20,8 +20,11 @@ export type EvoConfirmDialogProps = Omit<
   ComponentProps<"dialog">,
   "open" | "role" | "aria-labelledby" | "aria-modal" | "closedby"
 > & {
+  /** Controlled open state. When provided, the consumer manages it via `onOpenChange`. */
   open?: boolean;
+  /** Initial open state for uncontrolled usage. Ignored when `open` is provided. */
   defaultOpen?: boolean;
+  /** Callback fired when the dialog requests to change its open state. Receives the new boolean value. */
   onOpenChange?: (open: boolean) => void;
   children?: ReactNode;
 };

--- a/packages/evo-react/src/details/details.stories.tsx
+++ b/packages/evo-react/src/details/details.stories.tsx
@@ -44,13 +44,11 @@ import {
     size: {
       control: "select",
       options: ["regular", "small"],
-      description: "Size of the summary",
       table: { defaultValue: { summary: "regular" } },
     },
     alignment: {
       control: "select",
       options: ["regular", "center"],
-      description: "Alignment of the summary",
       table: { defaultValue: { summary: "regular" } },
     },
     open: {
@@ -60,7 +58,6 @@ import {
     },
     onToggle: {
       action: "onToggle",
-      description: "Fired on toggle with `(event, { open })` arguments",
       table: { category: "Events" },
     },
   },

--- a/packages/evo-react/src/details/types.ts
+++ b/packages/evo-react/src/details/types.ts
@@ -4,8 +4,11 @@ export type Size = "regular" | "small";
 export type Alignment = "regular" | "center";
 
 export type EvoDetailsProps = Omit<ComponentProps<"details">, "onToggle"> & {
+  /** Size of the summary. */
   size?: Size;
+  /** Alignment of the summary. */
   alignment?: Alignment;
+  /** Fired on toggle with `(event, { open })` arguments. */
   onToggle?: (
     event: SyntheticEvent<HTMLDetailsElement>,
     data: { open: boolean },

--- a/packages/evo-react/src/filter-chip/filter-chip.stories.tsx
+++ b/packages/evo-react/src/filter-chip/filter-chip.stories.tsx
@@ -27,16 +27,12 @@ import { EvoFilterChip } from "@evo-web/react/filter-chip";
     variant: {
       control: "select",
       options: ["default", "expressive", "menu"],
-      description:
-        "Visual and interaction variant. Menu variants toggle open state; all others toggle selected state.",
     },
     selected: {
       control: "boolean",
-      description: "Controlled selected state.",
     },
     defaultSelected: {
       control: "boolean",
-      description: "Initial selected state when uncontrolled.",
     },
     open: {
       control: "boolean",
@@ -48,7 +44,6 @@ import { EvoFilterChip } from "@evo-web/react/filter-chip";
     },
     disabled: {
       control: "boolean",
-      description: "Disables interaction.",
     },
     href: {
       control: "text",
@@ -58,21 +53,15 @@ import { EvoFilterChip } from "@evo-web/react/filter-chip";
     a11ySelectedText: {
       type: "string",
       control: "text",
-      description:
-        "Localized clipped text announced when an anchor or menu filter is selected. Required with href.",
     },
     icon: {
       control: false,
-      description: "Leading icon rendered by the default variant.",
     },
     image: {
       control: false,
-      description: "Leading image rendered by the expressive variant.",
     },
     onClick: {
       action: "onClick",
-      description:
-        "Triggered with the click event and `{ selected }`, or `{ open }` for menu variants.",
       table: { category: "Events" },
     },
     children: {

--- a/packages/evo-react/src/filter-chip/types.ts
+++ b/packages/evo-react/src/filter-chip/types.ts
@@ -18,22 +18,33 @@ export type FilterChipOpenEvent = {
 export type FilterChipEvent = FilterChipSelectedEvent | FilterChipOpenEvent;
 
 type BaseFilterChipProps = {
+  /** Filter label. */
   children?: ReactNode;
+  /** Controlled selected state. */
   selected?: boolean;
+  /** Initial selected state when uncontrolled. */
   defaultSelected?: boolean;
+  /** Leading icon rendered by the default variant. */
   icon?: ReactElement;
+  /** Leading image rendered by the expressive variant. */
   image?: ReactElement<ComponentProps<"img">>;
+  /** Localized clipped text announced when an anchor or menu filter is selected. Required with `href`. */
   a11ySelectedText?: string;
+  /** Disables interaction. */
   disabled?: boolean;
 };
 
 export type AnchorFilterChipProps = Omit<ComponentProps<"a">, "onClick"> &
   BaseFilterChipProps & {
+    /** Link destination. Requires `a11ySelectedText` and is unavailable for the menu variant. */
     href: string;
+    /** Localized clipped text announced when the anchor filter is selected. */
     a11ySelectedText: string;
+    /** Visual and interaction variant. Menu variants toggle open state; all others toggle selected state. */
     variant?: FilterChipVariant;
     open?: never;
     defaultOpen?: never;
+    /** Triggered with the click event and `{ selected }`, or `{ open }` for menu variants. */
     onClick?: (
       event: MouseEvent<HTMLAnchorElement>,
       data: FilterChipSelectedEvent,
@@ -43,9 +54,11 @@ export type AnchorFilterChipProps = Omit<ComponentProps<"a">, "onClick"> &
 export type NativeFilterChipProps = Omit<ComponentProps<"button">, "onClick"> &
   BaseFilterChipProps & {
     href?: never;
+    /** Visual and interaction variant. Menu variants toggle open state; all others toggle selected state. */
     variant?: FilterChipVariant;
     open?: never;
     defaultOpen?: never;
+    /** Triggered with the click event and `{ selected }`, or `{ open }` for menu variants. */
     onClick?: (
       event: MouseEvent<HTMLButtonElement>,
       data: FilterChipSelectedEvent,
@@ -55,9 +68,13 @@ export type NativeFilterChipProps = Omit<ComponentProps<"button">, "onClick"> &
 export type MenuFilterChipProps = Omit<ComponentProps<"button">, "onClick"> &
   BaseFilterChipProps & {
     href?: never;
+    /** Visual and interaction variant. Menu variants toggle open state; all others toggle selected state. */
     variant: "menu";
+    /** Controlled open state for the menu variant. */
     open?: boolean;
+    /** Initial open state for an uncontrolled menu variant. */
     defaultOpen?: boolean;
+    /** Triggered with the click event and `{ selected }`, or `{ open }` for menu variants. */
     onClick?: (
       event: MouseEvent<HTMLButtonElement>,
       data: FilterChipOpenEvent,

--- a/packages/evo-react/src/icon-button/icon-button.stories.tsx
+++ b/packages/evo-react/src/icon-button/icon-button.stories.tsx
@@ -32,8 +32,6 @@ import { EvoIconButton } from "@evo-web/react/icon-button";
   },
   argTypes: {
     a11yText: {
-      description:
-        "Accessible label for the button (mapped to `aria-label`). Pass `null` only if alternative a11y info is present.",
       type: { name: "string", required: true },
       control: "text",
     },
@@ -43,29 +41,22 @@ import { EvoIconButton } from "@evo-web/react/icon-button";
     },
     as: {
       control: false,
-      description:
-        "Override the anchor element with a custom component (e.g. React Router's `Link`). Only applies when `href` is provided.",
     },
     priority: {
-      description: "Button priority level",
       options: ["primary", "secondary", "tertiary", "none"],
       control: { type: "select" },
     },
     size: {
-      description: "Alternative size: `large` or `small`",
       options: ["large", "small"],
       control: { type: "select" },
     },
     transparent: {
-      description: "Transparent background",
       control: "boolean",
     },
     partiallyDisabled: {
-      description: "Visually disabled but still focusable (`aria-disabled`)",
       control: "boolean",
     },
     disabled: {
-      description: "Fully disabled",
       control: "boolean",
     },
     onClick: {
@@ -77,7 +68,6 @@ import { EvoIconButton } from "@evo-web/react/icon-button";
       },
     },
     onEscape: {
-      description: "Triggered on Esc key press",
       action: "onEscape",
       table: {
         category: "Events",

--- a/packages/evo-react/src/icon-button/types.ts
+++ b/packages/evo-react/src/icon-button/types.ts
@@ -5,19 +5,32 @@ import type { EvoBadgeProps } from "../badge/types";
 export type { Priority, Size };
 
 type BaseIconButtonProps = {
+  /** Transparent background. */
   transparent?: boolean;
+  /** Button priority level. */
   priority?: Priority;
+  /** Alternative size: `large` or `small`. */
   size?: Size;
+  /** Visually disabled but still focusable (`aria-disabled`). */
   partiallyDisabled?: boolean;
+  /**
+   * Accessible label for the button, mapped to `aria-label`. English default to
+   * be overridden is `"button"`. Pass `null` explicitly _only_ if alternative
+   * accessibility information is present.
+   */
   a11yText: string | null;
 };
 
 export type AnchorIconButtonProps = Omit<ComponentProps<"a">, "ref"> &
   BaseIconButtonProps & {
+    /** Renders as an anchor element when provided. */
     href: string;
+    /** Custom component used in place of the native anchor. Only applies when `href` is provided. */
     as?: ComponentType<ComponentProps<"a">>;
     ref?: Ref<HTMLAnchorElement>;
+    /** Triggered on Escape key press. */
     onEscape?: (e: KeyboardEvent<HTMLAnchorElement>) => void;
+    /** Fully disabled. */
     disabled?: boolean;
   };
 
@@ -26,6 +39,7 @@ export type NativeIconButtonProps = Omit<ComponentProps<"button">, "ref"> &
     href?: never;
     as?: never;
     ref?: Ref<HTMLButtonElement>;
+    /** Triggered on Escape key press. */
     onEscape?: (e: KeyboardEvent<HTMLButtonElement>) => void;
   };
 

--- a/packages/evo-react/src/icon/icon.stories.tsx
+++ b/packages/evo-react/src/icon/icon.stories.tsx
@@ -1152,16 +1152,13 @@ const meta: Meta<EvoIconComponentProps> = {
   argTypes: {
     a11yText: {
       control: "text",
-      description: "Accessible label text for the icon. When provided, the icon will have role=\"img\".",
     },
     a11yVariant: {
       control: "select",
       options: ["label"],
-      description: "Controls how the accessible text is exposed. \"label\" uses aria-label directly; default uses a <title> element with aria-labelledby.",
     },
     prominent: {
       control: "boolean",
-      description: "Applies the prominent style modifier to the icon.",
     },
   },
   parameters: {

--- a/packages/evo-react/src/icon/icon.tsx
+++ b/packages/evo-react/src/icon/icon.tsx
@@ -21,8 +21,11 @@ export type EvoIconProps = SVGProps<SVGSVGElement> & {
    * @internal
    */
   __name: string;
+  /** Accessible label text. When provided, the icon has `role="img"`. */
   a11yText?: string;
+  /** Controls how accessible text is exposed. `"label"` uses `aria-label`; the default uses `title` and `aria-labelledby`. */
   a11yVariant?: A11yVariant;
+  /** Applies the prominent style modifier. */
   prominent?: boolean;
   /**
    * Internal use only - SVG symbol content


### PR DESCRIPTION
<!-- Insert GitHub issue number below. An issue is required for all PRs -->

- Fixes #

## Description

- Move evo-react prop descriptions from Storybook `argTypes` into TypeScript JSDoc so generated declarations and Storybook autodocs share one source of truth.
- Retain targeted Storybook description fallbacks only where React docgen cannot infer inherited, colliding, or union props.
- Update the evo-react migration skill to require type-level prop documentation and verify generated Storybook tables.
- Add a patch changeset for `@evo-web/react`.

## Notes

Storybook uses the configured `react-docgen-typescript` integration to extract these descriptions. No runtime prop declarations or component behavior changed.

## Screenshots

N/A — no visual changes.

## Checklist

<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->

- [ ] I verify the linked issue has been triaged ("Needs Triage" label removed)
- [ ] I verify all changes are within scope of the linked issue
- [ ] I added/updated/removed testing (Storybook in Skin) coverage as appropriate
