### PR TITLE
Tise brand mini expressive theme - pull in the latest version of the @ebay/design-tokens package (#788)

### DIFF
--- a/.changeset/bump-design-tokens-2-4-2.md
+++ b/.changeset/bump-design-tokens-2-4-2.md
@@ -1,0 +1,5 @@
+---
+"@ebay/skin": minor
+---
+
+Update DS tokens

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "@docsearch/css": "^4.4.0",
         "@docsearch/js": "^4.4.0",
         "@ebay/browserslist-config": "^2.13.0",
-        "@ebay/design-tokens": "^2.4.1",
+        "@ebay/design-tokens": "^2.4.2",
         "@ebay/skin": "^19",
         "@floating-ui/dom": "^1.7.4",
         "@marko-tags/subscribe": "npm:noist@^1.0.0",
@@ -3102,9 +3102,9 @@
       "license": "MIT"
     },
     "node_modules/@ebay/design-tokens": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@ebay/design-tokens/-/design-tokens-2.4.1.tgz",
-      "integrity": "sha512-Q2ziL3fWz9GTBw4LROxJpEglFftbGdgV/gDCExUfNLWOilI7MU4qWXPCSViohp8XFVxeLtWcbvNpveO/RMg8Kw==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@ebay/design-tokens/-/design-tokens-2.4.2.tgz",
+      "integrity": "sha512-9evZlrlrDZlRG3hi6VAVWjKXJAzg/QbH+u0mHvJarF12mpoqihRdz8VzBTfLu2YSbGFLkYe8h7ipxRq0LYNJVg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -26919,7 +26919,7 @@
       "name": "@evo-web/storybook-addon-theme",
       "version": "0.0.0",
       "devDependencies": {
-        "@ebay/design-tokens": "^2.4.1",
+        "@ebay/design-tokens": "^2.4.2",
         "@ebay/skin": "^19",
         "@storybook/addon-docs": "^10",
         "@storybook/icons": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@docsearch/css": "^4.4.0",
     "@docsearch/js": "^4.4.0",
     "@ebay/browserslist-config": "^2.13.0",
-    "@ebay/design-tokens": "^2.4.1",
+    "@ebay/design-tokens": "^2.4.2",
     "@ebay/skin": "^19",
     "@floating-ui/dom": "^1.7.4",
     "@marko-tags/subscribe": "npm:noist@^1.0.0",

--- a/packages/evo-storybook-addon-theme/package.json
+++ b/packages/evo-storybook-addon-theme/package.json
@@ -13,7 +13,7 @@
     "type:check": "tsc --noEmit"
   },
   "devDependencies": {
-    "@ebay/design-tokens": "^2.4.1",
+    "@ebay/design-tokens": "^2.4.2",
     "@ebay/skin": "^19",
     "@storybook/addon-docs": "^10",
     "@storybook/icons": "^2.0.1",

--- a/packages/skin/dist/tokens/evo-core.css
+++ b/packages/skin/dist/tokens/evo-core.css
@@ -33,6 +33,9 @@
     --color-blue-700: #002a69;
     --color-blue-800: #19133a;
     --color-brand-depop-red: #e20020;
+    --color-brand-tise-dark-purple: #422136;
+    --color-brand-tise-peach: #ff8f77;
+    --color-brand-tise-tan: #ffefeb;
     --color-clear: rgba(255, 255, 255, 0);
     --color-coral-100: #fff7f5;
     --color-coral-200: #ffe1d7;
@@ -280,6 +283,10 @@
     --expressive-theme-teal-light-foreground: #07465a;
     --expressive-theme-teal-medium-background: #1bbfca;
     --expressive-theme-teal-medium-foreground: #07465a;
+    --expressive-theme-tise-dark-purple-background: #422136;
+    --expressive-theme-tise-dark-purple-foreground: #ffefeb;
+    --expressive-theme-tise-peach-background: #ff8f77;
+    --expressive-theme-tise-peach-foreground: #422136;
     --expressive-theme-violet-dark-background: #271a68;
     --expressive-theme-violet-dark-foreground: #e2ddfd;
     --expressive-theme-violet-light-background: #836bff;


### PR DESCRIPTION
Closes #788

Tise brand mini expressive theme - pull in the latest version of the @ebay/design-tokens package

Validated by Local Conductor's engineer/QA loop (1 iteration) before this PR was opened. See the linked issue for the original request.