### PR TITLE
feat(cta-button): add Evo React component

### DIFF
--- a/.changeset/soft-otters-call.md
+++ b/.changeset/soft-otters-call.md
@@ -1,0 +1,6 @@
+---
+"@evo-web/marko": patch
+"@evo-web/react": patch
+---
+
+Add EvoCtaButton and CTA button modifier props.

--- a/.claude/skills/evo-app-migrate-react/SKILL.md
+++ b/.claude/skills/evo-app-migrate-react/SKILL.md
@@ -70,6 +70,7 @@ When migrating a listed component, read the linked file completely and apply the
 | `ebay-calendar`             | [evo-calendar.md](components/evo-calendar.md)                                           |
 | `ebay-ccd`                  | [evo-ccd.md](components/evo-ccd.md)                                                     |
 | `ebay-character-count`      | [evo-character-count.md](components/evo-character-count.md)                             |
+| `ebay-cta-button`           | [evo-cta-button.md](components/evo-cta-button.md)                                       |
 | `ebay-details`              | [evo-details.md](components/evo-details.md)                                             |
 | `ebay-confirm-dialog`       | [evo-confirm-dialog.md](components/evo-confirm-dialog.md)                               |
 | `ebay-filter-chip`          | [evo-filter-chip.md](components/evo-filter-chip.md)                                     |

--- a/.claude/skills/evo-app-migrate-react/components/evo-cta-button.md
+++ b/.claude/skills/evo-app-migrate-react/components/evo-cta-button.md
@@ -1,0 +1,48 @@
+# ebay-cta-button → evo-cta-button
+
+## Import change
+
+```diff
+- import { EbayCtaButton } from "@ebay/ui-core-react/ebay-cta-button";
++ import { EvoCtaButton } from "@evo-web/react/cta-button";
+```
+
+## Prop changes
+
+### Renamed: `truncate` → `truncated`
+
+```diff
+- <EbayCtaButton href="/action" truncate>
++ <EvoCtaButton href="/action" truncated>
+    Take action
+- </EbayCtaButton>
++ </EvoCtaButton>
+```
+
+### Changed: `size`
+
+`size` now accepts only `"large"`. Omit it to replace the legacy `"small"` value with the default size.
+
+```diff
+- <EbayCtaButton href="/action" size="small">
++ <EvoCtaButton href="/action">
+    Take action
+- </EbayCtaButton>
++ </EvoCtaButton>
+```
+
+### New: `as`
+
+Use `as` to replace the native anchor with a framework link component.
+
+```tsx
+import Link from "next/link";
+
+<EvoCtaButton href="/action" as={Link}>
+  Take action
+</EvoCtaButton>;
+```
+
+## Unchanged props
+
+`fluid` and native anchor attributes require no migration beyond the global component and import renames.

--- a/.claude/skills/evo-migrate-react/SKILL.md
+++ b/.claude/skills/evo-migrate-react/SKILL.md
@@ -491,8 +491,11 @@ After completing the component, update `.claude/skills/evo-app-migrate-react/`:
    - Type changes
    - Behavior differences
    - New composition requirements, if the React API changed to named sub-components
-3. If nothing changed beyond the global renames, write: `No prop changes. Global renames from Step 2 are sufficient.`
-4. Update `.claude/skills/evo-app-migrate-react/SKILL.md` **only as an index**:
+3. Include concise consumer code examples:
+   - Before/after diffs for renamed, removed, or type-changed props that require migration
+   - TSX examples for new props or composition patterns
+4. If nothing changed beyond the global renames, write: `No prop changes. Global renames from Step 2 are sufficient.`
+5. Update `.claude/skills/evo-app-migrate-react/SKILL.md` **only as an index**:
    - Add a row for `ebay-{name}` under **Step 3 — Apply per-component prop changes**.
    - Link that row to `components/evo-{name}.md`.
    - Do not inline per-component migration details in `SKILL.md`.

--- a/packages/evo-marko/src/tags/evo-cta-button/cta-button.stories.ts
+++ b/packages/evo-marko/src/tags/evo-cta-button/cta-button.stories.ts
@@ -18,11 +18,22 @@ export default {
   },
 
   argTypes: {
+    fluid: {
+      type: "boolean",
+      control: "boolean",
+      description: "Expand to the full width of the parent element",
+    },
     size: {
       type: "string",
-      options: ["normal (default)", "large"],
-      control: "inline-radio",
-      description: "Size of the CTA button",
+      options: ["large"],
+      control: "select",
+      description: "Use the large CTA button size",
+    },
+    truncated: {
+      type: "boolean",
+      control: "boolean",
+      description:
+        "Truncate overflowing text to a single line with an ellipsis",
     },
     href: {
       type: "string",
@@ -42,6 +53,7 @@ export const Default = buildExtensionTemplate(
   DefaultTemplateCode,
   {
     href: "https://www.ebay.com",
-    size: "regular",
+    fluid: false,
+    truncated: false,
   },
 );

--- a/packages/evo-marko/src/tags/evo-cta-button/index.marko
+++ b/packages/evo-marko/src/tags/evo-cta-button/index.marko
@@ -1,13 +1,30 @@
 export interface Input extends Marko.HTML.A {
-    size?: "large";
+  fluid?: boolean;
+  size?: "large";
+  truncated?: boolean;
 }
-<const/{ size, class: inputClass, content, ...htmlInput }=input>
+<const/{
+  fluid,
+  size,
+  truncated,
+  class: inputClass,
+  content,
+  ...htmlInput
+}=input>
 
-<a ...htmlInput class=["cta-btn", size && `cta-btn--${size}`, inputClass]>
-    <span class="cta-btn__cell">
-        <span>
-            <${content}/>
-        </span>
-        <evo-icon-arrow-right-24/>
+<a
+  ...htmlInput
+  class=[
+    "cta-btn",
+    size && `cta-btn--${size}`,
+    fluid && "cta-btn--fluid",
+    truncated && "cta-btn--truncated",
+    inputClass,
+  ]>
+  <span class="cta-btn__cell">
+    <span>
+      <${content}/>
     </span>
+    <evo-icon-arrow-right-24/>
+  </span>
 </a>

--- a/packages/evo-marko/src/tags/evo-cta-button/test/__snapshots__/test.server.ts.snap
+++ b/packages/evo-marko/src/tags/evo-cta-button/test/__snapshots__/test.server.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`cta-button > renders basic cta button 1`] = `
 "<a
-  class="cta-btn cta-btn--regular"
+  class="cta-btn"
   href="https://www.ebay.com"
 >
   <span
@@ -31,9 +31,71 @@ exports[`cta-button > renders basic cta button 1`] = `
 </a>"
 `;
 
-exports[`cta-button > renders small cta button 1`] = `
+exports[`cta-button > renders fluid cta button 1`] = `
+"<a
+  class="cta-btn cta-btn--fluid"
+  href="https://www.ebay.com"
+>
+  <span
+    class="cta-btn__cell"
+  >
+    <span>
+      CTA Button
+    </span>
+    <svg
+      aria-hidden="true"
+      class="icon icon--24"
+    >
+      <symbol
+        id="GENERATED-0"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="m21.71 11.29-8-8a1.004 1.004 0 0 0-1.42 1.42l6.3 6.29H3a1 1 0 0 0 0 2h15.59l-6.3 6.29a1.001 1.001 0 0 0 0 1.42 1.001 1.001 0 0 0 1.42 0l8-8a1.001 1.001 0 0 0 0-1.42Z"
+        />
+      </symbol>
+      <use
+        href="#icon-arrow-right-24"
+      />
+    </svg>
+  </span>
+</a>"
+`;
+
+exports[`cta-button > renders large cta button 1`] = `
 "<a
   class="cta-btn cta-btn--large"
+  href="https://www.ebay.com"
+>
+  <span
+    class="cta-btn__cell"
+  >
+    <span>
+      CTA Button
+    </span>
+    <svg
+      aria-hidden="true"
+      class="icon icon--24"
+    >
+      <symbol
+        id="GENERATED-0"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="m21.71 11.29-8-8a1.004 1.004 0 0 0-1.42 1.42l6.3 6.29H3a1 1 0 0 0 0 2h15.59l-6.3 6.29a1.001 1.001 0 0 0 0 1.42 1.001 1.001 0 0 0 1.42 0l8-8a1.001 1.001 0 0 0 0-1.42Z"
+        />
+      </symbol>
+      <use
+        href="#icon-arrow-right-24"
+      />
+    </svg>
+  </span>
+</a>"
+`;
+
+exports[`cta-button > renders truncated cta button 1`] = `
+"<a
+  class="cta-btn cta-btn--truncated"
   href="https://www.ebay.com"
 >
   <span

--- a/packages/evo-marko/src/tags/evo-cta-button/test/test.server.ts
+++ b/packages/evo-marko/src/tags/evo-cta-button/test/test.server.ts
@@ -9,7 +9,15 @@ describe("cta-button", () => {
     await snapshotHTML(Default);
   });
 
-  it("renders small cta button", async () => {
+  it("renders large cta button", async () => {
     await snapshotHTML(Default, { size: "large" });
+  });
+
+  it("renders fluid cta button", async () => {
+    await snapshotHTML(Default, { fluid: true });
+  });
+
+  it("renders truncated cta button", async () => {
+    await snapshotHTML(Default, { truncated: true });
   });
 });

--- a/packages/evo-react/src/cta-button/README.md
+++ b/packages/evo-react/src/cta-button/README.md
@@ -1,0 +1,5 @@
+# EvoCtaButton
+
+## Documentation
+
+[Storybook](https://opensource.ebay.com/evo-web/react/?path=/docs/buttons-evo-cta-button--documentation)

--- a/packages/evo-react/src/cta-button/cta-button.stories.tsx
+++ b/packages/evo-react/src/cta-button/cta-button.stories.tsx
@@ -1,0 +1,97 @@
+import type { ComponentProps } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { EvoCtaButton } from "./cta-button";
+
+const meta: Meta<typeof EvoCtaButton> = {
+  title: "buttons/evo-cta-button",
+  component: EvoCtaButton,
+  tags: ["autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component: `
+A call-to-action link with prominent button styling and a directional icon.
+
+## Usage
+
+\`\`\`tsx
+import { EvoCtaButton } from "@evo-web/react/cta-button";
+\`\`\`
+        `,
+      },
+    },
+  },
+  argTypes: {
+    as: {
+      control: false,
+    },
+    fluid: {
+      control: "boolean",
+    },
+    truncated: {
+      control: "boolean",
+    },
+    size: {
+      control: "select",
+      options: ["large"],
+    },
+    href: {
+      control: "text",
+      description: "The destination URL.",
+    },
+    children: {
+      control: "text",
+      description: "CTA button content.",
+    },
+  },
+  args: {
+    children: "Take Action Now!",
+    href: "https://www.ebay.com",
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof EvoCtaButton>;
+
+export const Default: Story = {};
+
+function Link({
+  to,
+  children,
+  ...rest
+}: ComponentProps<"a"> & { to?: string }) {
+  return (
+    <a data-custom-link="true" {...rest} href={to}>
+      {children}
+    </a>
+  );
+}
+
+export const WithCustomLinkComponent: Story = {
+  render: (args) => (
+    <EvoCtaButton
+      {...args}
+      as={({ href, ...rest }) => <Link {...rest} to={href} />}
+    />
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: `
+Pass a custom component via the \`as\` prop to replace the native \`<a>\`.
+
+\`\`\`tsx
+import { Link } from "react-router";
+
+<EvoCtaButton
+  href="/home"
+  as={({ href, ...rest }) => <Link {...rest} to={href} />}
+>
+  Take Action Now!
+</EvoCtaButton>
+\`\`\`
+        `,
+      },
+    },
+  },
+};

--- a/packages/evo-react/src/cta-button/cta-button.tsx
+++ b/packages/evo-react/src/cta-button/cta-button.tsx
@@ -1,0 +1,33 @@
+import classNames from "classnames";
+import { EvoButtonCell } from "../button/button-cell";
+import { EvoIconArrowRight24 } from "../icon/icons/arrow-right-24";
+import type { EvoCtaButtonProps } from "./types";
+import "@ebay/skin/cta-button.mjs";
+
+export function EvoCtaButton({
+  as: _as,
+  children,
+  className: extraClasses,
+  fluid = false,
+  size,
+  truncated = false,
+  ...rest
+}: EvoCtaButtonProps) {
+  const Component = _as ?? "a";
+  const className = classNames(
+    extraClasses,
+    "cta-btn",
+    size === "large" && "cta-btn--large",
+    fluid && "cta-btn--fluid",
+    truncated && "cta-btn--truncated",
+  );
+
+  return (
+    <Component {...rest} className={className}>
+      <EvoButtonCell type="cta">
+        <span>{children}</span>
+        <EvoIconArrowRight24 />
+      </EvoButtonCell>
+    </Component>
+  );
+}

--- a/packages/evo-react/src/cta-button/index.ts
+++ b/packages/evo-react/src/cta-button/index.ts
@@ -1,0 +1,2 @@
+export { EvoCtaButton } from "./cta-button";
+export type { CtaButtonSize, EvoCtaButtonProps } from "./types";

--- a/packages/evo-react/src/cta-button/test/__snapshots__/test.server.tsx.snap
+++ b/packages/evo-react/src/cta-button/test/__snapshots__/test.server.tsx.snap
@@ -1,0 +1,9 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`EvoCtaButton SSR > passes through anchor attributes and custom classes 1`] = `"<a href="/action" data-testid="cta" aria-label="Take action" class="custom-class cta-btn"><span class="cta-btn__cell"><span>Take Action Now!</span><svg class="icon icon--24" xmlns="http://www.w3.org/2000/svg" focusable="false" aria-hidden="true"><use xlink:href="#icon-arrow-right-24"></use></svg></span></a>"`;
+
+exports[`EvoCtaButton SSR > renders defaults 1`] = `"<a href="https://www.ebay.com" class="cta-btn"><span class="cta-btn__cell"><span>Take Action Now!</span><svg class="icon icon--24" xmlns="http://www.w3.org/2000/svg" focusable="false" aria-hidden="true"><use xlink:href="#icon-arrow-right-24"></use><defs><symbol viewBox="0 0 24 24" id="icon-arrow-right-24"><path d="m21.71 11.29-8-8a1.004 1.004 0 0 0-1.42 1.42l6.3 6.29H3a1 1 0 0 0 0 2h15.59l-6.3 6.29a1.001 1.001 0 0 0 0 1.42 1.001 1.001 0 0 0 1.42 0l8-8a1.001 1.001 0 0 0 0-1.42Z"/></symbol></defs></svg></span></a>"`;
+
+exports[`EvoCtaButton SSR > renders large, fluid, and truncated modifiers 1`] = `"<a href="/action" class="cta-btn cta-btn--large cta-btn--fluid cta-btn--truncated"><span class="cta-btn__cell"><span>Take Action Now!</span><svg class="icon icon--24" xmlns="http://www.w3.org/2000/svg" focusable="false" aria-hidden="true"><use xlink:href="#icon-arrow-right-24"></use></svg></span></a>"`;
+
+exports[`EvoCtaButton SSR > renders with a custom component 1`] = `"<a data-custom-link="true" href="/action" class="cta-btn"><span class="cta-btn__cell"><span>Take Action Now!</span><svg class="icon icon--24" xmlns="http://www.w3.org/2000/svg" focusable="false" aria-hidden="true"><use xlink:href="#icon-arrow-right-24"></use></svg></span></a>"`;

--- a/packages/evo-react/src/cta-button/test/test.browser.tsx
+++ b/packages/evo-react/src/cta-button/test/test.browser.tsx
@@ -1,0 +1,95 @@
+import { createRef } from "react";
+import type { ComponentProps } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-react";
+import { userEvent } from "vitest/browser";
+import { EvoCtaButton } from "../cta-button";
+
+describe("evo-cta-button", () => {
+  let user: ReturnType<typeof userEvent.setup>;
+
+  beforeEach(() => {
+    user = userEvent.setup();
+  });
+
+  afterEach(() => {
+    user.cleanup();
+  });
+
+  it("renders an anchor with CTA content and passes through attributes", async () => {
+    const screen = await render(
+      <EvoCtaButton
+        href="https://www.ebay.com"
+        className="custom-class"
+        data-testid="cta"
+      >
+        Take Action Now!
+      </EvoCtaButton>,
+    );
+
+    const link = screen.getByRole("link", { name: "Take Action Now!" });
+    await expect.element(link).toHaveAttribute("href", "https://www.ebay.com");
+    await expect.element(link).toHaveAttribute("data-testid", "cta");
+    await expect.element(link).toHaveClass("cta-btn");
+    await expect.element(link).toHaveClass("custom-class");
+  });
+
+  it("applies large, fluid, and truncated modifiers", async () => {
+    const screen = await render(
+      <EvoCtaButton href="/action" size="large" fluid truncated>
+        Take Action Now!
+      </EvoCtaButton>,
+    );
+
+    const link = screen.getByRole("link");
+    await expect.element(link).toHaveClass("cta-btn--large");
+    await expect.element(link).toHaveClass("cta-btn--fluid");
+    await expect.element(link).toHaveClass("cta-btn--truncated");
+  });
+
+  it("emits click events", async () => {
+    const onClick = vi.fn((event) => event.preventDefault());
+    const screen = await render(
+      <EvoCtaButton href="/action" onClick={onClick}>
+        Take Action Now!
+      </EvoCtaButton>,
+    );
+
+    await user.click(screen.getByRole("link"));
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("forwards refs to the anchor", async () => {
+    const ref = createRef<HTMLAnchorElement>();
+
+    await render(
+      <EvoCtaButton href="/action" ref={ref}>
+        Take Action Now!
+      </EvoCtaButton>,
+    );
+
+    expect(ref.current).toBeInstanceOf(HTMLAnchorElement);
+  });
+
+  it("renders with a custom component when as is provided", async () => {
+    function CustomLink({ href, children, ...rest }: ComponentProps<"a">) {
+      return (
+        <a data-custom-link="true" href={href} {...rest}>
+          {children}
+        </a>
+      );
+    }
+
+    const screen = await render(
+      <EvoCtaButton href="/action" as={CustomLink} fluid>
+        Take Action Now!
+      </EvoCtaButton>,
+    );
+
+    const link = screen.getByRole("link");
+    await expect.element(link).toHaveAttribute("data-custom-link", "true");
+    await expect.element(link).toHaveAttribute("href", "/action");
+    await expect.element(link).toHaveClass("cta-btn--fluid");
+  });
+});

--- a/packages/evo-react/src/cta-button/test/test.server.tsx
+++ b/packages/evo-react/src/cta-button/test/test.server.tsx
@@ -1,0 +1,59 @@
+import type { ComponentProps } from "react";
+import { renderToString } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { EvoCtaButton } from "../cta-button";
+
+describe("EvoCtaButton SSR", () => {
+  it("renders defaults", () => {
+    expect(
+      renderToString(
+        <EvoCtaButton href="https://www.ebay.com">
+          Take Action Now!
+        </EvoCtaButton>,
+      ),
+    ).toMatchSnapshot();
+  });
+
+  it("renders large, fluid, and truncated modifiers", () => {
+    expect(
+      renderToString(
+        <EvoCtaButton href="/action" size="large" fluid truncated>
+          Take Action Now!
+        </EvoCtaButton>,
+      ),
+    ).toMatchSnapshot();
+  });
+
+  it("passes through anchor attributes and custom classes", () => {
+    expect(
+      renderToString(
+        <EvoCtaButton
+          href="/action"
+          className="custom-class"
+          data-testid="cta"
+          aria-label="Take action"
+        >
+          Take Action Now!
+        </EvoCtaButton>,
+      ),
+    ).toMatchSnapshot();
+  });
+
+  it("renders with a custom component", () => {
+    function CustomLink({ href, children, ...rest }: ComponentProps<"a">) {
+      return (
+        <a data-custom-link="true" href={href} {...rest}>
+          {children}
+        </a>
+      );
+    }
+
+    expect(
+      renderToString(
+        <EvoCtaButton href="/action" as={CustomLink}>
+          Take Action Now!
+        </EvoCtaButton>,
+      ),
+    ).toMatchSnapshot();
+  });
+});

--- a/packages/evo-react/src/cta-button/types.ts
+++ b/packages/evo-react/src/cta-button/types.ts
@@ -1,0 +1,15 @@
+import type { ComponentProps, ComponentType } from "react";
+
+/** Supported CTA button size. */
+export type CtaButtonSize = "large";
+
+export type EvoCtaButtonProps = ComponentProps<"a"> & {
+  /** Custom component used in place of the native anchor, such as a framework Link. */
+  as?: ComponentType<ComponentProps<"a">>;
+  /** Expands the CTA button to the full width of its parent. */
+  fluid?: boolean;
+  /** Truncates overflowing text to a single line with an ellipsis. */
+  truncated?: boolean;
+  /** CTA button size. Omit for the default size. */
+  size?: CtaButtonSize;
+};

--- a/packages/evo-react/src/cta-button/types.ts
+++ b/packages/evo-react/src/cta-button/types.ts
@@ -4,7 +4,10 @@ import type { ComponentProps, ComponentType } from "react";
 export type CtaButtonSize = "large";
 
 export type EvoCtaButtonProps = ComponentProps<"a"> & {
-  /** Custom component used in place of the native anchor, such as a framework Link. */
+  /**
+   * Custom component used in place of the native anchor, such as a framework Link.
+   * It must render an `<a>` element because the CTA button's Skin CSS rules target anchors.
+   */
   as?: ComponentType<ComponentProps<"a">>;
   /** Expands the CTA button to the full width of its parent. */
   fluid?: boolean;


### PR DESCRIPTION
<!-- Insert GitHub issue number below. An issue is required for all PRs -->

- Fixes #

## Description

Adds `EvoCtaButton` to `@evo-web/react` with React 19 native refs, anchor attribute pass-through, custom link components via `as`, and `fluid`, `truncated`, and `size="large"` variants.

Aligns evo-marko CTA button support for the same visual modifiers, adds framework stories and test coverage, and documents application migration changes. Prop descriptions live in exported type JSDoc for Storybook docgen.

## Notes

- Adds patch changesets for `@evo-web/react` and `@evo-web/marko`.
- An issue number was not provided and must be added to the `Fixes #` field.

## Screenshots

N/A — uses existing Skin CTA button styles; no Skin visual changes.

## Checklist

<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->

- [ ] I verify the linked issue has been triaged ("Needs Triage" label removed)
- [ ] I verify all changes are within scope of the linked issue
- [ ] I added/updated/removed testing (Storybook in Skin) coverage as appropriate
