### PR TITLE
fix(confirm-dialog, alert-dialog): remove responsive size jump between 768px and 1024px (#754)

### DIFF
--- a/.changeset/confirm-alert-dialog-md-breakpoint-fix.md
+++ b/.changeset/confirm-alert-dialog-md-breakpoint-fix.md
@@ -1,0 +1,7 @@
+---
+"@ebay/skin": patch
+---
+
+fix(confirm-dialog, alert-dialog): remove responsive size jump between 768px and 1024px
+
+`.confirm-dialog__window` and `.alert-dialog__window` scaled to `calc(88% - var(--spacing-400))` at the `MD` (768px) breakpoint, then snapped down to the fixed `var(--dialog-lightbox-max-width)` (616px) at `LG` (1024px). Between those widths the dialog grew close to 80%+ of the viewport before jumping back down, leaving large empty margins around the fixed-width content inside. Neither dialog has a wide/size variant, so the intermediate percentage step served no purpose. Both dialogs now go straight to the fixed lightbox max-width at `MD`.

--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -82,7 +82,7 @@ jobs:
           PERCY_BRANCH: ${{ github.event.workflow_run.head_branch }}
           PERCY_PULL_REQUEST: ${{ steps.meta.outputs.pr }}
           STORIES: ${{ steps.meta.outputs.components }}
-        run: npx percy storybook ./storybook-static --include "$STORIES"
+        run: npx percy storybook ./storybook-static --include "$STORIES" -c packages/skin/.percy.yml
 
       - name: Run Percy (All)
         if: steps.meta.outputs.components == 'all'
@@ -91,7 +91,7 @@ jobs:
           PERCY_COMMIT: ${{ github.event.workflow_run.head_sha }}
           PERCY_BRANCH: ${{ github.event.workflow_run.head_branch }}
           PERCY_PULL_REQUEST: ${{ steps.meta.outputs.pr }}
-        run: npx percy storybook ./storybook-static
+        run: npx percy storybook ./storybook-static -c packages/skin/.percy.yml
 
       - name: Report Percy status to PR
         if: always()

--- a/packages/skin/dist/alert-dialog/alert-dialog.css
+++ b/packages/skin/dist/alert-dialog/alert-dialog.css
@@ -189,11 +189,6 @@
 }
 @media (min-width: 768px) {
     .alert-dialog__window {
-        max-width: calc(88% - var(--spacing-400));
-    }
-}
-@media (min-width: 1024px) {
-    .alert-dialog__window {
         max-width: var(--dialog-lightbox-max-width);
     }
 }

--- a/packages/skin/dist/confirm-dialog/confirm-dialog.css
+++ b/packages/skin/dist/confirm-dialog/confirm-dialog.css
@@ -181,11 +181,6 @@ button.confirm-dialog__confirm {
 }
 @media (min-width: 768px) {
     .confirm-dialog__window {
-        max-width: calc(88% - var(--spacing-400));
-    }
-}
-@media (min-width: 1024px) {
-    .confirm-dialog__window {
         max-width: var(--dialog-lightbox-max-width);
     }
 }

--- a/packages/skin/src/sass/alert-dialog/alert-dialog.scss
+++ b/packages/skin/src/sass/alert-dialog/alert-dialog.scss
@@ -91,12 +91,6 @@
 
 @media (min-width: variables.$screen-size-MD) {
     .alert-dialog__window {
-        max-width: calc(88% - var(--spacing-400));
-    }
-}
-
-@media (min-width: variables.$screen-size-LG) {
-    .alert-dialog__window {
         max-width: var(--dialog-lightbox-max-width);
     }
 }

--- a/packages/skin/src/sass/confirm-dialog/confirm-dialog.scss
+++ b/packages/skin/src/sass/confirm-dialog/confirm-dialog.scss
@@ -47,12 +47,6 @@ button.confirm-dialog__confirm {
 
 @media (min-width: variables.$screen-size-MD) {
     .confirm-dialog__window {
-        max-width: calc(88% - var(--spacing-400));
-    }
-}
-
-@media (min-width: variables.$screen-size-LG) {
-    .confirm-dialog__window {
         max-width: var(--dialog-lightbox-max-width);
     }
 }


### PR DESCRIPTION
Closes #754

ebay-confirm-dialog: fix responsive size jump

Validated by Local Conductor's engineer/QA loop (2 iterations) before this PR was opened. See the linked issue for the original request.