### PR TITLE
chore(tokens): bump @ebay/design-tokens from 2.4.2 to 2.4.3

### DIFF
--- a/.changeset/tame-jars-doze.md
+++ b/.changeset/tame-jars-doze.md
@@ -1,0 +1,5 @@
+---
+"@ebay/skin": minor
+---
+
+Update DS tokens

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "@docsearch/css": "^4.4.0",
         "@docsearch/js": "^4.4.0",
         "@ebay/browserslist-config": "^2.13.0",
-        "@ebay/design-tokens": "^2.4.2",
+        "@ebay/design-tokens": "^2.4.3",
         "@ebay/skin": "^19",
         "@floating-ui/dom": "^1.7.4",
         "@marko-tags/subscribe": "npm:noist@^1.0.0",
@@ -3102,9 +3102,9 @@
       "license": "MIT"
     },
     "node_modules/@ebay/design-tokens": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/@ebay/design-tokens/-/design-tokens-2.4.2.tgz",
-      "integrity": "sha512-9evZlrlrDZlRG3hi6VAVWjKXJAzg/QbH+u0mHvJarF12mpoqihRdz8VzBTfLu2YSbGFLkYe8h7ipxRq0LYNJVg==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@ebay/design-tokens/-/design-tokens-2.4.3.tgz",
+      "integrity": "sha512-mcNKSV6/3pS1rEbNAzp5RvZlhnSwkRoYFa7b0UeMNp3zD53VmiOkOlLbYRYNW1KzIz3YTKLh8fMTF2f9PQU29w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -26919,7 +26919,7 @@
       "name": "@evo-web/storybook-addon-theme",
       "version": "0.0.0",
       "devDependencies": {
-        "@ebay/design-tokens": "^2.4.2",
+        "@ebay/design-tokens": "^2.4.3",
         "@ebay/skin": "^19",
         "@storybook/addon-docs": "^10",
         "@storybook/icons": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@docsearch/css": "^4.4.0",
     "@docsearch/js": "^4.4.0",
     "@ebay/browserslist-config": "^2.13.0",
-    "@ebay/design-tokens": "^2.4.2",
+    "@ebay/design-tokens": "^2.4.3",
     "@ebay/skin": "^19",
     "@floating-ui/dom": "^1.7.4",
     "@marko-tags/subscribe": "npm:noist@^1.0.0",

--- a/packages/evo-storybook-addon-theme/package.json
+++ b/packages/evo-storybook-addon-theme/package.json
@@ -13,7 +13,7 @@
     "type:check": "tsc --noEmit"
   },
   "devDependencies": {
-    "@ebay/design-tokens": "^2.4.2",
+    "@ebay/design-tokens": "^2.4.3",
     "@ebay/skin": "^19",
     "@storybook/addon-docs": "^10",
     "@storybook/icons": "^2.0.1",

--- a/packages/skin/dist/tokens/evo-core.css
+++ b/packages/skin/dist/tokens/evo-core.css
@@ -183,6 +183,10 @@
     --dimension-icon-medium: 24px;
     --dimension-icon-small: 16px;
     --dimension-tap-target-minimum: 48px;
+    --expressive-theme-ag-indigo-dark-background: #01193d;
+    --expressive-theme-ag-indigo-dark-foreground: #ffffff;
+    --expressive-theme-ag-indigo-light-background: #d3effe;
+    --expressive-theme-ag-indigo-light-foreground: #01193d;
     --expressive-theme-avocado-dark-background: #4e4e0c;
     --expressive-theme-avocado-dark-foreground: #f8fcde;
     --expressive-theme-avocado-light-background: #e3f13c;


### PR DESCRIPTION
## Summary
- Bumps `@ebay/design-tokens` 2.4.2 → 2.4.3 to pull in the new AG mini expressive theme tokens (`expressiveTheme.ag.indigo.light` / `.dark`)
- Regenerates `packages/skin/dist/tokens/evo-core.css` with the 4 new custom properties (indigo light/dark background + foreground)
- Bumps the same dependency in `packages/evo-storybook-addon-theme/package.json`, matching prior precedent (PR #791)
- Adds changeset `tame-jars-doze.md` (`@ebay/skin`: minor — tokens added)

Fixes #869

## Test plan
- [ ] `npm install && npm run build` green
- [ ] Verify `evo-core.css` matches upstream `@ebay/design-tokens@2.4.3` `evo-core.scss` output byte-for-byte
- [ ] Confirm no other token files (`evo-light`, `evo-dark`, `evo-live-*`) changed content