### PR TITLE
feat(storybook): add RTL toggle to evo-marko and evo-react storybooks

### DIFF
--- a/packages/evo-storybook-addon-theme/src/preview.tsx
+++ b/packages/evo-storybook-addon-theme/src/preview.tsx
@@ -7,7 +7,29 @@ import ThemedDocsContainer from "./docs-container";
 export default {
   globalTypes: {
     colorScheme: {},
+    direction: {
+      description: "Text direction",
+      toolbar: {
+        icon: "transfer",
+        items: [
+          { type: "reset", icon: "transfer", title: "System" },
+          { value: "ltr", icon: "arrowright", title: "LTR" },
+          { value: "rtl", icon: "arrowleft", title: "RTL" },
+        ],
+      },
+    },
   },
+  decorators: [
+    (story: () => unknown, context: { globals: { direction?: string } }) => {
+      const { direction } = context.globals;
+      if (direction === "ltr" || direction === "rtl") {
+        document.documentElement.dir = direction;
+      } else {
+        document.documentElement.removeAttribute("dir");
+      }
+      return story();
+    },
+  ],
   parameters: {
     docs: {
       container: ThemedDocsContainer,


### PR DESCRIPTION
- Fixes #14

Adds an LTR/RTL text direction toggle to the shared storybook theme addon's toolbar, applied to the preview via a decorator. Defaults to System (no `dir` attribute).

🤖 Generated with [Claude Code](https://claude.com/claude-code)