### PR TITLE
fix(ebayui-react) Ebay Tabs programmatic navigation fix

### DIFF
--- a/.changeset/many-monkeys-lie.md
+++ b/.changeset/many-monkeys-lie.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ui-core-react": patch
+---
+
+Fix: ebay tabs programmatic navigation

--- a/packages/ebayui-core-react/src/ebay-tabs/__tests__/index.spec.tsx
+++ b/packages/ebayui-core-react/src/ebay-tabs/__tests__/index.spec.tsx
@@ -1,9 +1,10 @@
-import React from "react";
+import React, { useState } from "react";
 import { vi } from "vitest";
 import { render, fireEvent, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { DefaultTabs, ManuallyActivatedTabs } from "./index.stories";
+import { EbayTabs, EbayTab, EbayTabPanel } from "../index";
 
 describe("<EbayTabs>", () => {
     describe("on `tab` key press", () => {
@@ -207,6 +208,95 @@ describe("<EbayTabs>", () => {
                 await userEvent.tab({ shift: true });
                 expect(tabs[1]).toHaveFocus();
             });
+        });
+    });
+
+    describe("when selectedIndex prop changes programmatically", () => {
+        it("should update the selected panel when selectedIndex prop changes", () => {
+            const { rerender } = render(
+                <EbayTabs selectedIndex={0}>
+                    <EbayTab>Tab 1</EbayTab>
+                    <EbayTab>Tab 2</EbayTab>
+                    <EbayTab>Tab 3</EbayTab>
+                    <EbayTabPanel>
+                        <h3>Panel 1</h3>
+                    </EbayTabPanel>
+                    <EbayTabPanel>
+                        <h3>Panel 2</h3>
+                    </EbayTabPanel>
+                    <EbayTabPanel>
+                        <h3>Panel 3</h3>
+                    </EbayTabPanel>
+                </EbayTabs>,
+            );
+
+            expect(screen.getByText("Panel 1")).toBeVisible();
+            expect(screen.getByText("Panel 2")).not.toBeVisible();
+            expect(screen.getByText("Panel 3")).not.toBeVisible();
+
+            rerender(
+                <EbayTabs selectedIndex={2}>
+                    <EbayTab>Tab 1</EbayTab>
+                    <EbayTab>Tab 2</EbayTab>
+                    <EbayTab>Tab 3</EbayTab>
+                    <EbayTabPanel>
+                        <h3>Panel 1</h3>
+                    </EbayTabPanel>
+                    <EbayTabPanel>
+                        <h3>Panel 2</h3>
+                    </EbayTabPanel>
+                    <EbayTabPanel>
+                        <h3>Panel 3</h3>
+                    </EbayTabPanel>
+                </EbayTabs>,
+            );
+
+            expect(screen.getByText("Panel 1")).not.toBeVisible();
+            expect(screen.getByText("Panel 2")).not.toBeVisible();
+            expect(screen.getByText("Panel 3")).toBeVisible();
+        });
+
+        it("should update the selected panel when controlled by external state", () => {
+            const ControlledTabs = () => {
+                const [selectedTab, setSelectedTab] = useState(0);
+                return (
+                    <>
+                        {[0, 1, 2].map((i) => (
+                            <button key={i} onClick={() => setSelectedTab(i)}>
+                                Select Tab {i + 1}
+                            </button>
+                        ))}
+                        <EbayTabs selectedIndex={selectedTab}>
+                            <EbayTab>Tab 1</EbayTab>
+                            <EbayTab>Tab 2</EbayTab>
+                            <EbayTab>Tab 3</EbayTab>
+                            <EbayTabPanel>
+                                <h3>Panel 1</h3>
+                            </EbayTabPanel>
+                            <EbayTabPanel>
+                                <h3>Panel 2</h3>
+                            </EbayTabPanel>
+                            <EbayTabPanel>
+                                <h3>Panel 3</h3>
+                            </EbayTabPanel>
+                        </EbayTabs>
+                    </>
+                );
+            };
+
+            render(<ControlledTabs />);
+
+            expect(screen.getByText("Panel 1")).toBeVisible();
+            expect(screen.getByText("Panel 2")).not.toBeVisible();
+
+            fireEvent.click(screen.getByText("Select Tab 2"));
+            expect(screen.getByText("Panel 1")).not.toBeVisible();
+            expect(screen.getByText("Panel 2")).toBeVisible();
+            expect(screen.getByText("Panel 3")).not.toBeVisible();
+
+            fireEvent.click(screen.getByText("Select Tab 3"));
+            expect(screen.getByText("Panel 2")).not.toBeVisible();
+            expect(screen.getByText("Panel 3")).toBeVisible();
         });
     });
 });

--- a/packages/ebayui-core-react/src/ebay-tabs/tabs.tsx
+++ b/packages/ebayui-core-react/src/ebay-tabs/tabs.tsx
@@ -1,4 +1,4 @@
-import React, { cloneElement, FC, KeyboardEvent, useState } from "react";
+import React, { cloneElement, FC, KeyboardEvent, useEffect, useState } from "react";
 import classNames from "classnames";
 
 import { handleActionKeydown, handleLeftRightArrowsKeydown } from "../common/event-utils";
@@ -60,6 +60,10 @@ const Tabs: FC<TabsProps> = ({
             }
         });
     };
+
+    useEffect(() => {
+        setSelectedIndex(index);
+    }, [index]);
 
     const isLarge = size === "large";
 


### PR DESCRIPTION
<!-- Insert GitHub issue number below. An issue is required for all PRs -->
- Fixes #

Issue:
https://github.com/eBay/evo-web/issues/865

- Fix ebay programmatic navigation

## Description

[This commit](https://github.com/eBay/evo-web/commit/b25f12523a2dab761205d725eec36c503a24fdd7#diff-7723ed437c1419edf5e4027bc089c1d96087f0bec0974109b14708eab9b471ceL64
) broke the programmatic tab selection for EbayTabs. 

Check broken behavior here:
https://opensource.ebay.com/evo-web/ebayui-core-react/main/?path=/story/navigation-disclosure-ebay-tabs--programmatically-selected-tabs

Before:
https://github.com/user-attachments/assets/4f861439-394b-4e3e-99be-50b70b96152b

After:
https://github.com/user-attachments/assets/bf2ca5b7-c4ba-4865-9f9e-bd203aa4a113



## Notes

<!-- Be sure to mention anything unusual, out-of-scope or new technical debt, etc -->

## Screenshots

<!-- Upload screenshots of UI before & after these changes -->

## Checklist

<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->

- [ ] I verify the linked issue has been triaged ("Needs Triage" label removed)
- [ ] I verify all changes are within scope of the linked issue
- [ ] I added/updated/removed testing (Storybook in Skin) coverage as appropriate

<!-- For CSS changes -->

- [ ] I tested the UI in all supported browsers
- [ ] I tested the UI in dark mode and RTL mode
