### PR TITLE
docs(evo-icon): compact all-icons storybook example into a dense grid

### DIFF
--- a/packages/evo-marko/scripts/import-svg.ts
+++ b/packages/evo-marko/scripts/import-svg.ts
@@ -84,7 +84,10 @@ function setupDir(fileName: string) {
   cp.execSync(`rm -rf ${JSON.stringify(outputDir)}`);
   cp.execSync(`rm -rf ${JSON.stringify(example)}`);
   fs.mkdirSync(outputDir);
-  fs.writeFileSync(example, `div.icon-examples`);
+  fs.writeFileSync(
+    example,
+    fileName === "icon" ? `icon-grid` : `div.icon-examples`,
+  );
 }
 
 function addIcons(component: string, iconMap: Map<string, string>) {
@@ -138,13 +141,19 @@ function generateExamples(type: string, iconsList: string[]) {
     }
     const postfixName = type === "icon" ? "-icon" : "";
     const iconName = `evo${postfixName}-${name}`;
-    exampleHTML.push(`    div
+    if (type === "icon") {
+      exampleHTML.push(`  icon-example name="${iconName}"
+    ${iconName}\n`);
+    } else {
+      exampleHTML.push(`    div
         span.icon
             ${iconName}
         span.text
             -- ${iconName}\n`);
+    }
   }
   fs.writeFileSync(exampleFile, `${file}\n${exampleHTML.join("\n")}`);
+  cp.execSync(`npx prettier --write ${JSON.stringify(exampleFile)}`);
 }
 
 function generateIcon(componentName: string) {

--- a/packages/evo-marko/src/tags/evo-icon/examples/all.marko
+++ b/packages/evo-marko/src/tags/evo-icon/examples/all.marko
@@ -1,6714 +1,3357 @@
-div.icon-examples
-    div
-        span.icon
-            evo-icon-add-12
-        span.text
-            -- evo-icon-add-12
-
-    div
-        span.icon
-            evo-icon-add-16
-        span.text
-            -- evo-icon-add-16
-
-    div
-        span.icon
-            evo-icon-add-24
-        span.text
-            -- evo-icon-add-24
-
-    div
-        span.icon
-            evo-icon-add-image-24
-        span.text
-            -- evo-icon-add-image-24
-
-    div
-        span.icon
-            evo-icon-adjust-price-down-16
-        span.text
-            -- evo-icon-adjust-price-down-16
-
-    div
-        span.icon
-            evo-icon-adjust-price-down-24
-        span.text
-            -- evo-icon-adjust-price-down-24
-
-    div
-        span.icon
-            evo-icon-adjust-price-up-16
-        span.text
-            -- evo-icon-adjust-price-up-16
-
-    div
-        span.icon
-            evo-icon-adjust-price-up-24
-        span.text
-            -- evo-icon-adjust-price-up-24
-
-    div
-        span.icon
-            evo-icon-afterpay-12-colored
-        span.text
-            -- evo-icon-afterpay-12-colored
-
-    div
-        span.icon
-            evo-icon-afterpay-18-colored
-        span.text
-            -- evo-icon-afterpay-18-colored
-
-    div
-        span.icon
-            evo-icon-afterpay-24-colored
-        span.text
-            -- evo-icon-afterpay-24-colored
-
-    div
-        span.icon
-            evo-icon-afterpay-32-colored
-        span.text
-            -- evo-icon-afterpay-32-colored
-
-    div
-        span.icon
-            evo-icon-afterpay-logo-24-colored
-        span.text
-            -- evo-icon-afterpay-logo-24-colored
-
-    div
-        span.icon
-            evo-icon-ai-16
-        span.text
-            -- evo-icon-ai-16
-
-    div
-        span.icon
-            evo-icon-ai-20
-        span.text
-            -- evo-icon-ai-20
-
-    div
-        span.icon
-            evo-icon-ai-24
-        span.text
-            -- evo-icon-ai-24
-
-    div
-        span.icon
-            evo-icon-ai-camera-16
-        span.text
-            -- evo-icon-ai-camera-16
-
-    div
-        span.icon
-            evo-icon-ai-camera-20
-        span.text
-            -- evo-icon-ai-camera-20
-
-    div
-        span.icon
-            evo-icon-ai-camera-24
-        span.text
-            -- evo-icon-ai-camera-24
-
-    div
-        span.icon
-            evo-icon-ai-filled-16
-        span.text
-            -- evo-icon-ai-filled-16
-
-    div
-        span.icon
-            evo-icon-ai-filled-20
-        span.text
-            -- evo-icon-ai-filled-20
-
-    div
-        span.icon
-            evo-icon-ai-filled-24
-        span.text
-            -- evo-icon-ai-filled-24
-
-    div
-        span.icon
-            evo-icon-ai-mobile-16
-        span.text
-            -- evo-icon-ai-mobile-16
-
-    div
-        span.icon
-            evo-icon-ai-mobile-20
-        span.text
-            -- evo-icon-ai-mobile-20
-
-    div
-        span.icon
-            evo-icon-ai-mobile-24
-        span.text
-            -- evo-icon-ai-mobile-24
-
-    div
-        span.icon
-            evo-icon-ai-search-16
-        span.text
-            -- evo-icon-ai-search-16
-
-    div
-        span.icon
-            evo-icon-ai-search-20
-        span.text
-            -- evo-icon-ai-search-20
-
-    div
-        span.icon
-            evo-icon-ai-search-24
-        span.text
-            -- evo-icon-ai-search-24
-
-    div
-        span.icon
-            evo-icon-ai-search-filled-24
-        span.text
-            -- evo-icon-ai-search-filled-24
-
-    div
-        span.icon
-            evo-icon-ai-shirt-16
-        span.text
-            -- evo-icon-ai-shirt-16
-
-    div
-        span.icon
-            evo-icon-ai-shirt-20
-        span.text
-            -- evo-icon-ai-shirt-20
-
-    div
-        span.icon
-            evo-icon-ai-shirt-24
-        span.text
-            -- evo-icon-ai-shirt-24
-
-    div
-        span.icon
-            evo-icon-ai-spectrum-16-colored
-        span.text
-            -- evo-icon-ai-spectrum-16-colored
-
-    div
-        span.icon
-            evo-icon-ai-spectrum-20-colored
-        span.text
-            -- evo-icon-ai-spectrum-20-colored
-
-    div
-        span.icon
-            evo-icon-ai-spectrum-24-colored
-        span.text
-            -- evo-icon-ai-spectrum-24-colored
-
-    div
-        span.icon
-            evo-icon-ai-spectrum-filled-16-colored
-        span.text
-            -- evo-icon-ai-spectrum-filled-16-colored
-
-    div
-        span.icon
-            evo-icon-ai-spectrum-filled-20-colored
-        span.text
-            -- evo-icon-ai-spectrum-filled-20-colored
-
-    div
-        span.icon
-            evo-icon-ai-spectrum-filled-24-colored
-        span.text
-            -- evo-icon-ai-spectrum-filled-24-colored
-
-    div
-        span.icon
-            evo-icon-ai-spectrum-thin-16-colored
-        span.text
-            -- evo-icon-ai-spectrum-thin-16-colored
-
-    div
-        span.icon
-            evo-icon-ai-summary-16
-        span.text
-            -- evo-icon-ai-summary-16
-
-    div
-        span.icon
-            evo-icon-ai-summary-20
-        span.text
-            -- evo-icon-ai-summary-20
-
-    div
-        span.icon
-            evo-icon-ai-summary-24
-        span.text
-            -- evo-icon-ai-summary-24
-
-    div
-        span.icon
-            evo-icon-ai-thin-16
-        span.text
-            -- evo-icon-ai-thin-16
-
-    div
-        span.icon
-            evo-icon-ai-tools-16
-        span.text
-            -- evo-icon-ai-tools-16
-
-    div
-        span.icon
-            evo-icon-ai-tools-20
-        span.text
-            -- evo-icon-ai-tools-20
-
-    div
-        span.icon
-            evo-icon-ai-tools-24
-        span.text
-            -- evo-icon-ai-tools-24
-
-    div
-        span.icon
-            evo-icon-alipay-cn-12-colored
-        span.text
-            -- evo-icon-alipay-cn-12-colored
-
-    div
-        span.icon
-            evo-icon-alipay-cn-18-colored
-        span.text
-            -- evo-icon-alipay-cn-18-colored
-
-    div
-        span.icon
-            evo-icon-alipay-cn-24-colored
-        span.text
-            -- evo-icon-alipay-cn-24-colored
-
-    div
-        span.icon
-            evo-icon-alipay-cn-32-colored
-        span.text
-            -- evo-icon-alipay-cn-32-colored
-
-    div
-        span.icon
-            evo-icon-alipay-hk-12-colored
-        span.text
-            -- evo-icon-alipay-hk-12-colored
-
-    div
-        span.icon
-            evo-icon-alipay-hk-18-colored
-        span.text
-            -- evo-icon-alipay-hk-18-colored
-
-    div
-        span.icon
-            evo-icon-alipay-hk-24-colored
-        span.text
-            -- evo-icon-alipay-hk-24-colored
-
-    div
-        span.icon
-            evo-icon-alipay-hk-32-colored
-        span.text
-            -- evo-icon-alipay-hk-32-colored
-
-    div
-        span.icon
-            evo-icon-amex-12-colored
-        span.text
-            -- evo-icon-amex-12-colored
-
-    div
-        span.icon
-            evo-icon-amex-18-colored
-        span.text
-            -- evo-icon-amex-18-colored
-
-    div
-        span.icon
-            evo-icon-amex-24-colored
-        span.text
-            -- evo-icon-amex-24-colored
-
-    div
-        span.icon
-            evo-icon-amex-32-colored
-        span.text
-            -- evo-icon-amex-32-colored
-
-    div
-        span.icon
-            evo-icon-apple-24
-        span.text
-            -- evo-icon-apple-24
-
-    div
-        span.icon
-            evo-icon-apple-music-24-colored
-        span.text
-            -- evo-icon-apple-music-24-colored
-
-    div
-        span.icon
-            evo-icon-apple-pay-12-colored
-        span.text
-            -- evo-icon-apple-pay-12-colored
-
-    div
-        span.icon
-            evo-icon-apple-pay-18-colored
-        span.text
-            -- evo-icon-apple-pay-18-colored
-
-    div
-        span.icon
-            evo-icon-apple-pay-24-colored
-        span.text
-            -- evo-icon-apple-pay-24-colored
-
-    div
-        span.icon
-            evo-icon-apple-pay-32-colored
-        span.text
-            -- evo-icon-apple-pay-32-colored
-
-    div
-        span.icon
-            evo-icon-archive-16
-        span.text
-            -- evo-icon-archive-16
-
-    div
-        span.icon
-            evo-icon-archive-24
-        span.text
-            -- evo-icon-archive-24
-
-    div
-        span.icon
-            evo-icon-arrow-down-12
-        span.text
-            -- evo-icon-arrow-down-12
-
-    div
-        span.icon
-            evo-icon-arrow-down-16
-        span.text
-            -- evo-icon-arrow-down-16
-
-    div
-        span.icon
-            evo-icon-arrow-down-20
-        span.text
-            -- evo-icon-arrow-down-20
-
-    div
-        span.icon
-            evo-icon-arrow-down-24
-        span.text
-            -- evo-icon-arrow-down-24
-
-    div
-        span.icon
-            evo-icon-arrow-left-12
-        span.text
-            -- evo-icon-arrow-left-12
-
-    div
-        span.icon
-            evo-icon-arrow-left-16
-        span.text
-            -- evo-icon-arrow-left-16
-
-    div
-        span.icon
-            evo-icon-arrow-left-20
-        span.text
-            -- evo-icon-arrow-left-20
-
-    div
-        span.icon
-            evo-icon-arrow-left-24
-        span.text
-            -- evo-icon-arrow-left-24
-
-    div
-        span.icon
-            evo-icon-arrow-right-12
-        span.text
-            -- evo-icon-arrow-right-12
-
-    div
-        span.icon
-            evo-icon-arrow-right-16
-        span.text
-            -- evo-icon-arrow-right-16
-
-    div
-        span.icon
-            evo-icon-arrow-right-20
-        span.text
-            -- evo-icon-arrow-right-20
-
-    div
-        span.icon
-            evo-icon-arrow-right-24
-        span.text
-            -- evo-icon-arrow-right-24
-
-    div
-        span.icon
-            evo-icon-arrow-up-12
-        span.text
-            -- evo-icon-arrow-up-12
-
-    div
-        span.icon
-            evo-icon-arrow-up-16
-        span.text
-            -- evo-icon-arrow-up-16
-
-    div
-        span.icon
-            evo-icon-arrow-up-20
-        span.text
-            -- evo-icon-arrow-up-20
-
-    div
-        span.icon
-            evo-icon-arrow-up-24
-        span.text
-            -- evo-icon-arrow-up-24
-
-    div
-        span.icon
-            evo-icon-arrows-3d-16
-        span.text
-            -- evo-icon-arrows-3d-16
-
-    div
-        span.icon
-            evo-icon-arrows-3d-24
-        span.text
-            -- evo-icon-arrows-3d-24
-
-    div
-        span.icon
-            evo-icon-arrows-3d-filled-64-colored
-        span.text
-            -- evo-icon-arrows-3d-filled-64-colored
-
-    div
-        span.icon
-            evo-icon-arrows-expand-16
-        span.text
-            -- evo-icon-arrows-expand-16
-
-    div
-        span.icon
-            evo-icon-arrows-expand-24
-        span.text
-            -- evo-icon-arrows-expand-24
-
-    div
-        span.icon
-            evo-icon-article-16
-        span.text
-            -- evo-icon-article-16
-
-    div
-        span.icon
-            evo-icon-article-24
-        span.text
-            -- evo-icon-article-24
-
-    div
-        span.icon
-            evo-icon-attention-16
-        span.text
-            -- evo-icon-attention-16
-
-    div
-        span.icon
-            evo-icon-attention-24
-        span.text
-            -- evo-icon-attention-24
-
-    div
-        span.icon
-            evo-icon-attention-64
-        span.text
-            -- evo-icon-attention-64
-
-    div
-        span.icon
-            evo-icon-attention-filled-16
-        span.text
-            -- evo-icon-attention-filled-16
-
-    div
-        span.icon
-            evo-icon-attention-filled-24
-        span.text
-            -- evo-icon-attention-filled-24
-
-    div
-        span.icon
-            evo-icon-attention-triangle-16
-        span.text
-            -- evo-icon-attention-triangle-16
-
-    div
-        span.icon
-            evo-icon-attention-triangle-24
-        span.text
-            -- evo-icon-attention-triangle-24
-
-    div
-        span.icon
-            evo-icon-attention-triangle-filled-16
-        span.text
-            -- evo-icon-attention-triangle-filled-16
-
-    div
-        span.icon
-            evo-icon-attention-triangle-filled-24
-        span.text
-            -- evo-icon-attention-triangle-filled-24
-
-    div
-        span.icon
-            evo-icon-atv-16
-        span.text
-            -- evo-icon-atv-16
-
-    div
-        span.icon
-            evo-icon-atv-24
-        span.text
-            -- evo-icon-atv-24
-
-    div
-        span.icon
-            evo-icon-audio-high-16
-        span.text
-            -- evo-icon-audio-high-16
-
-    div
-        span.icon
-            evo-icon-audio-high-20
-        span.text
-            -- evo-icon-audio-high-20
-
-    div
-        span.icon
-            evo-icon-audio-high-24
-        span.text
-            -- evo-icon-audio-high-24
-
-    div
-        span.icon
-            evo-icon-audio-low-16
-        span.text
-            -- evo-icon-audio-low-16
-
-    div
-        span.icon
-            evo-icon-audio-off-16
-        span.text
-            -- evo-icon-audio-off-16
-
-    div
-        span.icon
-            evo-icon-audio-off-20
-        span.text
-            -- evo-icon-audio-off-20
-
-    div
-        span.icon
-            evo-icon-audio-off-24
-        span.text
-            -- evo-icon-audio-off-24
-
-    div
-        span.icon
-            evo-icon-authenticity-guarantee-16
-        span.text
-            -- evo-icon-authenticity-guarantee-16
-
-    div
-        span.icon
-            evo-icon-authenticity-guarantee-24
-        span.text
-            -- evo-icon-authenticity-guarantee-24
-
-    div
-        span.icon
-            evo-icon-authenticity-guarantee-filled-16
-        span.text
-            -- evo-icon-authenticity-guarantee-filled-16
-
-    div
-        span.icon
-            evo-icon-authenticity-guarantee-filled-16-colored
-        span.text
-            -- evo-icon-authenticity-guarantee-filled-16-colored
-
-    div
-        span.icon
-            evo-icon-authenticity-guarantee-filled-24
-        span.text
-            -- evo-icon-authenticity-guarantee-filled-24
-
-    div
-        span.icon
-            evo-icon-authenticity-guarantee-filled-24-colored
-        span.text
-            -- evo-icon-authenticity-guarantee-filled-24-colored
-
-    div
-        span.icon
-            evo-icon-auto-adjust-16
-        span.text
-            -- evo-icon-auto-adjust-16
-
-    div
-        span.icon
-            evo-icon-auto-adjust-24
-        span.text
-            -- evo-icon-auto-adjust-24
-
-    div
-        span.icon
-            evo-icon-background-removal-16
-        span.text
-            -- evo-icon-background-removal-16
-
-    div
-        span.icon
-            evo-icon-background-removal-24
-        span.text
-            -- evo-icon-background-removal-24
-
-    div
-        span.icon
-            evo-icon-bancontact-12-colored
-        span.text
-            -- evo-icon-bancontact-12-colored
-
-    div
-        span.icon
-            evo-icon-bancontact-18-colored
-        span.text
-            -- evo-icon-bancontact-18-colored
-
-    div
-        span.icon
-            evo-icon-bancontact-24-colored
-        span.text
-            -- evo-icon-bancontact-24-colored
-
-    div
-        span.icon
-            evo-icon-bancontact-32-colored
-        span.text
-            -- evo-icon-bancontact-32-colored
-
-    div
-        span.icon
-            evo-icon-bank-16
-        span.text
-            -- evo-icon-bank-16
-
-    div
-        span.icon
-            evo-icon-bank-20
-        span.text
-            -- evo-icon-bank-20
-
-    div
-        span.icon
-            evo-icon-bank-24
-        span.text
-            -- evo-icon-bank-24
-
-    div
-        span.icon
-            evo-icon-bank-64
-        span.text
-            -- evo-icon-bank-64
-
-    div
-        span.icon
-            evo-icon-bank-account-12-colored
-        span.text
-            -- evo-icon-bank-account-12-colored
-
-    div
-        span.icon
-            evo-icon-bank-account-18-colored
-        span.text
-            -- evo-icon-bank-account-18-colored
-
-    div
-        span.icon
-            evo-icon-bank-account-24-colored
-        span.text
-            -- evo-icon-bank-account-24-colored
-
-    div
-        span.icon
-            evo-icon-bank-account-32-colored
-        span.text
-            -- evo-icon-bank-account-32-colored
-
-    div
-        span.icon
-            evo-icon-bank-group-logo-24-colored
-        span.text
-            -- evo-icon-bank-group-logo-24-colored
-
-    div
-        span.icon
-            evo-icon-bank-of-america-12-colored
-        span.text
-            -- evo-icon-bank-of-america-12-colored
-
-    div
-        span.icon
-            evo-icon-bank-of-america-18-colored
-        span.text
-            -- evo-icon-bank-of-america-18-colored
-
-    div
-        span.icon
-            evo-icon-bank-of-america-24-colored
-        span.text
-            -- evo-icon-bank-of-america-24-colored
-
-    div
-        span.icon
-            evo-icon-bank-of-america-32-colored
-        span.text
-            -- evo-icon-bank-of-america-32-colored
-
-    div
-        span.icon
-            evo-icon-bar-chart-16
-        span.text
-            -- evo-icon-bar-chart-16
-
-    div
-        span.icon
-            evo-icon-bar-chart-24
-        span.text
-            -- evo-icon-bar-chart-24
-
-    div
-        span.icon
-            evo-icon-battery-waste-48
-        span.text
-            -- evo-icon-battery-waste-48
-
-    div
-        span.icon
-            evo-icon-bids-12
-        span.text
-            -- evo-icon-bids-12
-
-    div
-        span.icon
-            evo-icon-bids-16
-        span.text
-            -- evo-icon-bids-16
-
-    div
-        span.icon
-            evo-icon-bids-24
-        span.text
-            -- evo-icon-bids-24
-
-    div
-        span.icon
-            evo-icon-bids-64
-        span.text
-            -- evo-icon-bids-64
-
-    div
-        span.icon
-            evo-icon-boat-16
-        span.text
-            -- evo-icon-boat-16
-
-    div
-        span.icon
-            evo-icon-boat-24
-        span.text
-            -- evo-icon-boat-24
-
-    div
-        span.icon
-            evo-icon-book-16
-        span.text
-            -- evo-icon-book-16
-
-    div
-        span.icon
-            evo-icon-book-24
-        span.text
-            -- evo-icon-book-24
-
-    div
-        span.icon
-            evo-icon-bookmark-16
-        span.text
-            -- evo-icon-bookmark-16
-
-    div
-        span.icon
-            evo-icon-bookmark-24
-        span.text
-            -- evo-icon-bookmark-24
-
-    div
-        span.icon
-            evo-icon-bookmark-filled-16
-        span.text
-            -- evo-icon-bookmark-filled-16
-
-    div
-        span.icon
-            evo-icon-bookmark-filled-24
-        span.text
-            -- evo-icon-bookmark-filled-24
-
-    div
-        span.icon
-            evo-icon-brand-authorized-seller-16
-        span.text
-            -- evo-icon-brand-authorized-seller-16
-
-    div
-        span.icon
-            evo-icon-brand-authorized-seller-24
-        span.text
-            -- evo-icon-brand-authorized-seller-24
-
-    div
-        span.icon
-            evo-icon-brightness-16
-        span.text
-            -- evo-icon-brightness-16
-
-    div
-        span.icon
-            evo-icon-brightness-20
-        span.text
-            -- evo-icon-brightness-20
-
-    div
-        span.icon
-            evo-icon-brightness-24
-        span.text
-            -- evo-icon-brightness-24
-
-    div
-        span.icon
-            evo-icon-calendar-16
-        span.text
-            -- evo-icon-calendar-16
-
-    div
-        span.icon
-            evo-icon-calendar-24
-        span.text
-            -- evo-icon-calendar-24
-
-    div
-        span.icon
-            evo-icon-calendar-64
-        span.text
-            -- evo-icon-calendar-64
-
-    div
-        span.icon
-            evo-icon-camera-16
-        span.text
-            -- evo-icon-camera-16
-
-    div
-        span.icon
-            evo-icon-camera-24
-        span.text
-            -- evo-icon-camera-24
-
-    div
-        span.icon
-            evo-icon-camera-64
-        span.text
-            -- evo-icon-camera-64
-
-    div
-        span.icon
-            evo-icon-capital-one-12-colored
-        span.text
-            -- evo-icon-capital-one-12-colored
-
-    div
-        span.icon
-            evo-icon-capital-one-18-colored
-        span.text
-            -- evo-icon-capital-one-18-colored
-
-    div
-        span.icon
-            evo-icon-capital-one-24-colored
-        span.text
-            -- evo-icon-capital-one-24-colored
-
-    div
-        span.icon
-            evo-icon-capital-one-32-colored
-        span.text
-            -- evo-icon-capital-one-32-colored
-
-    div
-        span.icon
-            evo-icon-car-16
-        span.text
-            -- evo-icon-car-16
-
-    div
-        span.icon
-            evo-icon-car-24
-        span.text
-            -- evo-icon-car-24
-
-    div
-        span.icon
-            evo-icon-car-brake-16
-        span.text
-            -- evo-icon-car-brake-16
-
-    div
-        span.icon
-            evo-icon-car-brake-24
-        span.text
-            -- evo-icon-car-brake-24
-
-    div
-        span.icon
-            evo-icon-card-stack-64
-        span.text
-            -- evo-icon-card-stack-64
-
-    div
-        span.icon
-            evo-icon-carnet-12-colored
-        span.text
-            -- evo-icon-carnet-12-colored
-
-    div
-        span.icon
-            evo-icon-carnet-18-colored
-        span.text
-            -- evo-icon-carnet-18-colored
-
-    div
-        span.icon
-            evo-icon-carnet-24-colored
-        span.text
-            -- evo-icon-carnet-24-colored
-
-    div
-        span.icon
-            evo-icon-carnet-32-colored
-        span.text
-            -- evo-icon-carnet-32-colored
-
-    div
-        span.icon
-            evo-icon-carryon-24
-        span.text
-            -- evo-icon-carryon-24
-
-    div
-        span.icon
-            evo-icon-cart-16
-        span.text
-            -- evo-icon-cart-16
-
-    div
-        span.icon
-            evo-icon-cart-20
-        span.text
-            -- evo-icon-cart-20
-
-    div
-        span.icon
-            evo-icon-cart-24
-        span.text
-            -- evo-icon-cart-24
-
-    div
-        span.icon
-            evo-icon-cart-64
-        span.text
-            -- evo-icon-cart-64
-
-    div
-        span.icon
-            evo-icon-cart-add-16
-        span.text
-            -- evo-icon-cart-add-16
-
-    div
-        span.icon
-            evo-icon-cart-add-20
-        span.text
-            -- evo-icon-cart-add-20
-
-    div
-        span.icon
-            evo-icon-cart-add-24
-        span.text
-            -- evo-icon-cart-add-24
-
-    div
-        span.icon
-            evo-icon-cashapp-12-colored
-        span.text
-            -- evo-icon-cashapp-12-colored
-
-    div
-        span.icon
-            evo-icon-cashapp-18-colored
-        span.text
-            -- evo-icon-cashapp-18-colored
-
-    div
-        span.icon
-            evo-icon-cashapp-24-colored
-        span.text
-            -- evo-icon-cashapp-24-colored
-
-    div
-        span.icon
-            evo-icon-cashapp-32-colored
-        span.text
-            -- evo-icon-cashapp-32-colored
-
-    div
-        span.icon
-            evo-icon-categories-16
-        span.text
-            -- evo-icon-categories-16
-
-    div
-        span.icon
-            evo-icon-categories-24
-        span.text
-            -- evo-icon-categories-24
-
-    div
-        span.icon
-            evo-icon-cb-12-colored
-        span.text
-            -- evo-icon-cb-12-colored
-
-    div
-        span.icon
-            evo-icon-cb-18-colored
-        span.text
-            -- evo-icon-cb-18-colored
-
-    div
-        span.icon
-            evo-icon-cb-24-colored
-        span.text
-            -- evo-icon-cb-24-colored
-
-    div
-        span.icon
-            evo-icon-cb-32-colored
-        span.text
-            -- evo-icon-cb-32-colored
-
-    div
-        span.icon
-            evo-icon-ccd-charger-included
-        span.text
-            -- evo-icon-ccd-charger-included
-
-    div
-        span.icon
-            evo-icon-ccd-charger-not-included
-        span.text
-            -- evo-icon-ccd-charger-not-included
-
-    div
-        span.icon
-            evo-icon-ccd-top
-        span.text
-            -- evo-icon-ccd-top
-
-    div
-        span.icon
-            evo-icon-certified-recycled-16
-        span.text
-            -- evo-icon-certified-recycled-16
-
-    div
-        span.icon
-            evo-icon-certified-recycled-24
-        span.text
-            -- evo-icon-certified-recycled-24
-
-    div
-        span.icon
-            evo-icon-chair-16
-        span.text
-            -- evo-icon-chair-16
-
-    div
-        span.icon
-            evo-icon-chair-24
-        span.text
-            -- evo-icon-chair-24
-
-    div
-        span.icon
-            evo-icon-chase-12-colored
-        span.text
-            -- evo-icon-chase-12-colored
-
-    div
-        span.icon
-            evo-icon-chase-18-colored
-        span.text
-            -- evo-icon-chase-18-colored
-
-    div
-        span.icon
-            evo-icon-chase-24-colored
-        span.text
-            -- evo-icon-chase-24-colored
-
-    div
-        span.icon
-            evo-icon-chase-32-colored
-        span.text
-            -- evo-icon-chase-32-colored
-
-    div
-        span.icon
-            evo-icon-chat-16
-        span.text
-            -- evo-icon-chat-16
-
-    div
-        span.icon
-            evo-icon-chat-24
-        span.text
-            -- evo-icon-chat-24
-
-    div
-        span.icon
-            evo-icon-chat-64
-        span.text
-            -- evo-icon-chat-64
-
-    div
-        span.icon
-            evo-icon-check-in-24
-        span.text
-            -- evo-icon-check-in-24
-
-    div
-        span.icon
-            evo-icon-checkbox-checked-18
-        span.text
-            -- evo-icon-checkbox-checked-18
-
-    div
-        span.icon
-            evo-icon-checkbox-checked-24
-        span.text
-            -- evo-icon-checkbox-checked-24
-
-    div
-        span.icon
-            evo-icon-checkbox-mixed-18
-        span.text
-            -- evo-icon-checkbox-mixed-18
-
-    div
-        span.icon
-            evo-icon-checkbox-mixed-24
-        span.text
-            -- evo-icon-checkbox-mixed-24
-
-    div
-        span.icon
-            evo-icon-checkbox-unchecked-18
-        span.text
-            -- evo-icon-checkbox-unchecked-18
-
-    div
-        span.icon
-            evo-icon-checkbox-unchecked-24
-        span.text
-            -- evo-icon-checkbox-unchecked-24
-
-    div
-        span.icon
-            evo-icon-checkmark-24
-        span.text
-            -- evo-icon-checkmark-24
-
-    div
-        span.icon
-            evo-icon-chevron-down-12
-        span.text
-            -- evo-icon-chevron-down-12
-
-    div
-        span.icon
-            evo-icon-chevron-down-16
-        span.text
-            -- evo-icon-chevron-down-16
-
-    div
-        span.icon
-            evo-icon-chevron-down-20
-        span.text
-            -- evo-icon-chevron-down-20
-
-    div
-        span.icon
-            evo-icon-chevron-down-24
-        span.text
-            -- evo-icon-chevron-down-24
-
-    div
-        span.icon
-            evo-icon-chevron-left-12
-        span.text
-            -- evo-icon-chevron-left-12
-
-    div
-        span.icon
-            evo-icon-chevron-left-16
-        span.text
-            -- evo-icon-chevron-left-16
-
-    div
-        span.icon
-            evo-icon-chevron-left-20
-        span.text
-            -- evo-icon-chevron-left-20
-
-    div
-        span.icon
-            evo-icon-chevron-left-24
-        span.text
-            -- evo-icon-chevron-left-24
-
-    div
-        span.icon
-            evo-icon-chevron-right-12
-        span.text
-            -- evo-icon-chevron-right-12
-
-    div
-        span.icon
-            evo-icon-chevron-right-16
-        span.text
-            -- evo-icon-chevron-right-16
-
-    div
-        span.icon
-            evo-icon-chevron-right-20
-        span.text
-            -- evo-icon-chevron-right-20
-
-    div
-        span.icon
-            evo-icon-chevron-right-24
-        span.text
-            -- evo-icon-chevron-right-24
-
-    div
-        span.icon
-            evo-icon-chevron-up-12
-        span.text
-            -- evo-icon-chevron-up-12
-
-    div
-        span.icon
-            evo-icon-chevron-up-16
-        span.text
-            -- evo-icon-chevron-up-16
-
-    div
-        span.icon
-            evo-icon-chevron-up-20
-        span.text
-            -- evo-icon-chevron-up-20
-
-    div
-        span.icon
-            evo-icon-chevron-up-24
-        span.text
-            -- evo-icon-chevron-up-24
-
-    div
-        span.icon
-            evo-icon-chinese-coin-16
-        span.text
-            -- evo-icon-chinese-coin-16
-
-    div
-        span.icon
-            evo-icon-chinese-coin-24
-        span.text
-            -- evo-icon-chinese-coin-24
-
-    div
-        span.icon
-            evo-icon-citi-12-colored
-        span.text
-            -- evo-icon-citi-12-colored
-
-    div
-        span.icon
-            evo-icon-citi-18-colored
-        span.text
-            -- evo-icon-citi-18-colored
-
-    div
-        span.icon
-            evo-icon-citi-24-colored
-        span.text
-            -- evo-icon-citi-24-colored
-
-    div
-        span.icon
-            evo-icon-citi-32-colored
-        span.text
-            -- evo-icon-citi-32-colored
-
-    div
-        span.icon
-            evo-icon-clear-16
-        span.text
-            -- evo-icon-clear-16
-
-    div
-        span.icon
-            evo-icon-clear-20
-        span.text
-            -- evo-icon-clear-20
-
-    div
-        span.icon
-            evo-icon-clear-24
-        span.text
-            -- evo-icon-clear-24
-
-    div
-        span.icon
-            evo-icon-click-to-call-16
-        span.text
-            -- evo-icon-click-to-call-16
-
-    div
-        span.icon
-            evo-icon-click-to-call-24
-        span.text
-            -- evo-icon-click-to-call-24
-
-    div
-        span.icon
-            evo-icon-clock-12
-        span.text
-            -- evo-icon-clock-12
-
-    div
-        span.icon
-            evo-icon-clock-16
-        span.text
-            -- evo-icon-clock-16
-
-    div
-        span.icon
-            evo-icon-clock-24
-        span.text
-            -- evo-icon-clock-24
-
-    div
-        span.icon
-            evo-icon-clock-64
-        span.text
-            -- evo-icon-clock-64
-
-    div
-        span.icon
-            evo-icon-clock-fast-16
-        span.text
-            -- evo-icon-clock-fast-16
-
-    div
-        span.icon
-            evo-icon-clock-fast-24
-        span.text
-            -- evo-icon-clock-fast-24
-
-    div
-        span.icon
-            evo-icon-close-12
-        span.text
-            -- evo-icon-close-12
-
-    div
-        span.icon
-            evo-icon-close-16
-        span.text
-            -- evo-icon-close-16
-
-    div
-        span.icon
-            evo-icon-close-20
-        span.text
-            -- evo-icon-close-20
-
-    div
-        span.icon
-            evo-icon-close-24
-        span.text
-            -- evo-icon-close-24
-
-    div
-        span.icon
-            evo-icon-closed-caption-16
-        span.text
-            -- evo-icon-closed-caption-16
-
-    div
-        span.icon
-            evo-icon-closed-caption-24
-        span.text
-            -- evo-icon-closed-caption-24
-
-    div
-        span.icon
-            evo-icon-closed-caption-filled-16
-        span.text
-            -- evo-icon-closed-caption-filled-16
-
-    div
-        span.icon
-            evo-icon-closed-caption-filled-24
-        span.text
-            -- evo-icon-closed-caption-filled-24
-
-    div
-        span.icon
-            evo-icon-coin-24
-        span.text
-            -- evo-icon-coin-24
-
-    div
-        span.icon
-            evo-icon-coin-battery-48
-        span.text
-            -- evo-icon-coin-battery-48
-
-    div
-        span.icon
-            evo-icon-collections-16
-        span.text
-            -- evo-icon-collections-16
-
-    div
-        span.icon
-            evo-icon-collections-24
-        span.text
-            -- evo-icon-collections-24
-
-    div
-        span.icon
-            evo-icon-condensed-grid-24
-        span.text
-            -- evo-icon-condensed-grid-24
-
-    div
-        span.icon
-            evo-icon-condensed-grid-filled-24
-        span.text
-            -- evo-icon-condensed-grid-filled-24
-
-    div
-        span.icon
-            evo-icon-confirmation-16
-        span.text
-            -- evo-icon-confirmation-16
-
-    div
-        span.icon
-            evo-icon-confirmation-24
-        span.text
-            -- evo-icon-confirmation-24
-
-    div
-        span.icon
-            evo-icon-confirmation-64
-        span.text
-            -- evo-icon-confirmation-64
-
-    div
-        span.icon
-            evo-icon-confirmation-filled-12
-        span.text
-            -- evo-icon-confirmation-filled-12
-
-    div
-        span.icon
-            evo-icon-confirmation-filled-16
-        span.text
-            -- evo-icon-confirmation-filled-16
-
-    div
-        span.icon
-            evo-icon-confirmation-filled-24
-        span.text
-            -- evo-icon-confirmation-filled-24
-
-    div
-        span.icon
-            evo-icon-contract-16
-        span.text
-            -- evo-icon-contract-16
-
-    div
-        span.icon
-            evo-icon-contrast-24
-        span.text
-            -- evo-icon-contrast-24
-
-    div
-        span.icon
-            evo-icon-copy-16
-        span.text
-            -- evo-icon-copy-16
-
-    div
-        span.icon
-            evo-icon-copy-24
-        span.text
-            -- evo-icon-copy-24
-
-    div
-        span.icon
-            evo-icon-coupon-16
-        span.text
-            -- evo-icon-coupon-16
-
-    div
-        span.icon
-            evo-icon-coupon-20
-        span.text
-            -- evo-icon-coupon-20
-
-    div
-        span.icon
-            evo-icon-coupon-24
-        span.text
-            -- evo-icon-coupon-24
-
-    div
-        span.icon
-            evo-icon-credit-card-16
-        span.text
-            -- evo-icon-credit-card-16
-
-    div
-        span.icon
-            evo-icon-credit-card-20
-        span.text
-            -- evo-icon-credit-card-20
-
-    div
-        span.icon
-            evo-icon-credit-card-24
-        span.text
-            -- evo-icon-credit-card-24
-
-    div
-        span.icon
-            evo-icon-credit-card-64
-        span.text
-            -- evo-icon-credit-card-64
-
-    div
-        span.icon
-            evo-icon-credit-card-cvv-back-20
-        span.text
-            -- evo-icon-credit-card-cvv-back-20
-
-    div
-        span.icon
-            evo-icon-credit-card-cvv-back-24
-        span.text
-            -- evo-icon-credit-card-cvv-back-24
-
-    div
-        span.icon
-            evo-icon-credit-card-cvv-front-20
-        span.text
-            -- evo-icon-credit-card-cvv-front-20
-
-    div
-        span.icon
-            evo-icon-credit-card-cvv-front-24
-        span.text
-            -- evo-icon-credit-card-cvv-front-24
-
-    div
-        span.icon
-            evo-icon-crop-24
-        span.text
-            -- evo-icon-crop-24
-
-    div
-        span.icon
-            evo-icon-customize-16
-        span.text
-            -- evo-icon-customize-16
-
-    div
-        span.icon
-            evo-icon-customize-24
-        span.text
-            -- evo-icon-customize-24
-
-    div
-        span.icon
-            evo-icon-delete-16
-        span.text
-            -- evo-icon-delete-16
-
-    div
-        span.icon
-            evo-icon-delete-20
-        span.text
-            -- evo-icon-delete-20
-
-    div
-        span.icon
-            evo-icon-delete-24
-        span.text
-            -- evo-icon-delete-24
-
-    div
-        span.icon
-            evo-icon-density-compact-16
-        span.text
-            -- evo-icon-density-compact-16
-
-    div
-        span.icon
-            evo-icon-density-compact-24
-        span.text
-            -- evo-icon-density-compact-24
-
-    div
-        span.icon
-            evo-icon-density-default-16
-        span.text
-            -- evo-icon-density-default-16
-
-    div
-        span.icon
-            evo-icon-density-default-24
-        span.text
-            -- evo-icon-density-default-24
-
-    div
-        span.icon
-            evo-icon-density-relaxed-16
-        span.text
-            -- evo-icon-density-relaxed-16
-
-    div
-        span.icon
-            evo-icon-density-relaxed-24
-        span.text
-            -- evo-icon-density-relaxed-24
-
-    div
-        span.icon
-            evo-icon-density-row-compact-16
-        span.text
-            -- evo-icon-density-row-compact-16
-
-    div
-        span.icon
-            evo-icon-density-row-compact-24
-        span.text
-            -- evo-icon-density-row-compact-24
-
-    div
-        span.icon
-            evo-icon-density-row-relaxed-16
-        span.text
-            -- evo-icon-density-row-relaxed-16
-
-    div
-        span.icon
-            evo-icon-density-row-relaxed-24
-        span.text
-            -- evo-icon-density-row-relaxed-24
-
-    div
-        span.icon
-            evo-icon-desktop-16
-        span.text
-            -- evo-icon-desktop-16
-
-    div
-        span.icon
-            evo-icon-desktop-20
-        span.text
-            -- evo-icon-desktop-20
-
-    div
-        span.icon
-            evo-icon-desktop-24
-        span.text
-            -- evo-icon-desktop-24
-
-    div
-        span.icon
-            evo-icon-diamond-16
-        span.text
-            -- evo-icon-diamond-16
-
-    div
-        span.icon
-            evo-icon-diamond-24
-        span.text
-            -- evo-icon-diamond-24
-
-    div
-        span.icon
-            evo-icon-diners-12-colored
-        span.text
-            -- evo-icon-diners-12-colored
-
-    div
-        span.icon
-            evo-icon-diners-18-colored
-        span.text
-            -- evo-icon-diners-18-colored
-
-    div
-        span.icon
-            evo-icon-diners-24-colored
-        span.text
-            -- evo-icon-diners-24-colored
-
-    div
-        span.icon
-            evo-icon-diners-32-colored
-        span.text
-            -- evo-icon-diners-32-colored
-
-    div
-        span.icon
-            evo-icon-direct-debit-12-colored
-        span.text
-            -- evo-icon-direct-debit-12-colored
-
-    div
-        span.icon
-            evo-icon-direct-debit-18-colored
-        span.text
-            -- evo-icon-direct-debit-18-colored
-
-    div
-        span.icon
-            evo-icon-direct-debit-24-colored
-        span.text
-            -- evo-icon-direct-debit-24-colored
-
-    div
-        span.icon
-            evo-icon-direct-debit-32-colored
-        span.text
-            -- evo-icon-direct-debit-32-colored
-
-    div
-        span.icon
-            evo-icon-direct-from-brand-16
-        span.text
-            -- evo-icon-direct-from-brand-16
-
-    div
-        span.icon
-            evo-icon-direct-from-brand-24
-        span.text
-            -- evo-icon-direct-from-brand-24
-
-    div
-        span.icon
-            evo-icon-discord-24
-        span.text
-            -- evo-icon-discord-24
-
-    div
-        span.icon
-            evo-icon-discount-16
-        span.text
-            -- evo-icon-discount-16
-
-    div
-        span.icon
-            evo-icon-discount-24
-        span.text
-            -- evo-icon-discount-24
-
-    div
-        span.icon
-            evo-icon-discount-auto-16
-        span.text
-            -- evo-icon-discount-auto-16
-
-    div
-        span.icon
-            evo-icon-discount-auto-24
-        span.text
-            -- evo-icon-discount-auto-24
-
-    div
-        span.icon
-            evo-icon-discover-12-colored
-        span.text
-            -- evo-icon-discover-12-colored
-
-    div
-        span.icon
-            evo-icon-discover-18-colored
-        span.text
-            -- evo-icon-discover-18-colored
-
-    div
-        span.icon
-            evo-icon-discover-24-colored
-        span.text
-            -- evo-icon-discover-24-colored
-
-    div
-        span.icon
-            evo-icon-discover-32-colored
-        span.text
-            -- evo-icon-discover-32-colored
-
-    div
-        span.icon
-            evo-icon-dollar-16
-        span.text
-            -- evo-icon-dollar-16
-
-    div
-        span.icon
-            evo-icon-dollar-24
-        span.text
-            -- evo-icon-dollar-24
-
-    div
-        span.icon
-            evo-icon-dollar-off-24
-        span.text
-            -- evo-icon-dollar-off-24
-
-    div
-        span.icon
-            evo-icon-download-16
-        span.text
-            -- evo-icon-download-16
-
-    div
-        span.icon
-            evo-icon-download-20
-        span.text
-            -- evo-icon-download-20
-
-    div
-        span.icon
-            evo-icon-download-24
-        span.text
-            -- evo-icon-download-24
-
-    div
-        span.icon
-            evo-icon-drag-drop-16
-        span.text
-            -- evo-icon-drag-drop-16
-
-    div
-        span.icon
-            evo-icon-drag-drop-24
-        span.text
-            -- evo-icon-drag-drop-24
-
-    div
-        span.icon
-            evo-icon-ebay-balance-12-colored
-        span.text
-            -- evo-icon-ebay-balance-12-colored
-
-    div
-        span.icon
-            evo-icon-ebay-balance-18-colored
-        span.text
-            -- evo-icon-ebay-balance-18-colored
-
-    div
-        span.icon
-            evo-icon-ebay-balance-24-colored
-        span.text
-            -- evo-icon-ebay-balance-24-colored
-
-    div
-        span.icon
-            evo-icon-ebay-balance-32-colored
-        span.text
-            -- evo-icon-ebay-balance-32-colored
-
-    div
-        span.icon
-            evo-icon-ebay-bucks-logo-16-colored
-        span.text
-            -- evo-icon-ebay-bucks-logo-16-colored
-
-    div
-        span.icon
-            evo-icon-ebay-credit-card-black-12-colored
-        span.text
-            -- evo-icon-ebay-credit-card-black-12-colored
-
-    div
-        span.icon
-            evo-icon-ebay-credit-card-black-18-colored
-        span.text
-            -- evo-icon-ebay-credit-card-black-18-colored
-
-    div
-        span.icon
-            evo-icon-ebay-credit-card-black-24-colored
-        span.text
-            -- evo-icon-ebay-credit-card-black-24-colored
-
-    div
-        span.icon
-            evo-icon-ebay-credit-card-black-32-colored
-        span.text
-            -- evo-icon-ebay-credit-card-black-32-colored
-
-    div
-        span.icon
-            evo-icon-ebay-credit-card-purple-12-colored
-        span.text
-            -- evo-icon-ebay-credit-card-purple-12-colored
-
-    div
-        span.icon
-            evo-icon-ebay-credit-card-purple-18-colored
-        span.text
-            -- evo-icon-ebay-credit-card-purple-18-colored
-
-    div
-        span.icon
-            evo-icon-ebay-credit-card-purple-24-colored
-        span.text
-            -- evo-icon-ebay-credit-card-purple-24-colored
-
-    div
-        span.icon
-            evo-icon-ebay-credit-card-purple-32-colored
-        span.text
-            -- evo-icon-ebay-credit-card-purple-32-colored
-
-    div
-        span.icon
-            evo-icon-ebay-credit-card-white-12-colored
-        span.text
-            -- evo-icon-ebay-credit-card-white-12-colored
-
-    div
-        span.icon
-            evo-icon-ebay-credit-card-white-18-colored
-        span.text
-            -- evo-icon-ebay-credit-card-white-18-colored
-
-    div
-        span.icon
-            evo-icon-ebay-credit-card-white-24-colored
-        span.text
-            -- evo-icon-ebay-credit-card-white-24-colored
-
-    div
-        span.icon
-            evo-icon-ebay-credit-card-white-32-colored
-        span.text
-            -- evo-icon-ebay-credit-card-white-32-colored
-
-    div
-        span.icon
-            evo-icon-ebay-for-charity-16
-        span.text
-            -- evo-icon-ebay-for-charity-16
-
-    div
-        span.icon
-            evo-icon-ebay-for-charity-24
-        span.text
-            -- evo-icon-ebay-for-charity-24
-
-    div
-        span.icon
-            evo-icon-ebay-international-shipping-16
-        span.text
-            -- evo-icon-ebay-international-shipping-16
-
-    div
-        span.icon
-            evo-icon-ebay-international-shipping-24
-        span.text
-            -- evo-icon-ebay-international-shipping-24
-
-    div
-        span.icon
-            evo-icon-ebay-international-shipping-64
-        span.text
-            -- evo-icon-ebay-international-shipping-64
-
-    div
-        span.icon
-            evo-icon-ebay-live-16
-        span.text
-            -- evo-icon-ebay-live-16
-
-    div
-        span.icon
-            evo-icon-ebay-live-24
-        span.text
-            -- evo-icon-ebay-live-24
-
-    div
-        span.icon
-            evo-icon-ebay-logo-16-colored
-        span.text
-            -- evo-icon-ebay-logo-16-colored
-
-    div
-        span.icon
-            evo-icon-ebay-mastercard-12-colored
-        span.text
-            -- evo-icon-ebay-mastercard-12-colored
-
-    div
-        span.icon
-            evo-icon-ebay-mastercard-18-colored
-        span.text
-            -- evo-icon-ebay-mastercard-18-colored
-
-    div
-        span.icon
-            evo-icon-ebay-mastercard-24-colored
-        span.text
-            -- evo-icon-ebay-mastercard-24-colored
-
-    div
-        span.icon
-            evo-icon-ebay-mastercard-32-colored
-        span.text
-            -- evo-icon-ebay-mastercard-32-colored
-
-    div
-        span.icon
-            evo-icon-ebay-money-back-guarantee-logo-16-colored
-        span.text
-            -- evo-icon-ebay-money-back-guarantee-logo-16-colored
-
-    div
-        span.icon
-            evo-icon-ebay-plus-16
-        span.text
-            -- evo-icon-ebay-plus-16
-
-    div
-        span.icon
-            evo-icon-ebay-plus-24
-        span.text
-            -- evo-icon-ebay-plus-24
-
-    div
-        span.icon
-            evo-icon-ebay-plus-logo-16-colored
-        span.text
-            -- evo-icon-ebay-plus-logo-16-colored
-
-    div
-        span.icon
-            evo-icon-ebay-plus-logo-dark-16-colored
-        span.text
-            -- evo-icon-ebay-plus-logo-dark-16-colored
-
-    div
-        span.icon
-            evo-icon-ebay-preloved-16
-        span.text
-            -- evo-icon-ebay-preloved-16
-
-    div
-        span.icon
-            evo-icon-ebay-preloved-24
-        span.text
-            -- evo-icon-ebay-preloved-24
-
-    div
-        span.icon
-            evo-icon-ebay-refurbished-16
-        span.text
-            -- evo-icon-ebay-refurbished-16
-
-    div
-        span.icon
-            evo-icon-ebay-refurbished-24
-        span.text
-            -- evo-icon-ebay-refurbished-24
-
-    div
-        span.icon
-            evo-icon-eftpos-12-colored
-        span.text
-            -- evo-icon-eftpos-12-colored
-
-    div
-        span.icon
-            evo-icon-eftpos-18-colored
-        span.text
-            -- evo-icon-eftpos-18-colored
-
-    div
-        span.icon
-            evo-icon-eftpos-24-colored
-        span.text
-            -- evo-icon-eftpos-24-colored
-
-    div
-        span.icon
-            evo-icon-eftpos-32-colored
-        span.text
-            -- evo-icon-eftpos-32-colored
-
-    div
-        span.icon
-            evo-icon-elo-12-colored
-        span.text
-            -- evo-icon-elo-12-colored
-
-    div
-        span.icon
-            evo-icon-elo-18-colored
-        span.text
-            -- evo-icon-elo-18-colored
-
-    div
-        span.icon
-            evo-icon-elo-24-colored
-        span.text
-            -- evo-icon-elo-24-colored
-
-    div
-        span.icon
-            evo-icon-elo-32-colored
-        span.text
-            -- evo-icon-elo-32-colored
-
-    div
-        span.icon
-            evo-icon-escrow-card-12-colored
-        span.text
-            -- evo-icon-escrow-card-12-colored
-
-    div
-        span.icon
-            evo-icon-escrow-card-18-colored
-        span.text
-            -- evo-icon-escrow-card-18-colored
-
-    div
-        span.icon
-            evo-icon-escrow-card-24-colored
-        span.text
-            -- evo-icon-escrow-card-24-colored
-
-    div
-        span.icon
-            evo-icon-escrow-card-32-colored
-        span.text
-            -- evo-icon-escrow-card-32-colored
-
-    div
-        span.icon
-            evo-icon-euro-16
-        span.text
-            -- evo-icon-euro-16
-
-    div
-        span.icon
-            evo-icon-euro-24
-        span.text
-            -- evo-icon-euro-24
-
-    div
-        span.icon
-            evo-icon-european-conformity-48
-        span.text
-            -- evo-icon-european-conformity-48
-
-    div
-        span.icon
-            evo-icon-exclude-16
-        span.text
-            -- evo-icon-exclude-16
-
-    div
-        span.icon
-            evo-icon-exclude-24
-        span.text
-            -- evo-icon-exclude-24
-
-    div
-        span.icon
-            evo-icon-exclude-64
-        span.text
-            -- evo-icon-exclude-64
-
-    div
-        span.icon
-            evo-icon-expand-16
-        span.text
-            -- evo-icon-expand-16
-
-    div
-        span.icon
-            evo-icon-explore-16
-        span.text
-            -- evo-icon-explore-16
-
-    div
-        span.icon
-            evo-icon-explore-24
-        span.text
-            -- evo-icon-explore-24
-
-    div
-        span.icon
-            evo-icon-external-link-16
-        span.text
-            -- evo-icon-external-link-16
-
-    div
-        span.icon
-            evo-icon-external-link-20
-        span.text
-            -- evo-icon-external-link-20
-
-    div
-        span.icon
-            evo-icon-external-link-24
-        span.text
-            -- evo-icon-external-link-24
-
-    div
-        span.icon
-            evo-icon-eye-16
-        span.text
-            -- evo-icon-eye-16
-
-    div
-        span.icon
-            evo-icon-eye-24
-        span.text
-            -- evo-icon-eye-24
-
-    div
-        span.icon
-            evo-icon-face-happiest-24
-        span.text
-            -- evo-icon-face-happiest-24
-
-    div
-        span.icon
-            evo-icon-face-happy-16
-        span.text
-            -- evo-icon-face-happy-16
-
-    div
-        span.icon
-            evo-icon-face-happy-24
-        span.text
-            -- evo-icon-face-happy-24
-
-    div
-        span.icon
-            evo-icon-face-neutral-24
-        span.text
-            -- evo-icon-face-neutral-24
-
-    div
-        span.icon
-            evo-icon-face-sad-24
-        span.text
-            -- evo-icon-face-sad-24
-
-    div
-        span.icon
-            evo-icon-face-saddest-24
-        span.text
-            -- evo-icon-face-saddest-24
-
-    div
-        span.icon
-            evo-icon-facebook-24
-        span.text
-            -- evo-icon-facebook-24
-
-    div
-        span.icon
-            evo-icon-facebook-messenger-24
-        span.text
-            -- evo-icon-facebook-messenger-24
-
-    div
-        span.icon
-            evo-icon-fall-leaf-16
-        span.text
-            -- evo-icon-fall-leaf-16
-
-    div
-        span.icon
-            evo-icon-fall-leaf-24
-        span.text
-            -- evo-icon-fall-leaf-24
-
-    div
-        span.icon
-            evo-icon-fast-forward-16
-        span.text
-            -- evo-icon-fast-forward-16
-
-    div
-        span.icon
-            evo-icon-feedback-16
-        span.text
-            -- evo-icon-feedback-16
-
-    div
-        span.icon
-            evo-icon-feedback-20
-        span.text
-            -- evo-icon-feedback-20
-
-    div
-        span.icon
-            evo-icon-feedback-24
-        span.text
-            -- evo-icon-feedback-24
-
-    div
-        span.icon
-            evo-icon-feedback-error-16
-        span.text
-            -- evo-icon-feedback-error-16
-
-    div
-        span.icon
-            evo-icon-feedback-error-24
-        span.text
-            -- evo-icon-feedback-error-24
-
-    div
-        span.icon
-            evo-icon-feedback-negative-16
-        span.text
-            -- evo-icon-feedback-negative-16
-
-    div
-        span.icon
-            evo-icon-feedback-neutral-16
-        span.text
-            -- evo-icon-feedback-neutral-16
-
-    div
-        span.icon
-            evo-icon-feedback-positive-16
-        span.text
-            -- evo-icon-feedback-positive-16
-
-    div
-        span.icon
-            evo-icon-feedback-received-16
-        span.text
-            -- evo-icon-feedback-received-16
-
-    div
-        span.icon
-            evo-icon-feedback-received-24
-        span.text
-            -- evo-icon-feedback-received-24
-
-    div
-        span.icon
-            evo-icon-file-16
-        span.text
-            -- evo-icon-file-16
-
-    div
-        span.icon
-            evo-icon-file-24
-        span.text
-            -- evo-icon-file-24
-
-    div
-        span.icon
-            evo-icon-filter-16
-        span.text
-            -- evo-icon-filter-16
-
-    div
-        span.icon
-            evo-icon-filter-24
-        span.text
-            -- evo-icon-filter-24
-
-    div
-        span.icon
-            evo-icon-fingerprint-16
-        span.text
-            -- evo-icon-fingerprint-16
-
-    div
-        span.icon
-            evo-icon-fingerprint-24
-        span.text
-            -- evo-icon-fingerprint-24
-
-    div
-        span.icon
-            evo-icon-fingerprint-64
-        span.text
-            -- evo-icon-fingerprint-64
-
-    div
-        span.icon
-            evo-icon-flag-16
-        span.text
-            -- evo-icon-flag-16
-
-    div
-        span.icon
-            evo-icon-flag-24
-        span.text
-            -- evo-icon-flag-24
-
-    div
-        span.icon
-            evo-icon-flag-filled-16
-        span.text
-            -- evo-icon-flag-filled-16
-
-    div
-        span.icon
-            evo-icon-flag-filled-24
-        span.text
-            -- evo-icon-flag-filled-24
-
-    div
-        span.icon
-            evo-icon-flash-24
-        span.text
-            -- evo-icon-flash-24
-
-    div
-        span.icon
-            evo-icon-flash-auto-24
-        span.text
-            -- evo-icon-flash-auto-24
-
-    div
-        span.icon
-            evo-icon-flash-off-24
-        span.text
-            -- evo-icon-flash-off-24
-
-    div
-        span.icon
-            evo-icon-folder-16
-        span.text
-            -- evo-icon-folder-16
-
-    div
-        span.icon
-            evo-icon-folder-24
-        span.text
-            -- evo-icon-folder-24
-
-    div
-        span.icon
-            evo-icon-folder-add-16
-        span.text
-            -- evo-icon-folder-add-16
-
-    div
-        span.icon
-            evo-icon-folder-add-24
-        span.text
-            -- evo-icon-folder-add-24
-
-    div
-        span.icon
-            evo-icon-forklift-16
-        span.text
-            -- evo-icon-forklift-16
-
-    div
-        span.icon
-            evo-icon-forklift-24
-        span.text
-            -- evo-icon-forklift-24
-
-    div
-        span.icon
-            evo-icon-franc-16
-        span.text
-            -- evo-icon-franc-16
-
-    div
-        span.icon
-            evo-icon-franc-24
-        span.text
-            -- evo-icon-franc-24
-
-    div
-        span.icon
-            evo-icon-free-warranty-16
-        span.text
-            -- evo-icon-free-warranty-16
-
-    div
-        span.icon
-            evo-icon-free-warranty-24
-        span.text
-            -- evo-icon-free-warranty-24
-
-    div
-        span.icon
-            evo-icon-full-view-16
-        span.text
-            -- evo-icon-full-view-16
-
-    div
-        span.icon
-            evo-icon-full-view-24
-        span.text
-            -- evo-icon-full-view-24
-
-    div
-        span.icon
-            evo-icon-full-view-filled-16
-        span.text
-            -- evo-icon-full-view-filled-16
-
-    div
-        span.icon
-            evo-icon-full-view-filled-24
-        span.text
-            -- evo-icon-full-view-filled-24
-
-    div
-        span.icon
-            evo-icon-gallery-16
-        span.text
-            -- evo-icon-gallery-16
-
-    div
-        span.icon
-            evo-icon-gallery-24
-        span.text
-            -- evo-icon-gallery-24
-
-    div
-        span.icon
-            evo-icon-general-card-12-colored
-        span.text
-            -- evo-icon-general-card-12-colored
-
-    div
-        span.icon
-            evo-icon-general-card-18-colored
-        span.text
-            -- evo-icon-general-card-18-colored
-
-    div
-        span.icon
-            evo-icon-general-card-24-colored
-        span.text
-            -- evo-icon-general-card-24-colored
-
-    div
-        span.icon
-            evo-icon-general-card-32-colored
-        span.text
-            -- evo-icon-general-card-32-colored
-
-    div
-        span.icon
-            evo-icon-generic-card-12-colored
-        span.text
-            -- evo-icon-generic-card-12-colored
-
-    div
-        span.icon
-            evo-icon-generic-card-18-colored
-        span.text
-            -- evo-icon-generic-card-18-colored
-
-    div
-        span.icon
-            evo-icon-generic-card-24-colored
-        span.text
-            -- evo-icon-generic-card-24-colored
-
-    div
-        span.icon
-            evo-icon-generic-card-32-colored
-        span.text
-            -- evo-icon-generic-card-32-colored
-
-    div
-        span.icon
-            evo-icon-gift-16
-        span.text
-            -- evo-icon-gift-16
-
-    div
-        span.icon
-            evo-icon-gift-20
-        span.text
-            -- evo-icon-gift-20
-
-    div
-        span.icon
-            evo-icon-gift-24
-        span.text
-            -- evo-icon-gift-24
-
-    div
-        span.icon
-            evo-icon-gift-64
-        span.text
-            -- evo-icon-gift-64
-
-    div
-        span.icon
-            evo-icon-gift-card-12-colored
-        span.text
-            -- evo-icon-gift-card-12-colored
-
-    div
-        span.icon
-            evo-icon-gift-card-18-colored
-        span.text
-            -- evo-icon-gift-card-18-colored
-
-    div
-        span.icon
-            evo-icon-gift-card-24-colored
-        span.text
-            -- evo-icon-gift-card-24-colored
-
-    div
-        span.icon
-            evo-icon-gift-card-32-colored
-        span.text
-            -- evo-icon-gift-card-32-colored
-
-    div
-        span.icon
-            evo-icon-girocard-12-colored
-        span.text
-            -- evo-icon-girocard-12-colored
-
-    div
-        span.icon
-            evo-icon-girocard-18-colored
-        span.text
-            -- evo-icon-girocard-18-colored
-
-    div
-        span.icon
-            evo-icon-girocard-24-colored
-        span.text
-            -- evo-icon-girocard-24-colored
-
-    div
-        span.icon
-            evo-icon-girocard-32-colored
-        span.text
-            -- evo-icon-girocard-32-colored
-
-    div
-        span.icon
-            evo-icon-github-24
-        span.text
-            -- evo-icon-github-24
-
-    div
-        span.icon
-            evo-icon-glasses-24
-        span.text
-            -- evo-icon-glasses-24
-
-    div
-        span.icon
-            evo-icon-glasses-64
-        span.text
-            -- evo-icon-glasses-64
-
-    div
-        span.icon
-            evo-icon-google-24
-        span.text
-            -- evo-icon-google-24
-
-    div
-        span.icon
-            evo-icon-google-pay-12-colored
-        span.text
-            -- evo-icon-google-pay-12-colored
-
-    div
-        span.icon
-            evo-icon-google-pay-18-colored
-        span.text
-            -- evo-icon-google-pay-18-colored
-
-    div
-        span.icon
-            evo-icon-google-pay-24-colored
-        span.text
-            -- evo-icon-google-pay-24-colored
-
-    div
-        span.icon
-            evo-icon-google-pay-32-colored
-        span.text
-            -- evo-icon-google-pay-32-colored
-
-    div
-        span.icon
-            evo-icon-graph-16
-        span.text
-            -- evo-icon-graph-16
-
-    div
-        span.icon
-            evo-icon-graph-24
-        span.text
-            -- evo-icon-graph-24
-
-    div
-        span.icon
-            evo-icon-graph-64
-        span.text
-            -- evo-icon-graph-64
-
-    div
-        span.icon
-            evo-icon-graph-dynamic-16
-        span.text
-            -- evo-icon-graph-dynamic-16
-
-    div
-        span.icon
-            evo-icon-graph-dynamic-24
-        span.text
-            -- evo-icon-graph-dynamic-24
-
-    div
-        span.icon
-            evo-icon-grid-view-16
-        span.text
-            -- evo-icon-grid-view-16
-
-    div
-        span.icon
-            evo-icon-grid-view-24
-        span.text
-            -- evo-icon-grid-view-24
-
-    div
-        span.icon
-            evo-icon-grid-view-filled-16
-        span.text
-            -- evo-icon-grid-view-filled-16
-
-    div
-        span.icon
-            evo-icon-grid-view-filled-24
-        span.text
-            -- evo-icon-grid-view-filled-24
-
-    div
-        span.icon
-            evo-icon-guaranteed-fit-filled-16
-        span.text
-            -- evo-icon-guaranteed-fit-filled-16
-
-    div
-        span.icon
-            evo-icon-guaranteed-fit-filled-24
-        span.text
-            -- evo-icon-guaranteed-fit-filled-24
-
-    div
-        span.icon
-            evo-icon-hand-swipe-40
-        span.text
-            -- evo-icon-hand-swipe-40
-
-    div
-        span.icon
-            evo-icon-handbag-16
-        span.text
-            -- evo-icon-handbag-16
-
-    div
-        span.icon
-            evo-icon-handbag-24
-        span.text
-            -- evo-icon-handbag-24
-
-    div
-        span.icon
-            evo-icon-hanger-16
-        span.text
-            -- evo-icon-hanger-16
-
-    div
-        span.icon
-            evo-icon-hanger-24
-        span.text
-            -- evo-icon-hanger-24
-
-    div
-        span.icon
-            evo-icon-headlight-16
-        span.text
-            -- evo-icon-headlight-16
-
-    div
-        span.icon
-            evo-icon-headlight-24
-        span.text
-            -- evo-icon-headlight-24
-
-    div
-        span.icon
-            evo-icon-headphone-16
-        span.text
-            -- evo-icon-headphone-16
-
-    div
-        span.icon
-            evo-icon-headphone-24
-        span.text
-            -- evo-icon-headphone-24
-
-    div
-        span.icon
-            evo-icon-heart-16
-        span.text
-            -- evo-icon-heart-16
-
-    div
-        span.icon
-            evo-icon-heart-20
-        span.text
-            -- evo-icon-heart-20
-
-    div
-        span.icon
-            evo-icon-heart-24
-        span.text
-            -- evo-icon-heart-24
-
-    div
-        span.icon
-            evo-icon-heart-filled-16
-        span.text
-            -- evo-icon-heart-filled-16
-
-    div
-        span.icon
-            evo-icon-heart-filled-20
-        span.text
-            -- evo-icon-heart-filled-20
-
-    div
-        span.icon
-            evo-icon-heart-filled-24
-        span.text
-            -- evo-icon-heart-filled-24
-
-    div
-        span.icon
-            evo-icon-help-16
-        span.text
-            -- evo-icon-help-16
-
-    div
-        span.icon
-            evo-icon-help-20
-        span.text
-            -- evo-icon-help-20
-
-    div
-        span.icon
-            evo-icon-help-24
-        span.text
-            -- evo-icon-help-24
-
-    div
-        span.icon
-            evo-icon-help-outline-16
-        span.text
-            -- evo-icon-help-outline-16
-
-    div
-        span.icon
-            evo-icon-help-outline-20
-        span.text
-            -- evo-icon-help-outline-20
-
-    div
-        span.icon
-            evo-icon-help-outline-24
-        span.text
-            -- evo-icon-help-outline-24
-
-    div
-        span.icon
-            evo-icon-hide-16
-        span.text
-            -- evo-icon-hide-16
-
-    div
-        span.icon
-            evo-icon-hide-24
-        span.text
-            -- evo-icon-hide-24
-
-    div
-        span.icon
-            evo-icon-history-16
-        span.text
-            -- evo-icon-history-16
-
-    div
-        span.icon
-            evo-icon-history-24
-        span.text
-            -- evo-icon-history-24
-
-    div
-        span.icon
-            evo-icon-history-64
-        span.text
-            -- evo-icon-history-64
-
-    div
-        span.icon
-            evo-icon-home-16
-        span.text
-            -- evo-icon-home-16
-
-    div
-        span.icon
-            evo-icon-home-20
-        span.text
-            -- evo-icon-home-20
-
-    div
-        span.icon
-            evo-icon-home-24
-        span.text
-            -- evo-icon-home-24
-
-    div
-        span.icon
-            evo-icon-home-filled-24
-        span.text
-            -- evo-icon-home-filled-24
-
-    div
-        span.icon
-            evo-icon-image-16
-        span.text
-            -- evo-icon-image-16
-
-    div
-        span.icon
-            evo-icon-image-24
-        span.text
-            -- evo-icon-image-24
-
-    div
-        span.icon
-            evo-icon-image-64
-        span.text
-            -- evo-icon-image-64
-
-    div
-        span.icon
-            evo-icon-inbox-16
-        span.text
-            -- evo-icon-inbox-16
-
-    div
-        span.icon
-            evo-icon-inbox-24
-        span.text
-            -- evo-icon-inbox-24
-
-    div
-        span.icon
-            evo-icon-information-12
-        span.text
-            -- evo-icon-information-12
-
-    div
-        span.icon
-            evo-icon-information-16
-        span.text
-            -- evo-icon-information-16
-
-    div
-        span.icon
-            evo-icon-information-20
-        span.text
-            -- evo-icon-information-20
-
-    div
-        span.icon
-            evo-icon-information-24
-        span.text
-            -- evo-icon-information-24
-
-    div
-        span.icon
-            evo-icon-information-filled-16
-        span.text
-            -- evo-icon-information-filled-16
-
-    div
-        span.icon
-            evo-icon-information-filled-20
-        span.text
-            -- evo-icon-information-filled-20
-
-    div
-        span.icon
-            evo-icon-information-filled-24
-        span.text
-            -- evo-icon-information-filled-24
-
-    div
-        span.icon
-            evo-icon-inspect-16
-        span.text
-            -- evo-icon-inspect-16
-
-    div
-        span.icon
-            evo-icon-inspect-24
-        span.text
-            -- evo-icon-inspect-24
-
-    div
-        span.icon
-            evo-icon-inspect-64
-        span.text
-            -- evo-icon-inspect-64
-
-    div
-        span.icon
-            evo-icon-instagram-24
-        span.text
-            -- evo-icon-instagram-24
-
-    div
-        span.icon
-            evo-icon-interac-12-colored
-        span.text
-            -- evo-icon-interac-12-colored
-
-    div
-        span.icon
-            evo-icon-interac-18-colored
-        span.text
-            -- evo-icon-interac-18-colored
-
-    div
-        span.icon
-            evo-icon-interac-24-colored
-        span.text
-            -- evo-icon-interac-24-colored
-
-    div
-        span.icon
-            evo-icon-interac-32-colored
-        span.text
-            -- evo-icon-interac-32-colored
-
-    div
-        span.icon
-            evo-icon-item-list-16
-        span.text
-            -- evo-icon-item-list-16
-
-    div
-        span.icon
-            evo-icon-item-list-20
-        span.text
-            -- evo-icon-item-list-20
-
-    div
-        span.icon
-            evo-icon-item-list-24
-        span.text
-            -- evo-icon-item-list-24
-
-    div
-        span.icon
-            evo-icon-jcb-12-colored
-        span.text
-            -- evo-icon-jcb-12-colored
-
-    div
-        span.icon
-            evo-icon-jcb-18-colored
-        span.text
-            -- evo-icon-jcb-18-colored
-
-    div
-        span.icon
-            evo-icon-jcb-24-colored
-        span.text
-            -- evo-icon-jcb-24-colored
-
-    div
-        span.icon
-            evo-icon-jcb-32-colored
-        span.text
-            -- evo-icon-jcb-32-colored
-
-    div
-        span.icon
-            evo-icon-jet-ski-16
-        span.text
-            -- evo-icon-jet-ski-16
-
-    div
-        span.icon
-            evo-icon-jet-ski-24
-        span.text
-            -- evo-icon-jet-ski-24
-
-    div
-        span.icon
-            evo-icon-kakao-pay-12-colored
-        span.text
-            -- evo-icon-kakao-pay-12-colored
-
-    div
-        span.icon
-            evo-icon-kakao-pay-18-colored
-        span.text
-            -- evo-icon-kakao-pay-18-colored
-
-    div
-        span.icon
-            evo-icon-kakao-pay-24-colored
-        span.text
-            -- evo-icon-kakao-pay-24-colored
-
-    div
-        span.icon
-            evo-icon-kakao-pay-32-colored
-        span.text
-            -- evo-icon-kakao-pay-32-colored
-
-    div
-        span.icon
-            evo-icon-key-16
-        span.text
-            -- evo-icon-key-16
-
-    div
-        span.icon
-            evo-icon-key-24
-        span.text
-            -- evo-icon-key-24
-
-    div
-        span.icon
-            evo-icon-keyboard-16
-        span.text
-            -- evo-icon-keyboard-16
-
-    div
-        span.icon
-            evo-icon-keyboard-24
-        span.text
-            -- evo-icon-keyboard-24
-
-    div
-        span.icon
-            evo-icon-klarna-black-12-colored
-        span.text
-            -- evo-icon-klarna-black-12-colored
-
-    div
-        span.icon
-            evo-icon-klarna-black-18-colored
-        span.text
-            -- evo-icon-klarna-black-18-colored
-
-    div
-        span.icon
-            evo-icon-klarna-black-24-colored
-        span.text
-            -- evo-icon-klarna-black-24-colored
-
-    div
-        span.icon
-            evo-icon-klarna-black-32-colored
-        span.text
-            -- evo-icon-klarna-black-32-colored
-
-    div
-        span.icon
-            evo-icon-klarna-pink-12-colored
-        span.text
-            -- evo-icon-klarna-pink-12-colored
-
-    div
-        span.icon
-            evo-icon-klarna-pink-18-colored
-        span.text
-            -- evo-icon-klarna-pink-18-colored
-
-    div
-        span.icon
-            evo-icon-klarna-pink-24-colored
-        span.text
-            -- evo-icon-klarna-pink-24-colored
-
-    div
-        span.icon
-            evo-icon-klarna-pink-32-colored
-        span.text
-            -- evo-icon-klarna-pink-32-colored
-
-    div
-        span.icon
-            evo-icon-klarna-white-12-colored
-        span.text
-            -- evo-icon-klarna-white-12-colored
-
-    div
-        span.icon
-            evo-icon-klarna-white-18-colored
-        span.text
-            -- evo-icon-klarna-white-18-colored
-
-    div
-        span.icon
-            evo-icon-klarna-white-24-colored
-        span.text
-            -- evo-icon-klarna-white-24-colored
-
-    div
-        span.icon
-            evo-icon-klarna-white-32-colored
-        span.text
-            -- evo-icon-klarna-white-32-colored
-
-    div
-        span.icon
-            evo-icon-krona-16
-        span.text
-            -- evo-icon-krona-16
-
-    div
-        span.icon
-            evo-icon-krona-24
-        span.text
-            -- evo-icon-krona-24
-
-    div
-        span.icon
-            evo-icon-lamp-16
-        span.text
-            -- evo-icon-lamp-16
-
-    div
-        span.icon
-            evo-icon-lamp-24
-        span.text
-            -- evo-icon-lamp-24
-
-    div
-        span.icon
-            evo-icon-large-box-16
-        span.text
-            -- evo-icon-large-box-16
-
-    div
-        span.icon
-            evo-icon-large-box-24
-        span.text
-            -- evo-icon-large-box-24
-
-    div
-        span.icon
-            evo-icon-legacy-authenticity-guarantee-48-colored
-        span.text
-            -- evo-icon-legacy-authenticity-guarantee-48-colored
-
-    div
-        span.icon
-            evo-icon-legacy-click-to-call-48-colored
-        span.text
-            -- evo-icon-legacy-click-to-call-48-colored
-
-    div
-        span.icon
-            evo-icon-legacy-escrow-48-colored
-        span.text
-            -- evo-icon-legacy-escrow-48-colored
-
-    div
-        span.icon
-            evo-icon-legacy-free-warranty-48-colored
-        span.text
-            -- evo-icon-legacy-free-warranty-48-colored
-
-    div
-        span.icon
-            evo-icon-legacy-money-back-guarantee-chf-48-colored
-        span.text
-            -- evo-icon-legacy-money-back-guarantee-chf-48-colored
-
-    div
-        span.icon
-            evo-icon-legacy-money-back-guarantee-eu-48-colored
-        span.text
-            -- evo-icon-legacy-money-back-guarantee-eu-48-colored
-
-    div
-        span.icon
-            evo-icon-legacy-money-back-guarantee-uk-48-colored
-        span.text
-            -- evo-icon-legacy-money-back-guarantee-uk-48-colored
-
-    div
-        span.icon
-            evo-icon-legacy-money-back-guarantee-us-48-colored
-        span.text
-            -- evo-icon-legacy-money-back-guarantee-us-48-colored
-
-    div
-        span.icon
-            evo-icon-legacy-money-back-guarantee-zl-48-colored
-        span.text
-            -- evo-icon-legacy-money-back-guarantee-zl-48-colored
-
-    div
-        span.icon
-            evo-icon-legacy-top-rated-seller-48-colored
-        span.text
-            -- evo-icon-legacy-top-rated-seller-48-colored
-
-    div
-        span.icon
-            evo-icon-lightbulb-16
-        span.text
-            -- evo-icon-lightbulb-16
-
-    div
-        span.icon
-            evo-icon-lightbulb-24
-        span.text
-            -- evo-icon-lightbulb-24
-
-    div
-        span.icon
-            evo-icon-lightning-bolt-16
-        span.text
-            -- evo-icon-lightning-bolt-16
-
-    div
-        span.icon
-            evo-icon-lightning-bolt-24
-        span.text
-            -- evo-icon-lightning-bolt-24
-
-    div
-        span.icon
-            evo-icon-lightning-bolt-filled-12
-        span.text
-            -- evo-icon-lightning-bolt-filled-12
-
-    div
-        span.icon
-            evo-icon-lightning-bolt-filled-16
-        span.text
-            -- evo-icon-lightning-bolt-filled-16
-
-    div
-        span.icon
-            evo-icon-lightning-bolt-filled-24
-        span.text
-            -- evo-icon-lightning-bolt-filled-24
-
-    div
-        span.icon
-            evo-icon-link-16
-        span.text
-            -- evo-icon-link-16
-
-    div
-        span.icon
-            evo-icon-link-20
-        span.text
-            -- evo-icon-link-20
-
-    div
-        span.icon
-            evo-icon-link-24
-        span.text
-            -- evo-icon-link-24
-
-    div
-        span.icon
-            evo-icon-linkedin-24
-        span.text
-            -- evo-icon-linkedin-24
-
-    div
-        span.icon
-            evo-icon-list-view-16
-        span.text
-            -- evo-icon-list-view-16
-
-    div
-        span.icon
-            evo-icon-list-view-24
-        span.text
-            -- evo-icon-list-view-24
-
-    div
-        span.icon
-            evo-icon-list-view-filled-16
-        span.text
-            -- evo-icon-list-view-filled-16
-
-    div
-        span.icon
-            evo-icon-list-view-filled-24
-        span.text
-            -- evo-icon-list-view-filled-24
-
-    div
-        span.icon
-            evo-icon-live-bag-16
-        span.text
-            -- evo-icon-live-bag-16
-
-    div
-        span.icon
-            evo-icon-live-bag-20
-        span.text
-            -- evo-icon-live-bag-20
-
-    div
-        span.icon
-            evo-icon-live-bag-24
-        span.text
-            -- evo-icon-live-bag-24
-
-    div
-        span.icon
-            evo-icon-live-bag-filled-24
-        span.text
-            -- evo-icon-live-bag-filled-24
-
-    div
-        span.icon
-            evo-icon-live-bag-play-filled-16-colored
-        span.text
-            -- evo-icon-live-bag-play-filled-16-colored
-
-    div
-        span.icon
-            evo-icon-live-bag-play-filled-24-colored
-        span.text
-            -- evo-icon-live-bag-play-filled-24-colored
-
-    div
-        span.icon
-            evo-icon-live-bag-play-filled-64-colored
-        span.text
-            -- evo-icon-live-bag-play-filled-64-colored
-
-    div
-        span.icon
-            evo-icon-live-bag-thin-16
-        span.text
-            -- evo-icon-live-bag-thin-16
-
-    div
-        span.icon
-            evo-icon-live-broadcast-16
-        span.text
-            -- evo-icon-live-broadcast-16
-
-    div
-        span.icon
-            evo-icon-live-broadcast-20
-        span.text
-            -- evo-icon-live-broadcast-20
-
-    div
-        span.icon
-            evo-icon-live-broadcast-24
-        span.text
-            -- evo-icon-live-broadcast-24
-
-    div
-        span.icon
-            evo-icon-live-broadcast-filled-24
-        span.text
-            -- evo-icon-live-broadcast-filled-24
-
-    div
-        span.icon
-            evo-icon-live-broadcast-thin-16
-        span.text
-            -- evo-icon-live-broadcast-thin-16
-
-    div
-        span.icon
-            evo-icon-live-eye-16
-        span.text
-            -- evo-icon-live-eye-16
-
-    div
-        span.icon
-            evo-icon-live-eye-24
-        span.text
-            -- evo-icon-live-eye-24
-
-    div
-        span.icon
-            evo-icon-location-16
-        span.text
-            -- evo-icon-location-16
-
-    div
-        span.icon
-            evo-icon-location-24
-        span.text
-            -- evo-icon-location-24
-
-    div
-        span.icon
-            evo-icon-location-64
-        span.text
-            -- evo-icon-location-64
-
-    div
-        span.icon
-            evo-icon-location-arrow-16
-        span.text
-            -- evo-icon-location-arrow-16
-
-    div
-        span.icon
-            evo-icon-location-arrow-24
-        span.text
-            -- evo-icon-location-arrow-24
-
-    div
-        span.icon
-            evo-icon-lock-16
-        span.text
-            -- evo-icon-lock-16
-
-    div
-        span.icon
-            evo-icon-lock-24
-        span.text
-            -- evo-icon-lock-24
-
-    div
-        span.icon
-            evo-icon-lock-filled-16
-        span.text
-            -- evo-icon-lock-filled-16
-
-    div
-        span.icon
-            evo-icon-lock-filled-20
-        span.text
-            -- evo-icon-lock-filled-20
-
-    div
-        span.icon
-            evo-icon-lock-filled-24
-        span.text
-            -- evo-icon-lock-filled-24
-
-    div
-        span.icon
-            evo-icon-locker-16
-        span.text
-            -- evo-icon-locker-16
-
-    div
-        span.icon
-            evo-icon-locker-24
-        span.text
-            -- evo-icon-locker-24
-
-    div
-        span.icon
-            evo-icon-locker-64
-        span.text
-            -- evo-icon-locker-64
-
-    div
-        span.icon
-            evo-icon-maestro-12-colored
-        span.text
-            -- evo-icon-maestro-12-colored
-
-    div
-        span.icon
-            evo-icon-maestro-18-colored
-        span.text
-            -- evo-icon-maestro-18-colored
-
-    div
-        span.icon
-            evo-icon-maestro-24-colored
-        span.text
-            -- evo-icon-maestro-24-colored
-
-    div
-        span.icon
-            evo-icon-maestro-32-colored
-        span.text
-            -- evo-icon-maestro-32-colored
-
-    div
-        span.icon
-            evo-icon-mail-16
-        span.text
-            -- evo-icon-mail-16
-
-    div
-        span.icon
-            evo-icon-mail-20
-        span.text
-            -- evo-icon-mail-20
-
-    div
-        span.icon
-            evo-icon-mail-24
-        span.text
-            -- evo-icon-mail-24
-
-    div
-        span.icon
-            evo-icon-mail-64
-        span.text
-            -- evo-icon-mail-64
-
-    div
-        span.icon
-            evo-icon-mail-move-16
-        span.text
-            -- evo-icon-mail-move-16
-
-    div
-        span.icon
-            evo-icon-mail-move-24
-        span.text
-            -- evo-icon-mail-move-24
-
-    div
-        span.icon
-            evo-icon-mail-open-16
-        span.text
-            -- evo-icon-mail-open-16
-
-    div
-        span.icon
-            evo-icon-mail-open-24
-        span.text
-            -- evo-icon-mail-open-24
-
-    div
-        span.icon
-            evo-icon-mail-unread-16
-        span.text
-            -- evo-icon-mail-unread-16
-
-    div
-        span.icon
-            evo-icon-mail-unread-24
-        span.text
-            -- evo-icon-mail-unread-24
-
-    div
-        span.icon
-            evo-icon-map-16
-        span.text
-            -- evo-icon-map-16
-
-    div
-        span.icon
-            evo-icon-map-20
-        span.text
-            -- evo-icon-map-20
-
-    div
-        span.icon
-            evo-icon-map-24
-        span.text
-            -- evo-icon-map-24
-
-    div
-        span.icon
-            evo-icon-markdown-16
-        span.text
-            -- evo-icon-markdown-16
-
-    div
-        span.icon
-            evo-icon-markdown-20
-        span.text
-            -- evo-icon-markdown-20
-
-    div
-        span.icon
-            evo-icon-markdown-24
-        span.text
-            -- evo-icon-markdown-24
-
-    div
-        span.icon
-            evo-icon-masonry-view-16
-        span.text
-            -- evo-icon-masonry-view-16
-
-    div
-        span.icon
-            evo-icon-masonry-view-24
-        span.text
-            -- evo-icon-masonry-view-24
-
-    div
-        span.icon
-            evo-icon-masonry-view-filled-16
-        span.text
-            -- evo-icon-masonry-view-filled-16
-
-    div
-        span.icon
-            evo-icon-masonry-view-filled-24
-        span.text
-            -- evo-icon-masonry-view-filled-24
-
-    div
-        span.icon
-            evo-icon-mastercard-12-colored
-        span.text
-            -- evo-icon-mastercard-12-colored
-
-    div
-        span.icon
-            evo-icon-mastercard-18-colored
-        span.text
-            -- evo-icon-mastercard-18-colored
-
-    div
-        span.icon
-            evo-icon-mastercard-24-colored
-        span.text
-            -- evo-icon-mastercard-24-colored
-
-    div
-        span.icon
-            evo-icon-mastercard-32-colored
-        span.text
-            -- evo-icon-mastercard-32-colored
-
-    div
-        span.icon
-            evo-icon-medium-box-16
-        span.text
-            -- evo-icon-medium-box-16
-
-    div
-        span.icon
-            evo-icon-medium-box-24
-        span.text
-            -- evo-icon-medium-box-24
-
-    div
-        span.icon
-            evo-icon-megaphone-16
-        span.text
-            -- evo-icon-megaphone-16
-
-    div
-        span.icon
-            evo-icon-megaphone-24
-        span.text
-            -- evo-icon-megaphone-24
-
-    div
-        span.icon
-            evo-icon-menu-16
-        span.text
-            -- evo-icon-menu-16
-
-    div
-        span.icon
-            evo-icon-menu-20
-        span.text
-            -- evo-icon-menu-20
-
-    div
-        span.icon
-            evo-icon-menu-24
-        span.text
-            -- evo-icon-menu-24
-
-    div
-        span.icon
-            evo-icon-mercado-pago-12-colored
-        span.text
-            -- evo-icon-mercado-pago-12-colored
-
-    div
-        span.icon
-            evo-icon-mercado-pago-18-colored
-        span.text
-            -- evo-icon-mercado-pago-18-colored
-
-    div
-        span.icon
-            evo-icon-mercado-pago-24-colored
-        span.text
-            -- evo-icon-mercado-pago-24-colored
-
-    div
-        span.icon
-            evo-icon-mercado-pago-32-colored
-        span.text
-            -- evo-icon-mercado-pago-32-colored
-
-    div
-        span.icon
-            evo-icon-microphone-16
-        span.text
-            -- evo-icon-microphone-16
-
-    div
-        span.icon
-            evo-icon-microphone-24
-        span.text
-            -- evo-icon-microphone-24
-
-    div
-        span.icon
-            evo-icon-mobile-16
-        span.text
-            -- evo-icon-mobile-16
-
-    div
-        span.icon
-            evo-icon-mobile-20
-        span.text
-            -- evo-icon-mobile-20
-
-    div
-        span.icon
-            evo-icon-mobile-24
-        span.text
-            -- evo-icon-mobile-24
-
-    div
-        span.icon
-            evo-icon-mobile-signal-24
-        span.text
-            -- evo-icon-mobile-signal-24
-
-    div
-        span.icon
-            evo-icon-money-back-guarantee-16
-        span.text
-            -- evo-icon-money-back-guarantee-16
-
-    div
-        span.icon
-            evo-icon-money-back-guarantee-24
-        span.text
-            -- evo-icon-money-back-guarantee-24
-
-    div
-        span.icon
-            evo-icon-money-back-guarantee-filled-16
-        span.text
-            -- evo-icon-money-back-guarantee-filled-16
-
-    div
-        span.icon
-            evo-icon-money-back-guarantee-filled-16-colored
-        span.text
-            -- evo-icon-money-back-guarantee-filled-16-colored
-
-    div
-        span.icon
-            evo-icon-money-back-guarantee-filled-24
-        span.text
-            -- evo-icon-money-back-guarantee-filled-24
-
-    div
-        span.icon
-            evo-icon-money-back-guarantee-filled-24-colored
-        span.text
-            -- evo-icon-money-back-guarantee-filled-24-colored
-
-    div
-        span.icon
-            evo-icon-money-stack-16
-        span.text
-            -- evo-icon-money-stack-16
-
-    div
-        span.icon
-            evo-icon-money-stack-20
-        span.text
-            -- evo-icon-money-stack-20
-
-    div
-        span.icon
-            evo-icon-money-stack-24
-        span.text
-            -- evo-icon-money-stack-24
-
-    div
-        span.icon
-            evo-icon-money-stack-blue-12-colored
-        span.text
-            -- evo-icon-money-stack-blue-12-colored
-
-    div
-        span.icon
-            evo-icon-money-stack-blue-18-colored
-        span.text
-            -- evo-icon-money-stack-blue-18-colored
-
-    div
-        span.icon
-            evo-icon-money-stack-blue-24-colored
-        span.text
-            -- evo-icon-money-stack-blue-24-colored
-
-    div
-        span.icon
-            evo-icon-money-stack-blue-32-colored
-        span.text
-            -- evo-icon-money-stack-blue-32-colored
-
-    div
-        span.icon
-            evo-icon-monthly-invoice-12-colored
-        span.text
-            -- evo-icon-monthly-invoice-12-colored
-
-    div
-        span.icon
-            evo-icon-monthly-invoice-18-colored
-        span.text
-            -- evo-icon-monthly-invoice-18-colored
-
-    div
-        span.icon
-            evo-icon-monthly-invoice-24-colored
-        span.text
-            -- evo-icon-monthly-invoice-24-colored
-
-    div
-        span.icon
-            evo-icon-monthly-invoice-32-colored
-        span.text
-            -- evo-icon-monthly-invoice-32-colored
-
-    div
-        span.icon
-            evo-icon-moon-16
-        span.text
-            -- evo-icon-moon-16
-
-    div
-        span.icon
-            evo-icon-moon-20
-        span.text
-            -- evo-icon-moon-20
-
-    div
-        span.icon
-            evo-icon-moon-24
-        span.text
-            -- evo-icon-moon-24
-
-    div
-        span.icon
-            evo-icon-motorcycle-16
-        span.text
-            -- evo-icon-motorcycle-16
-
-    div
-        span.icon
-            evo-icon-motorcycle-24
-        span.text
-            -- evo-icon-motorcycle-24
-
-    div
-        span.icon
-            evo-icon-mountain-16
-        span.text
-            -- evo-icon-mountain-16
-
-    div
-        span.icon
-            evo-icon-mountain-24
-        span.text
-            -- evo-icon-mountain-24
-
-    div
-        span.icon
-            evo-icon-move-16
-        span.text
-            -- evo-icon-move-16
-
-    div
-        span.icon
-            evo-icon-move-24
-        span.text
-            -- evo-icon-move-24
-
-    div
-        span.icon
-            evo-icon-nectar-logo-24-colored
-        span.text
-            -- evo-icon-nectar-logo-24-colored
-
-    div
-        span.icon
-            evo-icon-negative-filled-16
-        span.text
-            -- evo-icon-negative-filled-16
-
-    div
-        span.icon
-            evo-icon-negative-filled-24
-        span.text
-            -- evo-icon-negative-filled-24
-
-    div
-        span.icon
-            evo-icon-neutral-16
-        span.text
-            -- evo-icon-neutral-16
-
-    div
-        span.icon
-            evo-icon-neutral-24
-        span.text
-            -- evo-icon-neutral-24
-
-    div
-        span.icon
-            evo-icon-nfc-16
-        span.text
-            -- evo-icon-nfc-16
-
-    div
-        span.icon
-            evo-icon-nfc-24
-        span.text
-            -- evo-icon-nfc-24
-
-    div
-        span.icon
-            evo-icon-nfc-card-12-colored
-        span.text
-            -- evo-icon-nfc-card-12-colored
-
-    div
-        span.icon
-            evo-icon-nfc-card-18-colored
-        span.text
-            -- evo-icon-nfc-card-18-colored
-
-    div
-        span.icon
-            evo-icon-nfc-card-24-colored
-        span.text
-            -- evo-icon-nfc-card-24-colored
-
-    div
-        span.icon
-            evo-icon-nfc-card-32-colored
-        span.text
-            -- evo-icon-nfc-card-32-colored
-
-    div
-        span.icon
-            evo-icon-no-children-zero-three-48
-        span.text
-            -- evo-icon-no-children-zero-three-48
-
-    div
-        span.icon
-            evo-icon-note-12
-        span.text
-            -- evo-icon-note-12
-
-    div
-        span.icon
-            evo-icon-note-16
-        span.text
-            -- evo-icon-note-16
-
-    div
-        span.icon
-            evo-icon-note-24
-        span.text
-            -- evo-icon-note-24
-
-    div
-        span.icon
-            evo-icon-notification-16
-        span.text
-            -- evo-icon-notification-16
-
-    div
-        span.icon
-            evo-icon-notification-20
-        span.text
-            -- evo-icon-notification-20
-
-    div
-        span.icon
-            evo-icon-notification-24
-        span.text
-            -- evo-icon-notification-24
-
-    div
-        span.icon
-            evo-icon-notification-64
-        span.text
-            -- evo-icon-notification-64
-
-    div
-        span.icon
-            evo-icon-notification-filled-16
-        span.text
-            -- evo-icon-notification-filled-16
-
-    div
-        span.icon
-            evo-icon-notification-filled-20
-        span.text
-            -- evo-icon-notification-filled-20
-
-    div
-        span.icon
-            evo-icon-notification-filled-24
-        span.text
-            -- evo-icon-notification-filled-24
-
-    div
-        span.icon
-            evo-icon-out-of-reach-48
-        span.text
-            -- evo-icon-out-of-reach-48
-
-    div
-        span.icon
-            evo-icon-overflow-horizontal-16
-        span.text
-            -- evo-icon-overflow-horizontal-16
-
-    div
-        span.icon
-            evo-icon-overflow-horizontal-20
-        span.text
-            -- evo-icon-overflow-horizontal-20
-
-    div
-        span.icon
-            evo-icon-overflow-horizontal-24
-        span.text
-            -- evo-icon-overflow-horizontal-24
-
-    div
-        span.icon
-            evo-icon-overflow-vertical-16
-        span.text
-            -- evo-icon-overflow-vertical-16
-
-    div
-        span.icon
-            evo-icon-overflow-vertical-20
-        span.text
-            -- evo-icon-overflow-vertical-20
-
-    div
-        span.icon
-            evo-icon-overflow-vertical-24
-        span.text
-            -- evo-icon-overflow-vertical-24
-
-    div
-        span.icon
-            evo-icon-package-16
-        span.text
-            -- evo-icon-package-16
-
-    div
-        span.icon
-            evo-icon-package-24
-        span.text
-            -- evo-icon-package-24
-
-    div
-        span.icon
-            evo-icon-package-64
-        span.text
-            -- evo-icon-package-64
-
-    div
-        span.icon
-            evo-icon-package-error-24
-        span.text
-            -- evo-icon-package-error-24
-
-    div
-        span.icon
-            evo-icon-panel-16
-        span.text
-            -- evo-icon-panel-16
-
-    div
-        span.icon
-            evo-icon-panel-20
-        span.text
-            -- evo-icon-panel-20
-
-    div
-        span.icon
-            evo-icon-panel-24
-        span.text
-            -- evo-icon-panel-24
-
-    div
-        span.icon
-            evo-icon-panel-close-16
-        span.text
-            -- evo-icon-panel-close-16
-
-    div
-        span.icon
-            evo-icon-panel-close-20
-        span.text
-            -- evo-icon-panel-close-20
-
-    div
-        span.icon
-            evo-icon-panel-close-24
-        span.text
-            -- evo-icon-panel-close-24
-
-    div
-        span.icon
-            evo-icon-panel-close-vertical-16
-        span.text
-            -- evo-icon-panel-close-vertical-16
-
-    div
-        span.icon
-            evo-icon-panel-close-vertical-20
-        span.text
-            -- evo-icon-panel-close-vertical-20
-
-    div
-        span.icon
-            evo-icon-panel-close-vertical-24
-        span.text
-            -- evo-icon-panel-close-vertical-24
-
-    div
-        span.icon
-            evo-icon-panel-open-16
-        span.text
-            -- evo-icon-panel-open-16
-
-    div
-        span.icon
-            evo-icon-panel-open-20
-        span.text
-            -- evo-icon-panel-open-20
-
-    div
-        span.icon
-            evo-icon-panel-open-24
-        span.text
-            -- evo-icon-panel-open-24
-
-    div
-        span.icon
-            evo-icon-panel-open-vertical-16
-        span.text
-            -- evo-icon-panel-open-vertical-16
-
-    div
-        span.icon
-            evo-icon-panel-open-vertical-20
-        span.text
-            -- evo-icon-panel-open-vertical-20
-
-    div
-        span.icon
-            evo-icon-panel-open-vertical-24
-        span.text
-            -- evo-icon-panel-open-vertical-24
-
-    div
-        span.icon
-            evo-icon-passkey-16
-        span.text
-            -- evo-icon-passkey-16
-
-    div
-        span.icon
-            evo-icon-passkey-24
-        span.text
-            -- evo-icon-passkey-24
-
-    div
-        span.icon
-            evo-icon-passkey-64
-        span.text
-            -- evo-icon-passkey-64
-
-    div
-        span.icon
-            evo-icon-pause-16
-        span.text
-            -- evo-icon-pause-16
-
-    div
-        span.icon
-            evo-icon-pause-20
-        span.text
-            -- evo-icon-pause-20
-
-    div
-        span.icon
-            evo-icon-pause-24
-        span.text
-            -- evo-icon-pause-24
-
-    div
-        span.icon
-            evo-icon-pause-filled-64-colored
-        span.text
-            -- evo-icon-pause-filled-64-colored
-
-    div
-        span.icon
-            evo-icon-pay-by-bank-12-colored
-        span.text
-            -- evo-icon-pay-by-bank-12-colored
-
-    div
-        span.icon
-            evo-icon-pay-by-bank-18-colored
-        span.text
-            -- evo-icon-pay-by-bank-18-colored
-
-    div
-        span.icon
-            evo-icon-pay-by-bank-24-colored
-        span.text
-            -- evo-icon-pay-by-bank-24-colored
-
-    div
-        span.icon
-            evo-icon-pay-by-bank-32-colored
-        span.text
-            -- evo-icon-pay-by-bank-32-colored
-
-    div
-        span.icon
-            evo-icon-pay-by-bank-be-24-colored
-        span.text
-            -- evo-icon-pay-by-bank-be-24-colored
-
-    div
-        span.icon
-            evo-icon-pay-by-bank-de-24-colored
-        span.text
-            -- evo-icon-pay-by-bank-de-24-colored
-
-    div
-        span.icon
-            evo-icon-pay-by-bank-fr-24-colored
-        span.text
-            -- evo-icon-pay-by-bank-fr-24-colored
-
-    div
-        span.icon
-            evo-icon-pay-by-bank-uk-24-colored
-        span.text
-            -- evo-icon-pay-by-bank-uk-24-colored
-
-    div
-        span.icon
-            evo-icon-payoneer-12-colored
-        span.text
-            -- evo-icon-payoneer-12-colored
-
-    div
-        span.icon
-            evo-icon-payoneer-18-colored
-        span.text
-            -- evo-icon-payoneer-18-colored
-
-    div
-        span.icon
-            evo-icon-payoneer-24-colored
-        span.text
-            -- evo-icon-payoneer-24-colored
-
-    div
-        span.icon
-            evo-icon-payoneer-32-colored
-        span.text
-            -- evo-icon-payoneer-32-colored
-
-    div
-        span.icon
-            evo-icon-payout-16
-        span.text
-            -- evo-icon-payout-16
-
-    div
-        span.icon
-            evo-icon-payout-20
-        span.text
-            -- evo-icon-payout-20
-
-    div
-        span.icon
-            evo-icon-payout-24
-        span.text
-            -- evo-icon-payout-24
-
-    div
-        span.icon
-            evo-icon-paypal-12-colored
-        span.text
-            -- evo-icon-paypal-12-colored
-
-    div
-        span.icon
-            evo-icon-paypal-18-colored
-        span.text
-            -- evo-icon-paypal-18-colored
-
-    div
-        span.icon
-            evo-icon-paypal-24-colored
-        span.text
-            -- evo-icon-paypal-24-colored
-
-    div
-        span.icon
-            evo-icon-paypal-32-colored
-        span.text
-            -- evo-icon-paypal-32-colored
-
-    div
-        span.icon
-            evo-icon-paypal-blue-12-colored
-        span.text
-            -- evo-icon-paypal-blue-12-colored
-
-    div
-        span.icon
-            evo-icon-paypal-blue-18-colored
-        span.text
-            -- evo-icon-paypal-blue-18-colored
-
-    div
-        span.icon
-            evo-icon-paypal-blue-24-colored
-        span.text
-            -- evo-icon-paypal-blue-24-colored
-
-    div
-        span.icon
-            evo-icon-paypal-blue-32-colored
-        span.text
-            -- evo-icon-paypal-blue-32-colored
-
-    div
-        span.icon
-            evo-icon-paypal-credit-12-colored
-        span.text
-            -- evo-icon-paypal-credit-12-colored
-
-    div
-        span.icon
-            evo-icon-paypal-credit-18-colored
-        span.text
-            -- evo-icon-paypal-credit-18-colored
-
-    div
-        span.icon
-            evo-icon-paypal-credit-24-colored
-        span.text
-            -- evo-icon-paypal-credit-24-colored
-
-    div
-        span.icon
-            evo-icon-paypal-credit-32-colored
-        span.text
-            -- evo-icon-paypal-credit-32-colored
-
-    div
-        span.icon
-            evo-icon-paypal-disabled-12-colored
-        span.text
-            -- evo-icon-paypal-disabled-12-colored
-
-    div
-        span.icon
-            evo-icon-paypal-disabled-18-colored
-        span.text
-            -- evo-icon-paypal-disabled-18-colored
-
-    div
-        span.icon
-            evo-icon-paypal-disabled-24-colored
-        span.text
-            -- evo-icon-paypal-disabled-24-colored
-
-    div
-        span.icon
-            evo-icon-paypal-disabled-32-colored
-        span.text
-            -- evo-icon-paypal-disabled-32-colored
-
-    div
-        span.icon
-            evo-icon-paypal-logo-16
-        span.text
-            -- evo-icon-paypal-logo-16
-
-    div
-        span.icon
-            evo-icon-paypay-12-colored
-        span.text
-            -- evo-icon-paypay-12-colored
-
-    div
-        span.icon
-            evo-icon-paypay-18-colored
-        span.text
-            -- evo-icon-paypay-18-colored
-
-    div
-        span.icon
-            evo-icon-paypay-24-colored
-        span.text
-            -- evo-icon-paypay-24-colored
-
-    div
-        span.icon
-            evo-icon-paypay-32-colored
-        span.text
-            -- evo-icon-paypay-32-colored
-
-    div
-        span.icon
-            evo-icon-pencil-16
-        span.text
-            -- evo-icon-pencil-16
-
-    div
-        span.icon
-            evo-icon-pencil-20
-        span.text
-            -- evo-icon-pencil-20
-
-    div
-        span.icon
-            evo-icon-pencil-24
-        span.text
-            -- evo-icon-pencil-24
-
-    div
-        span.icon
-            evo-icon-pencil-signed-24
-        span.text
-            -- evo-icon-pencil-signed-24
-
-    div
-        span.icon
-            evo-icon-people-16
-        span.text
-            -- evo-icon-people-16
-
-    div
-        span.icon
-            evo-icon-people-24
-        span.text
-            -- evo-icon-people-24
-
-    div
-        span.icon
-            evo-icon-peso-16
-        span.text
-            -- evo-icon-peso-16
-
-    div
-        span.icon
-            evo-icon-peso-24
-        span.text
-            -- evo-icon-peso-24
-
-    div
-        span.icon
-            evo-icon-phone-16
-        span.text
-            -- evo-icon-phone-16
-
-    div
-        span.icon
-            evo-icon-phone-24
-        span.text
-            -- evo-icon-phone-24
-
-    div
-        span.icon
-            evo-icon-pin-12
-        span.text
-            -- evo-icon-pin-12
-
-    div
-        span.icon
-            evo-icon-pin-16
-        span.text
-            -- evo-icon-pin-16
-
-    div
-        span.icon
-            evo-icon-pin-24
-        span.text
-            -- evo-icon-pin-24
-
-    div
-        span.icon
-            evo-icon-pin-filled-12
-        span.text
-            -- evo-icon-pin-filled-12
-
-    div
-        span.icon
-            evo-icon-pin-filled-16
-        span.text
-            -- evo-icon-pin-filled-16
-
-    div
-        span.icon
-            evo-icon-pin-filled-24
-        span.text
-            -- evo-icon-pin-filled-24
-
-    div
-        span.icon
-            evo-icon-pinterest-24
-        span.text
-            -- evo-icon-pinterest-24
-
-    div
-        span.icon
-            evo-icon-play-16
-        span.text
-            -- evo-icon-play-16
-
-    div
-        span.icon
-            evo-icon-play-20
-        span.text
-            -- evo-icon-play-20
-
-    div
-        span.icon
-            evo-icon-play-24
-        span.text
-            -- evo-icon-play-24
-
-    div
-        span.icon
-            evo-icon-play-disabled-16
-        span.text
-            -- evo-icon-play-disabled-16
-
-    div
-        span.icon
-            evo-icon-play-filled-16-colored
-        span.text
-            -- evo-icon-play-filled-16-colored
-
-    div
-        span.icon
-            evo-icon-play-filled-24-colored
-        span.text
-            -- evo-icon-play-filled-24-colored
-
-    div
-        span.icon
-            evo-icon-play-filled-64-colored
-        span.text
-            -- evo-icon-play-filled-64-colored
-
-    div
-        span.icon
-            evo-icon-postepay-12-colored
-        span.text
-            -- evo-icon-postepay-12-colored
-
-    div
-        span.icon
-            evo-icon-postepay-18-colored
-        span.text
-            -- evo-icon-postepay-18-colored
-
-    div
-        span.icon
-            evo-icon-postepay-24-colored
-        span.text
-            -- evo-icon-postepay-24-colored
-
-    div
-        span.icon
-            evo-icon-postepay-32-colored
-        span.text
-            -- evo-icon-postepay-32-colored
-
-    div
-        span.icon
-            evo-icon-potted-plant-16
-        span.text
-            -- evo-icon-potted-plant-16
-
-    div
-        span.icon
-            evo-icon-potted-plant-24
-        span.text
-            -- evo-icon-potted-plant-24
-
-    div
-        span.icon
-            evo-icon-pound-16
-        span.text
-            -- evo-icon-pound-16
-
-    div
-        span.icon
-            evo-icon-pound-24
-        span.text
-            -- evo-icon-pound-24
-
-    div
-        span.icon
-            evo-icon-print-16
-        span.text
-            -- evo-icon-print-16
-
-    div
-        span.icon
-            evo-icon-print-24
-        span.text
-            -- evo-icon-print-24
-
-    div
-        span.icon
-            evo-icon-profile-16
-        span.text
-            -- evo-icon-profile-16
-
-    div
-        span.icon
-            evo-icon-profile-20
-        span.text
-            -- evo-icon-profile-20
-
-    div
-        span.icon
-            evo-icon-profile-24
-        span.text
-            -- evo-icon-profile-24
-
-    div
-        span.icon
-            evo-icon-profile-filled-24
-        span.text
-            -- evo-icon-profile-filled-24
-
-    div
-        span.icon
-            evo-icon-profile-verification-16
-        span.text
-            -- evo-icon-profile-verification-16
-
-    div
-        span.icon
-            evo-icon-profile-verification-20
-        span.text
-            -- evo-icon-profile-verification-20
-
-    div
-        span.icon
-            evo-icon-profile-verification-24
-        span.text
-            -- evo-icon-profile-verification-24
-
-    div
-        span.icon
-            evo-icon-progress-current-24
-        span.text
-            -- evo-icon-progress-current-24
-
-    div
-        span.icon
-            evo-icon-progress-upcoming-24
-        span.text
-            -- evo-icon-progress-upcoming-24
-
-    div
-        span.icon
-            evo-icon-promotion-12
-        span.text
-            -- evo-icon-promotion-12
-
-    div
-        span.icon
-            evo-icon-promotion-16
-        span.text
-            -- evo-icon-promotion-16
-
-    div
-        span.icon
-            evo-icon-promotion-24
-        span.text
-            -- evo-icon-promotion-24
-
-    div
-        span.icon
-            evo-icon-psa-16
-        span.text
-            -- evo-icon-psa-16
-
-    div
-        span.icon
-            evo-icon-psa-16-colored
-        span.text
-            -- evo-icon-psa-16-colored
-
-    div
-        span.icon
-            evo-icon-psa-logo-16
-        span.text
-            -- evo-icon-psa-logo-16
-
-    div
-        span.icon
-            evo-icon-psa-logo-color-16-colored
-        span.text
-            -- evo-icon-psa-logo-color-16-colored
-
-    div
-        span.icon
-            evo-icon-psa-vault-16
-        span.text
-            -- evo-icon-psa-vault-16
-
-    div
-        span.icon
-            evo-icon-psa-vault-16-colored
-        span.text
-            -- evo-icon-psa-vault-16-colored
-
-    div
-        span.icon
-            evo-icon-psa-vault-24
-        span.text
-            -- evo-icon-psa-vault-24
-
-    div
-        span.icon
-            evo-icon-psa-vault-logo-16
-        span.text
-            -- evo-icon-psa-vault-logo-16
-
-    div
-        span.icon
-            evo-icon-psa-vault-logo-color-16-colored
-        span.text
-            -- evo-icon-psa-vault-logo-color-16-colored
-
-    div
-        span.icon
-            evo-icon-qr-code-16
-        span.text
-            -- evo-icon-qr-code-16
-
-    div
-        span.icon
-            evo-icon-qr-code-24
-        span.text
-            -- evo-icon-qr-code-24
-
-    div
-        span.icon
-            evo-icon-radio-checked-18
-        span.text
-            -- evo-icon-radio-checked-18
-
-    div
-        span.icon
-            evo-icon-radio-checked-24
-        span.text
-            -- evo-icon-radio-checked-24
-
-    div
-        span.icon
-            evo-icon-radio-unchecked-18
-        span.text
-            -- evo-icon-radio-unchecked-18
-
-    div
-        span.icon
-            evo-icon-radio-unchecked-24
-        span.text
-            -- evo-icon-radio-unchecked-24
-
-    div
-        span.icon
-            evo-icon-recovery-code-16
-        span.text
-            -- evo-icon-recovery-code-16
-
-    div
-        span.icon
-            evo-icon-recovery-code-24
-        span.text
-            -- evo-icon-recovery-code-24
-
-    div
-        span.icon
-            evo-icon-reddit-24
-        span.text
-            -- evo-icon-reddit-24
-
-    div
-        span.icon
-            evo-icon-refresh-16
-        span.text
-            -- evo-icon-refresh-16
-
-    div
-        span.icon
-            evo-icon-refresh-20
-        span.text
-            -- evo-icon-refresh-20
-
-    div
-        span.icon
-            evo-icon-refresh-24
-        span.text
-            -- evo-icon-refresh-24
-
-    div
-        span.icon
-            evo-icon-relaxed-grid-24
-        span.text
-            -- evo-icon-relaxed-grid-24
-
-    div
-        span.icon
-            evo-icon-relaxed-grid-filled-24
-        span.text
-            -- evo-icon-relaxed-grid-filled-24
-
-    div
-        span.icon
-            evo-icon-remove-12
-        span.text
-            -- evo-icon-remove-12
-
-    div
-        span.icon
-            evo-icon-remove-16
-        span.text
-            -- evo-icon-remove-16
-
-    div
-        span.icon
-            evo-icon-remove-24
-        span.text
-            -- evo-icon-remove-24
-
-    div
-        span.icon
-            evo-icon-reply-16
-        span.text
-            -- evo-icon-reply-16
-
-    div
-        span.icon
-            evo-icon-reply-24
-        span.text
-            -- evo-icon-reply-24
-
-    div
-        span.icon
-            evo-icon-reply-chat-12
-        span.text
-            -- evo-icon-reply-chat-12
-
-    div
-        span.icon
-            evo-icon-reply-chat-16
-        span.text
-            -- evo-icon-reply-chat-16
-
-    div
-        span.icon
-            evo-icon-reply-chat-24
-        span.text
-            -- evo-icon-reply-chat-24
-
-    div
-        span.icon
-            evo-icon-return-16
-        span.text
-            -- evo-icon-return-16
-
-    div
-        span.icon
-            evo-icon-return-24
-        span.text
-            -- evo-icon-return-24
-
-    div
-        span.icon
-            evo-icon-rewind-16
-        span.text
-            -- evo-icon-rewind-16
-
-    div
-        span.icon
-            evo-icon-ribbon-16
-        span.text
-            -- evo-icon-ribbon-16
-
-    div
-        span.icon
-            evo-icon-ribbon-24
-        span.text
-            -- evo-icon-ribbon-24
-
-    div
-        span.icon
-            evo-icon-rim-16
-        span.text
-            -- evo-icon-rim-16
-
-    div
-        span.icon
-            evo-icon-rim-24
-        span.text
-            -- evo-icon-rim-24
-
-    div
-        span.icon
-            evo-icon-ringgit-16
-        span.text
-            -- evo-icon-ringgit-16
-
-    div
-        span.icon
-            evo-icon-ringgit-24
-        span.text
-            -- evo-icon-ringgit-24
-
-    div
-        span.icon
-            evo-icon-rotate-16
-        span.text
-            -- evo-icon-rotate-16
-
-    div
-        span.icon
-            evo-icon-rotate-20
-        span.text
-            -- evo-icon-rotate-20
-
-    div
-        span.icon
-            evo-icon-rotate-24
-        span.text
-            -- evo-icon-rotate-24
-
-    div
-        span.icon
-            evo-icon-rotate-landscape-left-24
-        span.text
-            -- evo-icon-rotate-landscape-left-24
-
-    div
-        span.icon
-            evo-icon-rotate-landscape-right-24
-        span.text
-            -- evo-icon-rotate-landscape-right-24
-
-    div
-        span.icon
-            evo-icon-rotate-portrait-left-24
-        span.text
-            -- evo-icon-rotate-portrait-left-24
-
-    div
-        span.icon
-            evo-icon-rotate-portrait-right-24
-        span.text
-            -- evo-icon-rotate-portrait-right-24
-
-    div
-        span.icon
-            evo-icon-ruler-16
-        span.text
-            -- evo-icon-ruler-16
-
-    div
-        span.icon
-            evo-icon-ruler-24
-        span.text
-            -- evo-icon-ruler-24
-
-    div
-        span.icon
-            evo-icon-rupee-16
-        span.text
-            -- evo-icon-rupee-16
-
-    div
-        span.icon
-            evo-icon-rupee-24
-        span.text
-            -- evo-icon-rupee-24
-
-    div
-        span.icon
-            evo-icon-satchel-16
-        span.text
-            -- evo-icon-satchel-16
-
-    div
-        span.icon
-            evo-icon-satchel-24
-        span.text
-            -- evo-icon-satchel-24
-
-    div
-        span.icon
-            evo-icon-scan-16
-        span.text
-            -- evo-icon-scan-16
-
-    div
-        span.icon
-            evo-icon-scan-24
-        span.text
-            -- evo-icon-scan-24
-
-    div
-        span.icon
-            evo-icon-search-16
-        span.text
-            -- evo-icon-search-16
-
-    div
-        span.icon
-            evo-icon-search-20
-        span.text
-            -- evo-icon-search-20
-
-    div
-        span.icon
-            evo-icon-search-24
-        span.text
-            -- evo-icon-search-24
-
-    div
-        span.icon
-            evo-icon-search-64
-        span.text
-            -- evo-icon-search-64
-
-    div
-        span.icon
-            evo-icon-search-filled-24
-        span.text
-            -- evo-icon-search-filled-24
-
-    div
-        span.icon
-            evo-icon-search-similar-16
-        span.text
-            -- evo-icon-search-similar-16
-
-    div
-        span.icon
-            evo-icon-search-similar-20
-        span.text
-            -- evo-icon-search-similar-20
-
-    div
-        span.icon
-            evo-icon-search-similar-24
-        span.text
-            -- evo-icon-search-similar-24
-
-    div
-        span.icon
-            evo-icon-seasons-16
-        span.text
-            -- evo-icon-seasons-16
-
-    div
-        span.icon
-            evo-icon-seasons-24
-        span.text
-            -- evo-icon-seasons-24
-
-    div
-        span.icon
-            evo-icon-secure-purchase-16
-        span.text
-            -- evo-icon-secure-purchase-16
-
-    div
-        span.icon
-            evo-icon-secure-purchase-24
-        span.text
-            -- evo-icon-secure-purchase-24
-
-    div
-        span.icon
-            evo-icon-security-key-24
-        span.text
-            -- evo-icon-security-key-24
-
-    div
-        span.icon
-            evo-icon-select-all-24
-        span.text
-            -- evo-icon-select-all-24
-
-    div
-        span.icon
-            evo-icon-selling-12
-        span.text
-            -- evo-icon-selling-12
-
-    div
-        span.icon
-            evo-icon-selling-16
-        span.text
-            -- evo-icon-selling-16
-
-    div
-        span.icon
-            evo-icon-selling-20
-        span.text
-            -- evo-icon-selling-20
-
-    div
-        span.icon
-            evo-icon-selling-24
-        span.text
-            -- evo-icon-selling-24
-
-    div
-        span.icon
-            evo-icon-selling-filled-24
-        span.text
-            -- evo-icon-selling-filled-24
-
-    div
-        span.icon
-            evo-icon-send-24
-        span.text
-            -- evo-icon-send-24
-
-    div
-        span.icon
-            evo-icon-settings-16
-        span.text
-            -- evo-icon-settings-16
-
-    div
-        span.icon
-            evo-icon-settings-20
-        span.text
-            -- evo-icon-settings-20
-
-    div
-        span.icon
-            evo-icon-settings-24
-        span.text
-            -- evo-icon-settings-24
-
-    div
-        span.icon
-            evo-icon-share-android-16
-        span.text
-            -- evo-icon-share-android-16
-
-    div
-        span.icon
-            evo-icon-share-android-20
-        span.text
-            -- evo-icon-share-android-20
-
-    div
-        span.icon
-            evo-icon-share-android-24
-        span.text
-            -- evo-icon-share-android-24
-
-    div
-        span.icon
-            evo-icon-share-ios-16
-        span.text
-            -- evo-icon-share-ios-16
-
-    div
-        span.icon
-            evo-icon-share-ios-20
-        span.text
-            -- evo-icon-share-ios-20
-
-    div
-        span.icon
-            evo-icon-share-ios-24
-        span.text
-            -- evo-icon-share-ios-24
-
-    div
-        span.icon
-            evo-icon-sharpen-24
-        span.text
-            -- evo-icon-sharpen-24
-
-    div
-        span.icon
-            evo-icon-ship-and-local-16
-        span.text
-            -- evo-icon-ship-and-local-16
-
-    div
-        span.icon
-            evo-icon-ship-and-local-24
-        span.text
-            -- evo-icon-ship-and-local-24
-
-    div
-        span.icon
-            evo-icon-ship-and-safety-16
-        span.text
-            -- evo-icon-ship-and-safety-16
-
-    div
-        span.icon
-            evo-icon-ship-and-safety-24
-        span.text
-            -- evo-icon-ship-and-safety-24
-
-    div
-        span.icon
-            evo-icon-shirt-16
-        span.text
-            -- evo-icon-shirt-16
-
-    div
-        span.icon
-            evo-icon-shirt-24
-        span.text
-            -- evo-icon-shirt-24
-
-    div
-        span.icon
-            evo-icon-shoe-box-24
-        span.text
-            -- evo-icon-shoe-box-24
-
-    div
-        span.icon
-            evo-icon-shopping-event-16
-        span.text
-            -- evo-icon-shopping-event-16
-
-    div
-        span.icon
-            evo-icon-shopping-event-24
-        span.text
-            -- evo-icon-shopping-event-24
-
-    div
-        span.icon
-            evo-icon-shovel-16
-        span.text
-            -- evo-icon-shovel-16
-
-    div
-        span.icon
-            evo-icon-shovel-24
-        span.text
-            -- evo-icon-shovel-24
-
-    div
-        span.icon
-            evo-icon-show-16
-        span.text
-            -- evo-icon-show-16
-
-    div
-        span.icon
-            evo-icon-show-24
-        span.text
-            -- evo-icon-show-24
-
-    div
-        span.icon
-            evo-icon-skull-12
-        span.text
-            -- evo-icon-skull-12
-
-    div
-        span.icon
-            evo-icon-skull-16
-        span.text
-            -- evo-icon-skull-16
-
-    div
-        span.icon
-            evo-icon-skull-24
-        span.text
-            -- evo-icon-skull-24
-
-    div
-        span.icon
-            evo-icon-small-box-16
-        span.text
-            -- evo-icon-small-box-16
-
-    div
-        span.icon
-            evo-icon-small-box-24
-        span.text
-            -- evo-icon-small-box-24
-
-    div
-        span.icon
-            evo-icon-small-letter-24
-        span.text
-            -- evo-icon-small-letter-24
-
-    div
-        span.icon
-            evo-icon-sneaker-16
-        span.text
-            -- evo-icon-sneaker-16
-
-    div
-        span.icon
-            evo-icon-sneaker-24
-        span.text
-            -- evo-icon-sneaker-24
-
-    div
-        span.icon
-            evo-icon-snowflake-16
-        span.text
-            -- evo-icon-snowflake-16
-
-    div
-        span.icon
-            evo-icon-snowflake-24
-        span.text
-            -- evo-icon-snowflake-24
-
-    div
-        span.icon
-            evo-icon-snowmobile-16
-        span.text
-            -- evo-icon-snowmobile-16
-
-    div
-        span.icon
-            evo-icon-snowmobile-24
-        span.text
-            -- evo-icon-snowmobile-24
-
-    div
-        span.icon
-            evo-icon-sort-12
-        span.text
-            -- evo-icon-sort-12
-
-    div
-        span.icon
-            evo-icon-sort-16
-        span.text
-            -- evo-icon-sort-16
-
-    div
-        span.icon
-            evo-icon-sort-24
-        span.text
-            -- evo-icon-sort-24
-
-    div
-        span.icon
-            evo-icon-sort-down-12
-        span.text
-            -- evo-icon-sort-down-12
-
-    div
-        span.icon
-            evo-icon-sort-up-12
-        span.text
-            -- evo-icon-sort-up-12
-
-    div
-        span.icon
-            evo-icon-sparkline-down-16
-        span.text
-            -- evo-icon-sparkline-down-16
-
-    div
-        span.icon
-            evo-icon-sparkline-down-20
-        span.text
-            -- evo-icon-sparkline-down-20
-
-    div
-        span.icon
-            evo-icon-sparkline-down-24
-        span.text
-            -- evo-icon-sparkline-down-24
-
-    div
-        span.icon
-            evo-icon-sparkline-up-16
-        span.text
-            -- evo-icon-sparkline-up-16
-
-    div
-        span.icon
-            evo-icon-sparkline-up-20
-        span.text
-            -- evo-icon-sparkline-up-20
-
-    div
-        span.icon
-            evo-icon-sparkline-up-24
-        span.text
-            -- evo-icon-sparkline-up-24
-
-    div
-        span.icon
-            evo-icon-sparkline-up-filled-24
-        span.text
-            -- evo-icon-sparkline-up-filled-24
-
-    div
-        span.icon
-            evo-icon-speedometer-16
-        span.text
-            -- evo-icon-speedometer-16
-
-    div
-        span.icon
-            evo-icon-speedometer-24
-        span.text
-            -- evo-icon-speedometer-24
-
-    div
-        span.icon
-            evo-icon-spinner-20
-        span.text
-            -- evo-icon-spinner-20
-
-    div
-        span.icon
-            evo-icon-spinner-24
-        span.text
-            -- evo-icon-spinner-24
-
-    div
-        span.icon
-            evo-icon-spinner-30
-        span.text
-            -- evo-icon-spinner-30
-
-    div
-        span.icon
-            evo-icon-split-payment-16
-        span.text
-            -- evo-icon-split-payment-16
-
-    div
-        span.icon
-            evo-icon-split-payment-24
-        span.text
-            -- evo-icon-split-payment-24
-
-    div
-        span.icon
-            evo-icon-split-view-24
-        span.text
-            -- evo-icon-split-view-24
-
-    div
-        span.icon
-            evo-icon-split-view-filled-24
-        span.text
-            -- evo-icon-split-view-filled-24
-
-    div
-        span.icon
-            evo-icon-spring-leaf-16
-        span.text
-            -- evo-icon-spring-leaf-16
-
-    div
-        span.icon
-            evo-icon-spring-leaf-24
-        span.text
-            -- evo-icon-spring-leaf-24
-
-    div
-        span.icon
-            evo-icon-star-empty-16
-        span.text
-            -- evo-icon-star-empty-16
-
-    div
-        span.icon
-            evo-icon-star-empty-24
-        span.text
-            -- evo-icon-star-empty-24
-
-    div
-        span.icon
-            evo-icon-star-empty-40
-        span.text
-            -- evo-icon-star-empty-40
-
-    div
-        span.icon
-            evo-icon-star-filled-16
-        span.text
-            -- evo-icon-star-filled-16
-
-    div
-        span.icon
-            evo-icon-star-filled-24
-        span.text
-            -- evo-icon-star-filled-24
-
-    div
-        span.icon
-            evo-icon-star-filled-40
-        span.text
-            -- evo-icon-star-filled-40
-
-    div
-        span.icon
-            evo-icon-star-half-16-colored
-        span.text
-            -- evo-icon-star-half-16-colored
-
-    div
-        span.icon
-            evo-icon-star-half-24-colored
-        span.text
-            -- evo-icon-star-half-24-colored
-
-    div
-        span.icon
-            evo-icon-star-half-dark-16-colored
-        span.text
-            -- evo-icon-star-half-dark-16-colored
-
-    div
-        span.icon
-            evo-icon-star-half-dark-24-colored
-        span.text
-            -- evo-icon-star-half-dark-24-colored
-
-    div
-        span.icon
-            evo-icon-stepper-attention-24
-        span.text
-            -- evo-icon-stepper-attention-24
-
-    div
-        span.icon
-            evo-icon-stepper-confirmation-24
-        span.text
-            -- evo-icon-stepper-confirmation-24
-
-    div
-        span.icon
-            evo-icon-stepper-current-24
-        span.text
-            -- evo-icon-stepper-current-24
-
-    div
-        span.icon
-            evo-icon-stepper-upcoming-24
-        span.text
-            -- evo-icon-stepper-upcoming-24
-
-    div
-        span.icon
-            evo-icon-stop-16
-        span.text
-            -- evo-icon-stop-16
-
-    div
-        span.icon
-            evo-icon-stop-20
-        span.text
-            -- evo-icon-stop-20
-
-    div
-        span.icon
-            evo-icon-stop-24
-        span.text
-            -- evo-icon-stop-24
-
-    div
-        span.icon
-            evo-icon-store-16
-        span.text
-            -- evo-icon-store-16
-
-    div
-        span.icon
-            evo-icon-store-24
-        span.text
-            -- evo-icon-store-24
-
-    div
-        span.icon
-            evo-icon-store-64
-        span.text
-            -- evo-icon-store-64
-
-    div
-        span.icon
-            evo-icon-store-filled-24
-        span.text
-            -- evo-icon-store-filled-24
-
-    div
-        span.icon
-            evo-icon-suitcase-24
-        span.text
-            -- evo-icon-suitcase-24
-
-    div
-        span.icon
-            evo-icon-support-24
-        span.text
-            -- evo-icon-support-24
-
-    div
-        span.icon
-            evo-icon-swap-16
-        span.text
-            -- evo-icon-swap-16
-
-    div
-        span.icon
-            evo-icon-swap-24
-        span.text
-            -- evo-icon-swap-24
-
-    div
-        span.icon
-            evo-icon-switch-camera-24
-        span.text
-            -- evo-icon-switch-camera-24
-
-    div
-        span.icon
-            evo-icon-tablet-16
-        span.text
-            -- evo-icon-tablet-16
-
-    div
-        span.icon
-            evo-icon-tablet-20
-        span.text
-            -- evo-icon-tablet-20
-
-    div
-        span.icon
-            evo-icon-tablet-24
-        span.text
-            -- evo-icon-tablet-24
-
-    div
-        span.icon
-            evo-icon-target-16
-        span.text
-            -- evo-icon-target-16
-
-    div
-        span.icon
-            evo-icon-target-24
-        span.text
-            -- evo-icon-target-24
-
-    div
-        span.icon
-            evo-icon-td-12-colored
-        span.text
-            -- evo-icon-td-12-colored
-
-    div
-        span.icon
-            evo-icon-td-18-colored
-        span.text
-            -- evo-icon-td-18-colored
-
-    div
-        span.icon
-            evo-icon-td-24-colored
-        span.text
-            -- evo-icon-td-24-colored
-
-    div
-        span.icon
-            evo-icon-td-32-colored
-        span.text
-            -- evo-icon-td-32-colored
-
-    div
-        span.icon
-            evo-icon-text-messaging-16
-        span.text
-            -- evo-icon-text-messaging-16
-
-    div
-        span.icon
-            evo-icon-text-messaging-20
-        span.text
-            -- evo-icon-text-messaging-20
-
-    div
-        span.icon
-            evo-icon-text-messaging-24
-        span.text
-            -- evo-icon-text-messaging-24
-
-    div
-        span.icon
-            evo-icon-text-messaging-64
-        span.text
-            -- evo-icon-text-messaging-64
-
-    div
-        span.icon
-            evo-icon-text-size-16
-        span.text
-            -- evo-icon-text-size-16
-
-    div
-        span.icon
-            evo-icon-text-size-24
-        span.text
-            -- evo-icon-text-size-24
-
-    div
-        span.icon
-            evo-icon-the-ebay-vault-16
-        span.text
-            -- evo-icon-the-ebay-vault-16
-
-    div
-        span.icon
-            evo-icon-the-ebay-vault-24
-        span.text
-            -- evo-icon-the-ebay-vault-24
-
-    div
-        span.icon
-            evo-icon-thumb-down-16
-        span.text
-            -- evo-icon-thumb-down-16
-
-    div
-        span.icon
-            evo-icon-thumb-down-20
-        span.text
-            -- evo-icon-thumb-down-20
-
-    div
-        span.icon
-            evo-icon-thumb-down-24
-        span.text
-            -- evo-icon-thumb-down-24
-
-    div
-        span.icon
-            evo-icon-thumb-down-filled-16
-        span.text
-            -- evo-icon-thumb-down-filled-16
-
-    div
-        span.icon
-            evo-icon-thumb-down-filled-20
-        span.text
-            -- evo-icon-thumb-down-filled-20
-
-    div
-        span.icon
-            evo-icon-thumb-down-filled-24
-        span.text
-            -- evo-icon-thumb-down-filled-24
-
-    div
-        span.icon
-            evo-icon-thumb-up-16
-        span.text
-            -- evo-icon-thumb-up-16
-
-    div
-        span.icon
-            evo-icon-thumb-up-20
-        span.text
-            -- evo-icon-thumb-up-20
-
-    div
-        span.icon
-            evo-icon-thumb-up-24
-        span.text
-            -- evo-icon-thumb-up-24
-
-    div
-        span.icon
-            evo-icon-thumb-up-64
-        span.text
-            -- evo-icon-thumb-up-64
-
-    div
-        span.icon
-            evo-icon-thumb-up-filled-16
-        span.text
-            -- evo-icon-thumb-up-filled-16
-
-    div
-        span.icon
-            evo-icon-thumb-up-filled-20
-        span.text
-            -- evo-icon-thumb-up-filled-20
-
-    div
-        span.icon
-            evo-icon-thumb-up-filled-24
-        span.text
-            -- evo-icon-thumb-up-filled-24
-
-    div
-        span.icon
-            evo-icon-tick-12
-        span.text
-            -- evo-icon-tick-12
-
-    div
-        span.icon
-            evo-icon-tick-16
-        span.text
-            -- evo-icon-tick-16
-
-    div
-        span.icon
-            evo-icon-tick-24
-        span.text
-            -- evo-icon-tick-24
-
-    div
-        span.icon
-            evo-icon-tiktok-24
-        span.text
-            -- evo-icon-tiktok-24
-
-    div
-        span.icon
-            evo-icon-tire-16
-        span.text
-            -- evo-icon-tire-16
-
-    div
-        span.icon
-            evo-icon-tire-24
-        span.text
-            -- evo-icon-tire-24
-
-    div
-        span.icon
-            evo-icon-toggle-mode-bottom-24
-        span.text
-            -- evo-icon-toggle-mode-bottom-24
-
-    div
-        span.icon
-            evo-icon-toggle-mode-top-24
-        span.text
-            -- evo-icon-toggle-mode-top-24
-
-    div
-        span.icon
-            evo-icon-top-rated-plus-16
-        span.text
-            -- evo-icon-top-rated-plus-16
-
-    div
-        span.icon
-            evo-icon-top-rated-plus-24
-        span.text
-            -- evo-icon-top-rated-plus-24
-
-    div
-        span.icon
-            evo-icon-top-rated-seller-16
-        span.text
-            -- evo-icon-top-rated-seller-16
-
-    div
-        span.icon
-            evo-icon-top-rated-seller-24
-        span.text
-            -- evo-icon-top-rated-seller-24
-
-    div
-        span.icon
-            evo-icon-top-service-16
-        span.text
-            -- evo-icon-top-service-16
-
-    div
-        span.icon
-            evo-icon-top-service-24
-        span.text
-            -- evo-icon-top-service-24
-
-    div
-        span.icon
-            evo-icon-top-service-filled-16
-        span.text
-            -- evo-icon-top-service-filled-16
-
-    div
-        span.icon
-            evo-icon-top-service-filled-16-colored
-        span.text
-            -- evo-icon-top-service-filled-16-colored
-
-    div
-        span.icon
-            evo-icon-top-service-filled-24
-        span.text
-            -- evo-icon-top-service-filled-24
-
-    div
-        span.icon
-            evo-icon-top-service-filled-24-colored
-        span.text
-            -- evo-icon-top-service-filled-24-colored
-
-    div
-        span.icon
-            evo-icon-trading-card-16
-        span.text
-            -- evo-icon-trading-card-16
-
-    div
-        span.icon
-            evo-icon-trading-card-24
-        span.text
-            -- evo-icon-trading-card-24
-
-    div
-        span.icon
-            evo-icon-trading-card-edition-24
-        span.text
-            -- evo-icon-trading-card-edition-24
-
-    div
-        span.icon
-            evo-icon-trading-card-grade-16
-        span.text
-            -- evo-icon-trading-card-grade-16
-
-    div
-        span.icon
-            evo-icon-trading-card-grade-24
-        span.text
-            -- evo-icon-trading-card-grade-24
-
-    div
-        span.icon
-            evo-icon-transaction-24
-        span.text
-            -- evo-icon-transaction-24
-
-    div
-        span.icon
-            evo-icon-translate-16
-        span.text
-            -- evo-icon-translate-16
-
-    div
-        span.icon
-            evo-icon-translate-20
-        span.text
-            -- evo-icon-translate-20
-
-    div
-        span.icon
-            evo-icon-translate-24
-        span.text
-            -- evo-icon-translate-24
-
-    div
-        span.icon
-            evo-icon-trend-down-16-fit
-        span.text
-            -- evo-icon-trend-down-16-fit
-
-    div
-        span.icon
-            evo-icon-trend-up-16-fit
-        span.text
-            -- evo-icon-trend-up-16-fit
-
-    div
-        span.icon
-            evo-icon-trophy-16
-        span.text
-            -- evo-icon-trophy-16
-
-    div
-        span.icon
-            evo-icon-trophy-24
-        span.text
-            -- evo-icon-trophy-24
-
-    div
-        span.icon
-            evo-icon-truck-16
-        span.text
-            -- evo-icon-truck-16
-
-    div
-        span.icon
-            evo-icon-truck-24
-        span.text
-            -- evo-icon-truck-24
-
-    div
-        span.icon
-            evo-icon-truck-64
-        span.text
-            -- evo-icon-truck-64
-
-    div
-        span.icon
-            evo-icon-truck-shipped-12
-        span.text
-            -- evo-icon-truck-shipped-12
-
-    div
-        span.icon
-            evo-icon-truck-shipped-16
-        span.text
-            -- evo-icon-truck-shipped-16
-
-    div
-        span.icon
-            evo-icon-truck-shipped-24
-        span.text
-            -- evo-icon-truck-shipped-24
-
-    div
-        span.icon
-            evo-icon-twitter-24
-        span.text
-            -- evo-icon-twitter-24
-
-    div
-        span.icon
-            evo-icon-undo-16
-        span.text
-            -- evo-icon-undo-16
-
-    div
-        span.icon
-            evo-icon-undo-24
-        span.text
-            -- evo-icon-undo-24
-
-    div
-        span.icon
-            evo-icon-unionpay-12-colored
-        span.text
-            -- evo-icon-unionpay-12-colored
-
-    div
-        span.icon
-            evo-icon-unionpay-18-colored
-        span.text
-            -- evo-icon-unionpay-18-colored
-
-    div
-        span.icon
-            evo-icon-unionpay-24-colored
-        span.text
-            -- evo-icon-unionpay-24-colored
-
-    div
-        span.icon
-            evo-icon-unionpay-32-colored
-        span.text
-            -- evo-icon-unionpay-32-colored
-
-    div
-        span.icon
-            evo-icon-unlock-16
-        span.text
-            -- evo-icon-unlock-16
-
-    div
-        span.icon
-            evo-icon-unlock-24
-        span.text
-            -- evo-icon-unlock-24
-
-    div
-        span.icon
-            evo-icon-unselect-all-24
-        span.text
-            -- evo-icon-unselect-all-24
-
-    div
-        span.icon
-            evo-icon-upload-16
-        span.text
-            -- evo-icon-upload-16
-
-    div
-        span.icon
-            evo-icon-upload-24
-        span.text
-            -- evo-icon-upload-24
-
-    div
-        span.icon
-            evo-icon-usaa-12-colored
-        span.text
-            -- evo-icon-usaa-12-colored
-
-    div
-        span.icon
-            evo-icon-usaa-18-colored
-        span.text
-            -- evo-icon-usaa-18-colored
-
-    div
-        span.icon
-            evo-icon-usaa-24-colored
-        span.text
-            -- evo-icon-usaa-24-colored
-
-    div
-        span.icon
-            evo-icon-usaa-32-colored
-        span.text
-            -- evo-icon-usaa-32-colored
-
-    div
-        span.icon
-            evo-icon-venmo-12-colored
-        span.text
-            -- evo-icon-venmo-12-colored
-
-    div
-        span.icon
-            evo-icon-venmo-18-colored
-        span.text
-            -- evo-icon-venmo-18-colored
-
-    div
-        span.icon
-            evo-icon-venmo-24-colored
-        span.text
-            -- evo-icon-venmo-24-colored
-
-    div
-        span.icon
-            evo-icon-venmo-32-colored
-        span.text
-            -- evo-icon-venmo-32-colored
-
-    div
-        span.icon
-            evo-icon-verified-condition-16
-        span.text
-            -- evo-icon-verified-condition-16
-
-    div
-        span.icon
-            evo-icon-verified-condition-24
-        span.text
-            -- evo-icon-verified-condition-24
-
-    div
-        span.icon
-            evo-icon-video-24
-        span.text
-            -- evo-icon-video-24
-
-    div
-        span.icon
-            evo-icon-visa-12-colored
-        span.text
-            -- evo-icon-visa-12-colored
-
-    div
-        span.icon
-            evo-icon-visa-18-colored
-        span.text
-            -- evo-icon-visa-18-colored
-
-    div
-        span.icon
-            evo-icon-visa-24-colored
-        span.text
-            -- evo-icon-visa-24-colored
-
-    div
-        span.icon
-            evo-icon-visa-32-colored
-        span.text
-            -- evo-icon-visa-32-colored
-
-    div
-        span.icon
-            evo-icon-wallet-16
-        span.text
-            -- evo-icon-wallet-16
-
-    div
-        span.icon
-            evo-icon-wallet-24
-        span.text
-            -- evo-icon-wallet-24
-
-    div
-        span.icon
-            evo-icon-wallet-64
-        span.text
-            -- evo-icon-wallet-64
-
-    div
-        span.icon
-            evo-icon-wallet-balance-12-colored
-        span.text
-            -- evo-icon-wallet-balance-12-colored
-
-    div
-        span.icon
-            evo-icon-wallet-balance-18-colored
-        span.text
-            -- evo-icon-wallet-balance-18-colored
-
-    div
-        span.icon
-            evo-icon-wallet-balance-24-colored
-        span.text
-            -- evo-icon-wallet-balance-24-colored
-
-    div
-        span.icon
-            evo-icon-wallet-balance-32-colored
-        span.text
-            -- evo-icon-wallet-balance-32-colored
-
-    div
-        span.icon
-            evo-icon-watch-16
-        span.text
-            -- evo-icon-watch-16
-
-    div
-        span.icon
-            evo-icon-watch-24
-        span.text
-            -- evo-icon-watch-24
-
-    div
-        span.icon
-            evo-icon-wells-fargo-12-colored
-        span.text
-            -- evo-icon-wells-fargo-12-colored
-
-    div
-        span.icon
-            evo-icon-wells-fargo-18-colored
-        span.text
-            -- evo-icon-wells-fargo-18-colored
-
-    div
-        span.icon
-            evo-icon-wells-fargo-24-colored
-        span.text
-            -- evo-icon-wells-fargo-24-colored
-
-    div
-        span.icon
-            evo-icon-wells-fargo-32-colored
-        span.text
-            -- evo-icon-wells-fargo-32-colored
-
-    div
-        span.icon
-            evo-icon-whatsapp-24
-        span.text
-            -- evo-icon-whatsapp-24
-
-    div
-        span.icon
-            evo-icon-wire-transfer-16
-        span.text
-            -- evo-icon-wire-transfer-16
-
-    div
-        span.icon
-            evo-icon-wire-transfer-24
-        span.text
-            -- evo-icon-wire-transfer-24
-
-    div
-        span.icon
-            evo-icon-wire-transfer-card-12-colored
-        span.text
-            -- evo-icon-wire-transfer-card-12-colored
-
-    div
-        span.icon
-            evo-icon-wire-transfer-card-18-colored
-        span.text
-            -- evo-icon-wire-transfer-card-18-colored
-
-    div
-        span.icon
-            evo-icon-wire-transfer-card-24-colored
-        span.text
-            -- evo-icon-wire-transfer-card-24-colored
-
-    div
-        span.icon
-            evo-icon-wire-transfer-card-32-colored
-        span.text
-            -- evo-icon-wire-transfer-card-32-colored
-
-    div
-        span.icon
-            evo-icon-won-16
-        span.text
-            -- evo-icon-won-16
-
-    div
-        span.icon
-            evo-icon-won-24
-        span.text
-            -- evo-icon-won-24
-
-    div
-        span.icon
-            evo-icon-wrench-16
-        span.text
-            -- evo-icon-wrench-16
-
-    div
-        span.icon
-            evo-icon-wrench-24
-        span.text
-            -- evo-icon-wrench-24
-
-    div
-        span.icon
-            evo-icon-youtube-24
-        span.text
-            -- evo-icon-youtube-24
-
-    div
-        span.icon
-            evo-icon-yuan-16
-        span.text
-            -- evo-icon-yuan-16
-
-    div
-        span.icon
-            evo-icon-yuan-24
-        span.text
-            -- evo-icon-yuan-24
-
-    div
-        span.icon
-            evo-icon-zip-pay-12-colored
-        span.text
-            -- evo-icon-zip-pay-12-colored
-
-    div
-        span.icon
-            evo-icon-zip-pay-18-colored
-        span.text
-            -- evo-icon-zip-pay-18-colored
-
-    div
-        span.icon
-            evo-icon-zip-pay-24-colored
-        span.text
-            -- evo-icon-zip-pay-24-colored
-
-    div
-        span.icon
-            evo-icon-zip-pay-32-colored
-        span.text
-            -- evo-icon-zip-pay-32-colored
-
-    div
-        span.icon
-            evo-icon-zloty-16
-        span.text
-            -- evo-icon-zloty-16
-
-    div
-        span.icon
-            evo-icon-zloty-24
-        span.text
-            -- evo-icon-zloty-24
-
-    div
-        span.icon
-            evo-icon-zoom-in-16
-        span.text
-            -- evo-icon-zoom-in-16
-
-    div
-        span.icon
-            evo-icon-zoom-in-24
-        span.text
-            -- evo-icon-zoom-in-24
-
-    div
-        span.icon
-            evo-icon-zoom-out-16
-        span.text
-            -- evo-icon-zoom-out-16
-
-    div
-        span.icon
-            evo-icon-zoom-out-24
-        span.text
-            -- evo-icon-zoom-out-24
+icon-grid
+  icon-example name="evo-icon-add-12"
+    evo-icon-add-12
+
+  icon-example name="evo-icon-add-16"
+    evo-icon-add-16
+
+  icon-example name="evo-icon-add-24"
+    evo-icon-add-24
+
+  icon-example name="evo-icon-add-image-24"
+    evo-icon-add-image-24
+
+  icon-example name="evo-icon-adjust-price-down-16"
+    evo-icon-adjust-price-down-16
+
+  icon-example name="evo-icon-adjust-price-down-24"
+    evo-icon-adjust-price-down-24
+
+  icon-example name="evo-icon-adjust-price-up-16"
+    evo-icon-adjust-price-up-16
+
+  icon-example name="evo-icon-adjust-price-up-24"
+    evo-icon-adjust-price-up-24
+
+  icon-example name="evo-icon-afterpay-12-colored"
+    evo-icon-afterpay-12-colored
+
+  icon-example name="evo-icon-afterpay-18-colored"
+    evo-icon-afterpay-18-colored
+
+  icon-example name="evo-icon-afterpay-24-colored"
+    evo-icon-afterpay-24-colored
+
+  icon-example name="evo-icon-afterpay-32-colored"
+    evo-icon-afterpay-32-colored
+
+  icon-example name="evo-icon-afterpay-logo-24-colored"
+    evo-icon-afterpay-logo-24-colored
+
+  icon-example name="evo-icon-ai-16"
+    evo-icon-ai-16
+
+  icon-example name="evo-icon-ai-20"
+    evo-icon-ai-20
+
+  icon-example name="evo-icon-ai-24"
+    evo-icon-ai-24
+
+  icon-example name="evo-icon-ai-camera-16"
+    evo-icon-ai-camera-16
+
+  icon-example name="evo-icon-ai-camera-20"
+    evo-icon-ai-camera-20
+
+  icon-example name="evo-icon-ai-camera-24"
+    evo-icon-ai-camera-24
+
+  icon-example name="evo-icon-ai-filled-16"
+    evo-icon-ai-filled-16
+
+  icon-example name="evo-icon-ai-filled-20"
+    evo-icon-ai-filled-20
+
+  icon-example name="evo-icon-ai-filled-24"
+    evo-icon-ai-filled-24
+
+  icon-example name="evo-icon-ai-mobile-16"
+    evo-icon-ai-mobile-16
+
+  icon-example name="evo-icon-ai-mobile-20"
+    evo-icon-ai-mobile-20
+
+  icon-example name="evo-icon-ai-mobile-24"
+    evo-icon-ai-mobile-24
+
+  icon-example name="evo-icon-ai-search-16"
+    evo-icon-ai-search-16
+
+  icon-example name="evo-icon-ai-search-20"
+    evo-icon-ai-search-20
+
+  icon-example name="evo-icon-ai-search-24"
+    evo-icon-ai-search-24
+
+  icon-example name="evo-icon-ai-search-filled-24"
+    evo-icon-ai-search-filled-24
+
+  icon-example name="evo-icon-ai-shirt-16"
+    evo-icon-ai-shirt-16
+
+  icon-example name="evo-icon-ai-shirt-20"
+    evo-icon-ai-shirt-20
+
+  icon-example name="evo-icon-ai-shirt-24"
+    evo-icon-ai-shirt-24
+
+  icon-example name="evo-icon-ai-spectrum-16-colored"
+    evo-icon-ai-spectrum-16-colored
+
+  icon-example name="evo-icon-ai-spectrum-20-colored"
+    evo-icon-ai-spectrum-20-colored
+
+  icon-example name="evo-icon-ai-spectrum-24-colored"
+    evo-icon-ai-spectrum-24-colored
+
+  icon-example name="evo-icon-ai-spectrum-filled-16-colored"
+    evo-icon-ai-spectrum-filled-16-colored
+
+  icon-example name="evo-icon-ai-spectrum-filled-20-colored"
+    evo-icon-ai-spectrum-filled-20-colored
+
+  icon-example name="evo-icon-ai-spectrum-filled-24-colored"
+    evo-icon-ai-spectrum-filled-24-colored
+
+  icon-example name="evo-icon-ai-spectrum-thin-16-colored"
+    evo-icon-ai-spectrum-thin-16-colored
+
+  icon-example name="evo-icon-ai-summary-16"
+    evo-icon-ai-summary-16
+
+  icon-example name="evo-icon-ai-summary-20"
+    evo-icon-ai-summary-20
+
+  icon-example name="evo-icon-ai-summary-24"
+    evo-icon-ai-summary-24
+
+  icon-example name="evo-icon-ai-thin-16"
+    evo-icon-ai-thin-16
+
+  icon-example name="evo-icon-ai-tools-16"
+    evo-icon-ai-tools-16
+
+  icon-example name="evo-icon-ai-tools-20"
+    evo-icon-ai-tools-20
+
+  icon-example name="evo-icon-ai-tools-24"
+    evo-icon-ai-tools-24
+
+  icon-example name="evo-icon-alipay-cn-12-colored"
+    evo-icon-alipay-cn-12-colored
+
+  icon-example name="evo-icon-alipay-cn-18-colored"
+    evo-icon-alipay-cn-18-colored
+
+  icon-example name="evo-icon-alipay-cn-24-colored"
+    evo-icon-alipay-cn-24-colored
+
+  icon-example name="evo-icon-alipay-cn-32-colored"
+    evo-icon-alipay-cn-32-colored
+
+  icon-example name="evo-icon-alipay-hk-12-colored"
+    evo-icon-alipay-hk-12-colored
+
+  icon-example name="evo-icon-alipay-hk-18-colored"
+    evo-icon-alipay-hk-18-colored
+
+  icon-example name="evo-icon-alipay-hk-24-colored"
+    evo-icon-alipay-hk-24-colored
+
+  icon-example name="evo-icon-alipay-hk-32-colored"
+    evo-icon-alipay-hk-32-colored
+
+  icon-example name="evo-icon-amex-12-colored"
+    evo-icon-amex-12-colored
+
+  icon-example name="evo-icon-amex-18-colored"
+    evo-icon-amex-18-colored
+
+  icon-example name="evo-icon-amex-24-colored"
+    evo-icon-amex-24-colored
+
+  icon-example name="evo-icon-amex-32-colored"
+    evo-icon-amex-32-colored
+
+  icon-example name="evo-icon-apple-24"
+    evo-icon-apple-24
+
+  icon-example name="evo-icon-apple-music-24-colored"
+    evo-icon-apple-music-24-colored
+
+  icon-example name="evo-icon-apple-pay-12-colored"
+    evo-icon-apple-pay-12-colored
+
+  icon-example name="evo-icon-apple-pay-18-colored"
+    evo-icon-apple-pay-18-colored
+
+  icon-example name="evo-icon-apple-pay-24-colored"
+    evo-icon-apple-pay-24-colored
+
+  icon-example name="evo-icon-apple-pay-32-colored"
+    evo-icon-apple-pay-32-colored
+
+  icon-example name="evo-icon-archive-16"
+    evo-icon-archive-16
+
+  icon-example name="evo-icon-archive-24"
+    evo-icon-archive-24
+
+  icon-example name="evo-icon-arrow-down-12"
+    evo-icon-arrow-down-12
+
+  icon-example name="evo-icon-arrow-down-16"
+    evo-icon-arrow-down-16
+
+  icon-example name="evo-icon-arrow-down-20"
+    evo-icon-arrow-down-20
+
+  icon-example name="evo-icon-arrow-down-24"
+    evo-icon-arrow-down-24
+
+  icon-example name="evo-icon-arrow-left-12"
+    evo-icon-arrow-left-12
+
+  icon-example name="evo-icon-arrow-left-16"
+    evo-icon-arrow-left-16
+
+  icon-example name="evo-icon-arrow-left-20"
+    evo-icon-arrow-left-20
+
+  icon-example name="evo-icon-arrow-left-24"
+    evo-icon-arrow-left-24
+
+  icon-example name="evo-icon-arrow-right-12"
+    evo-icon-arrow-right-12
+
+  icon-example name="evo-icon-arrow-right-16"
+    evo-icon-arrow-right-16
+
+  icon-example name="evo-icon-arrow-right-20"
+    evo-icon-arrow-right-20
+
+  icon-example name="evo-icon-arrow-right-24"
+    evo-icon-arrow-right-24
+
+  icon-example name="evo-icon-arrow-up-12"
+    evo-icon-arrow-up-12
+
+  icon-example name="evo-icon-arrow-up-16"
+    evo-icon-arrow-up-16
+
+  icon-example name="evo-icon-arrow-up-20"
+    evo-icon-arrow-up-20
+
+  icon-example name="evo-icon-arrow-up-24"
+    evo-icon-arrow-up-24
+
+  icon-example name="evo-icon-arrows-3d-16"
+    evo-icon-arrows-3d-16
+
+  icon-example name="evo-icon-arrows-3d-24"
+    evo-icon-arrows-3d-24
+
+  icon-example name="evo-icon-arrows-3d-filled-64-colored"
+    evo-icon-arrows-3d-filled-64-colored
+
+  icon-example name="evo-icon-arrows-expand-16"
+    evo-icon-arrows-expand-16
+
+  icon-example name="evo-icon-arrows-expand-24"
+    evo-icon-arrows-expand-24
+
+  icon-example name="evo-icon-article-16"
+    evo-icon-article-16
+
+  icon-example name="evo-icon-article-24"
+    evo-icon-article-24
+
+  icon-example name="evo-icon-attention-16"
+    evo-icon-attention-16
+
+  icon-example name="evo-icon-attention-24"
+    evo-icon-attention-24
+
+  icon-example name="evo-icon-attention-64"
+    evo-icon-attention-64
+
+  icon-example name="evo-icon-attention-filled-16"
+    evo-icon-attention-filled-16
+
+  icon-example name="evo-icon-attention-filled-24"
+    evo-icon-attention-filled-24
+
+  icon-example name="evo-icon-attention-triangle-16"
+    evo-icon-attention-triangle-16
+
+  icon-example name="evo-icon-attention-triangle-24"
+    evo-icon-attention-triangle-24
+
+  icon-example name="evo-icon-attention-triangle-filled-16"
+    evo-icon-attention-triangle-filled-16
+
+  icon-example name="evo-icon-attention-triangle-filled-24"
+    evo-icon-attention-triangle-filled-24
+
+  icon-example name="evo-icon-atv-16"
+    evo-icon-atv-16
+
+  icon-example name="evo-icon-atv-24"
+    evo-icon-atv-24
+
+  icon-example name="evo-icon-audio-high-16"
+    evo-icon-audio-high-16
+
+  icon-example name="evo-icon-audio-high-20"
+    evo-icon-audio-high-20
+
+  icon-example name="evo-icon-audio-high-24"
+    evo-icon-audio-high-24
+
+  icon-example name="evo-icon-audio-low-16"
+    evo-icon-audio-low-16
+
+  icon-example name="evo-icon-audio-off-16"
+    evo-icon-audio-off-16
+
+  icon-example name="evo-icon-audio-off-20"
+    evo-icon-audio-off-20
+
+  icon-example name="evo-icon-audio-off-24"
+    evo-icon-audio-off-24
+
+  icon-example name="evo-icon-authenticity-guarantee-16"
+    evo-icon-authenticity-guarantee-16
+
+  icon-example name="evo-icon-authenticity-guarantee-24"
+    evo-icon-authenticity-guarantee-24
+
+  icon-example name="evo-icon-authenticity-guarantee-filled-16"
+    evo-icon-authenticity-guarantee-filled-16
+
+  icon-example name="evo-icon-authenticity-guarantee-filled-16-colored"
+    evo-icon-authenticity-guarantee-filled-16-colored
+
+  icon-example name="evo-icon-authenticity-guarantee-filled-24"
+    evo-icon-authenticity-guarantee-filled-24
+
+  icon-example name="evo-icon-authenticity-guarantee-filled-24-colored"
+    evo-icon-authenticity-guarantee-filled-24-colored
+
+  icon-example name="evo-icon-auto-adjust-16"
+    evo-icon-auto-adjust-16
+
+  icon-example name="evo-icon-auto-adjust-24"
+    evo-icon-auto-adjust-24
+
+  icon-example name="evo-icon-background-removal-16"
+    evo-icon-background-removal-16
+
+  icon-example name="evo-icon-background-removal-24"
+    evo-icon-background-removal-24
+
+  icon-example name="evo-icon-bancontact-12-colored"
+    evo-icon-bancontact-12-colored
+
+  icon-example name="evo-icon-bancontact-18-colored"
+    evo-icon-bancontact-18-colored
+
+  icon-example name="evo-icon-bancontact-24-colored"
+    evo-icon-bancontact-24-colored
+
+  icon-example name="evo-icon-bancontact-32-colored"
+    evo-icon-bancontact-32-colored
+
+  icon-example name="evo-icon-bank-16"
+    evo-icon-bank-16
+
+  icon-example name="evo-icon-bank-20"
+    evo-icon-bank-20
+
+  icon-example name="evo-icon-bank-24"
+    evo-icon-bank-24
+
+  icon-example name="evo-icon-bank-64"
+    evo-icon-bank-64
+
+  icon-example name="evo-icon-bank-account-12-colored"
+    evo-icon-bank-account-12-colored
+
+  icon-example name="evo-icon-bank-account-18-colored"
+    evo-icon-bank-account-18-colored
+
+  icon-example name="evo-icon-bank-account-24-colored"
+    evo-icon-bank-account-24-colored
+
+  icon-example name="evo-icon-bank-account-32-colored"
+    evo-icon-bank-account-32-colored
+
+  icon-example name="evo-icon-bank-group-logo-24-colored"
+    evo-icon-bank-group-logo-24-colored
+
+  icon-example name="evo-icon-bank-of-america-12-colored"
+    evo-icon-bank-of-america-12-colored
+
+  icon-example name="evo-icon-bank-of-america-18-colored"
+    evo-icon-bank-of-america-18-colored
+
+  icon-example name="evo-icon-bank-of-america-24-colored"
+    evo-icon-bank-of-america-24-colored
+
+  icon-example name="evo-icon-bank-of-america-32-colored"
+    evo-icon-bank-of-america-32-colored
+
+  icon-example name="evo-icon-bar-chart-16"
+    evo-icon-bar-chart-16
+
+  icon-example name="evo-icon-bar-chart-24"
+    evo-icon-bar-chart-24
+
+  icon-example name="evo-icon-battery-waste-48"
+    evo-icon-battery-waste-48
+
+  icon-example name="evo-icon-bids-12"
+    evo-icon-bids-12
+
+  icon-example name="evo-icon-bids-16"
+    evo-icon-bids-16
+
+  icon-example name="evo-icon-bids-24"
+    evo-icon-bids-24
+
+  icon-example name="evo-icon-bids-64"
+    evo-icon-bids-64
+
+  icon-example name="evo-icon-boat-16"
+    evo-icon-boat-16
+
+  icon-example name="evo-icon-boat-24"
+    evo-icon-boat-24
+
+  icon-example name="evo-icon-book-16"
+    evo-icon-book-16
+
+  icon-example name="evo-icon-book-24"
+    evo-icon-book-24
+
+  icon-example name="evo-icon-bookmark-16"
+    evo-icon-bookmark-16
+
+  icon-example name="evo-icon-bookmark-24"
+    evo-icon-bookmark-24
+
+  icon-example name="evo-icon-bookmark-filled-16"
+    evo-icon-bookmark-filled-16
+
+  icon-example name="evo-icon-bookmark-filled-24"
+    evo-icon-bookmark-filled-24
+
+  icon-example name="evo-icon-brand-authorized-seller-16"
+    evo-icon-brand-authorized-seller-16
+
+  icon-example name="evo-icon-brand-authorized-seller-24"
+    evo-icon-brand-authorized-seller-24
+
+  icon-example name="evo-icon-brightness-16"
+    evo-icon-brightness-16
+
+  icon-example name="evo-icon-brightness-20"
+    evo-icon-brightness-20
+
+  icon-example name="evo-icon-brightness-24"
+    evo-icon-brightness-24
+
+  icon-example name="evo-icon-calendar-16"
+    evo-icon-calendar-16
+
+  icon-example name="evo-icon-calendar-24"
+    evo-icon-calendar-24
+
+  icon-example name="evo-icon-calendar-64"
+    evo-icon-calendar-64
+
+  icon-example name="evo-icon-camera-16"
+    evo-icon-camera-16
+
+  icon-example name="evo-icon-camera-24"
+    evo-icon-camera-24
+
+  icon-example name="evo-icon-camera-64"
+    evo-icon-camera-64
+
+  icon-example name="evo-icon-capital-one-12-colored"
+    evo-icon-capital-one-12-colored
+
+  icon-example name="evo-icon-capital-one-18-colored"
+    evo-icon-capital-one-18-colored
+
+  icon-example name="evo-icon-capital-one-24-colored"
+    evo-icon-capital-one-24-colored
+
+  icon-example name="evo-icon-capital-one-32-colored"
+    evo-icon-capital-one-32-colored
+
+  icon-example name="evo-icon-car-16"
+    evo-icon-car-16
+
+  icon-example name="evo-icon-car-24"
+    evo-icon-car-24
+
+  icon-example name="evo-icon-car-brake-16"
+    evo-icon-car-brake-16
+
+  icon-example name="evo-icon-car-brake-24"
+    evo-icon-car-brake-24
+
+  icon-example name="evo-icon-card-stack-64"
+    evo-icon-card-stack-64
+
+  icon-example name="evo-icon-carnet-12-colored"
+    evo-icon-carnet-12-colored
+
+  icon-example name="evo-icon-carnet-18-colored"
+    evo-icon-carnet-18-colored
+
+  icon-example name="evo-icon-carnet-24-colored"
+    evo-icon-carnet-24-colored
+
+  icon-example name="evo-icon-carnet-32-colored"
+    evo-icon-carnet-32-colored
+
+  icon-example name="evo-icon-carryon-24"
+    evo-icon-carryon-24
+
+  icon-example name="evo-icon-cart-16"
+    evo-icon-cart-16
+
+  icon-example name="evo-icon-cart-20"
+    evo-icon-cart-20
+
+  icon-example name="evo-icon-cart-24"
+    evo-icon-cart-24
+
+  icon-example name="evo-icon-cart-64"
+    evo-icon-cart-64
+
+  icon-example name="evo-icon-cart-add-16"
+    evo-icon-cart-add-16
+
+  icon-example name="evo-icon-cart-add-20"
+    evo-icon-cart-add-20
+
+  icon-example name="evo-icon-cart-add-24"
+    evo-icon-cart-add-24
+
+  icon-example name="evo-icon-cashapp-12-colored"
+    evo-icon-cashapp-12-colored
+
+  icon-example name="evo-icon-cashapp-18-colored"
+    evo-icon-cashapp-18-colored
+
+  icon-example name="evo-icon-cashapp-24-colored"
+    evo-icon-cashapp-24-colored
+
+  icon-example name="evo-icon-cashapp-32-colored"
+    evo-icon-cashapp-32-colored
+
+  icon-example name="evo-icon-categories-16"
+    evo-icon-categories-16
+
+  icon-example name="evo-icon-categories-24"
+    evo-icon-categories-24
+
+  icon-example name="evo-icon-cb-12-colored"
+    evo-icon-cb-12-colored
+
+  icon-example name="evo-icon-cb-18-colored"
+    evo-icon-cb-18-colored
+
+  icon-example name="evo-icon-cb-24-colored"
+    evo-icon-cb-24-colored
+
+  icon-example name="evo-icon-cb-32-colored"
+    evo-icon-cb-32-colored
+
+  icon-example name="evo-icon-ccd-charger-included"
+    evo-icon-ccd-charger-included
+
+  icon-example name="evo-icon-ccd-charger-not-included"
+    evo-icon-ccd-charger-not-included
+
+  icon-example name="evo-icon-ccd-top"
+    evo-icon-ccd-top
+
+  icon-example name="evo-icon-certified-recycled-16"
+    evo-icon-certified-recycled-16
+
+  icon-example name="evo-icon-certified-recycled-24"
+    evo-icon-certified-recycled-24
+
+  icon-example name="evo-icon-chair-16"
+    evo-icon-chair-16
+
+  icon-example name="evo-icon-chair-24"
+    evo-icon-chair-24
+
+  icon-example name="evo-icon-chase-12-colored"
+    evo-icon-chase-12-colored
+
+  icon-example name="evo-icon-chase-18-colored"
+    evo-icon-chase-18-colored
+
+  icon-example name="evo-icon-chase-24-colored"
+    evo-icon-chase-24-colored
+
+  icon-example name="evo-icon-chase-32-colored"
+    evo-icon-chase-32-colored
+
+  icon-example name="evo-icon-chat-16"
+    evo-icon-chat-16
+
+  icon-example name="evo-icon-chat-24"
+    evo-icon-chat-24
+
+  icon-example name="evo-icon-chat-64"
+    evo-icon-chat-64
+
+  icon-example name="evo-icon-check-in-24"
+    evo-icon-check-in-24
+
+  icon-example name="evo-icon-checkbox-checked-18"
+    evo-icon-checkbox-checked-18
+
+  icon-example name="evo-icon-checkbox-checked-24"
+    evo-icon-checkbox-checked-24
+
+  icon-example name="evo-icon-checkbox-mixed-18"
+    evo-icon-checkbox-mixed-18
+
+  icon-example name="evo-icon-checkbox-mixed-24"
+    evo-icon-checkbox-mixed-24
+
+  icon-example name="evo-icon-checkbox-unchecked-18"
+    evo-icon-checkbox-unchecked-18
+
+  icon-example name="evo-icon-checkbox-unchecked-24"
+    evo-icon-checkbox-unchecked-24
+
+  icon-example name="evo-icon-checkmark-24"
+    evo-icon-checkmark-24
+
+  icon-example name="evo-icon-chevron-down-12"
+    evo-icon-chevron-down-12
+
+  icon-example name="evo-icon-chevron-down-16"
+    evo-icon-chevron-down-16
+
+  icon-example name="evo-icon-chevron-down-20"
+    evo-icon-chevron-down-20
+
+  icon-example name="evo-icon-chevron-down-24"
+    evo-icon-chevron-down-24
+
+  icon-example name="evo-icon-chevron-left-12"
+    evo-icon-chevron-left-12
+
+  icon-example name="evo-icon-chevron-left-16"
+    evo-icon-chevron-left-16
+
+  icon-example name="evo-icon-chevron-left-20"
+    evo-icon-chevron-left-20
+
+  icon-example name="evo-icon-chevron-left-24"
+    evo-icon-chevron-left-24
+
+  icon-example name="evo-icon-chevron-right-12"
+    evo-icon-chevron-right-12
+
+  icon-example name="evo-icon-chevron-right-16"
+    evo-icon-chevron-right-16
+
+  icon-example name="evo-icon-chevron-right-20"
+    evo-icon-chevron-right-20
+
+  icon-example name="evo-icon-chevron-right-24"
+    evo-icon-chevron-right-24
+
+  icon-example name="evo-icon-chevron-up-12"
+    evo-icon-chevron-up-12
+
+  icon-example name="evo-icon-chevron-up-16"
+    evo-icon-chevron-up-16
+
+  icon-example name="evo-icon-chevron-up-20"
+    evo-icon-chevron-up-20
+
+  icon-example name="evo-icon-chevron-up-24"
+    evo-icon-chevron-up-24
+
+  icon-example name="evo-icon-chinese-coin-16"
+    evo-icon-chinese-coin-16
+
+  icon-example name="evo-icon-chinese-coin-24"
+    evo-icon-chinese-coin-24
+
+  icon-example name="evo-icon-citi-12-colored"
+    evo-icon-citi-12-colored
+
+  icon-example name="evo-icon-citi-18-colored"
+    evo-icon-citi-18-colored
+
+  icon-example name="evo-icon-citi-24-colored"
+    evo-icon-citi-24-colored
+
+  icon-example name="evo-icon-citi-32-colored"
+    evo-icon-citi-32-colored
+
+  icon-example name="evo-icon-clear-16"
+    evo-icon-clear-16
+
+  icon-example name="evo-icon-clear-20"
+    evo-icon-clear-20
+
+  icon-example name="evo-icon-clear-24"
+    evo-icon-clear-24
+
+  icon-example name="evo-icon-click-to-call-16"
+    evo-icon-click-to-call-16
+
+  icon-example name="evo-icon-click-to-call-24"
+    evo-icon-click-to-call-24
+
+  icon-example name="evo-icon-clock-12"
+    evo-icon-clock-12
+
+  icon-example name="evo-icon-clock-16"
+    evo-icon-clock-16
+
+  icon-example name="evo-icon-clock-24"
+    evo-icon-clock-24
+
+  icon-example name="evo-icon-clock-64"
+    evo-icon-clock-64
+
+  icon-example name="evo-icon-clock-fast-16"
+    evo-icon-clock-fast-16
+
+  icon-example name="evo-icon-clock-fast-24"
+    evo-icon-clock-fast-24
+
+  icon-example name="evo-icon-close-12"
+    evo-icon-close-12
+
+  icon-example name="evo-icon-close-16"
+    evo-icon-close-16
+
+  icon-example name="evo-icon-close-20"
+    evo-icon-close-20
+
+  icon-example name="evo-icon-close-24"
+    evo-icon-close-24
+
+  icon-example name="evo-icon-closed-caption-16"
+    evo-icon-closed-caption-16
+
+  icon-example name="evo-icon-closed-caption-24"
+    evo-icon-closed-caption-24
+
+  icon-example name="evo-icon-closed-caption-filled-16"
+    evo-icon-closed-caption-filled-16
+
+  icon-example name="evo-icon-closed-caption-filled-24"
+    evo-icon-closed-caption-filled-24
+
+  icon-example name="evo-icon-coin-24"
+    evo-icon-coin-24
+
+  icon-example name="evo-icon-coin-battery-48"
+    evo-icon-coin-battery-48
+
+  icon-example name="evo-icon-collections-16"
+    evo-icon-collections-16
+
+  icon-example name="evo-icon-collections-24"
+    evo-icon-collections-24
+
+  icon-example name="evo-icon-condensed-grid-24"
+    evo-icon-condensed-grid-24
+
+  icon-example name="evo-icon-condensed-grid-filled-24"
+    evo-icon-condensed-grid-filled-24
+
+  icon-example name="evo-icon-confirmation-16"
+    evo-icon-confirmation-16
+
+  icon-example name="evo-icon-confirmation-24"
+    evo-icon-confirmation-24
+
+  icon-example name="evo-icon-confirmation-64"
+    evo-icon-confirmation-64
+
+  icon-example name="evo-icon-confirmation-filled-12"
+    evo-icon-confirmation-filled-12
+
+  icon-example name="evo-icon-confirmation-filled-16"
+    evo-icon-confirmation-filled-16
+
+  icon-example name="evo-icon-confirmation-filled-24"
+    evo-icon-confirmation-filled-24
+
+  icon-example name="evo-icon-contract-16"
+    evo-icon-contract-16
+
+  icon-example name="evo-icon-contrast-24"
+    evo-icon-contrast-24
+
+  icon-example name="evo-icon-copy-16"
+    evo-icon-copy-16
+
+  icon-example name="evo-icon-copy-24"
+    evo-icon-copy-24
+
+  icon-example name="evo-icon-coupon-16"
+    evo-icon-coupon-16
+
+  icon-example name="evo-icon-coupon-20"
+    evo-icon-coupon-20
+
+  icon-example name="evo-icon-coupon-24"
+    evo-icon-coupon-24
+
+  icon-example name="evo-icon-credit-card-16"
+    evo-icon-credit-card-16
+
+  icon-example name="evo-icon-credit-card-20"
+    evo-icon-credit-card-20
+
+  icon-example name="evo-icon-credit-card-24"
+    evo-icon-credit-card-24
+
+  icon-example name="evo-icon-credit-card-64"
+    evo-icon-credit-card-64
+
+  icon-example name="evo-icon-credit-card-cvv-back-20"
+    evo-icon-credit-card-cvv-back-20
+
+  icon-example name="evo-icon-credit-card-cvv-back-24"
+    evo-icon-credit-card-cvv-back-24
+
+  icon-example name="evo-icon-credit-card-cvv-front-20"
+    evo-icon-credit-card-cvv-front-20
+
+  icon-example name="evo-icon-credit-card-cvv-front-24"
+    evo-icon-credit-card-cvv-front-24
+
+  icon-example name="evo-icon-crop-24"
+    evo-icon-crop-24
+
+  icon-example name="evo-icon-customize-16"
+    evo-icon-customize-16
+
+  icon-example name="evo-icon-customize-24"
+    evo-icon-customize-24
+
+  icon-example name="evo-icon-delete-16"
+    evo-icon-delete-16
+
+  icon-example name="evo-icon-delete-20"
+    evo-icon-delete-20
+
+  icon-example name="evo-icon-delete-24"
+    evo-icon-delete-24
+
+  icon-example name="evo-icon-density-compact-16"
+    evo-icon-density-compact-16
+
+  icon-example name="evo-icon-density-compact-24"
+    evo-icon-density-compact-24
+
+  icon-example name="evo-icon-density-default-16"
+    evo-icon-density-default-16
+
+  icon-example name="evo-icon-density-default-24"
+    evo-icon-density-default-24
+
+  icon-example name="evo-icon-density-relaxed-16"
+    evo-icon-density-relaxed-16
+
+  icon-example name="evo-icon-density-relaxed-24"
+    evo-icon-density-relaxed-24
+
+  icon-example name="evo-icon-density-row-compact-16"
+    evo-icon-density-row-compact-16
+
+  icon-example name="evo-icon-density-row-compact-24"
+    evo-icon-density-row-compact-24
+
+  icon-example name="evo-icon-density-row-relaxed-16"
+    evo-icon-density-row-relaxed-16
+
+  icon-example name="evo-icon-density-row-relaxed-24"
+    evo-icon-density-row-relaxed-24
+
+  icon-example name="evo-icon-desktop-16"
+    evo-icon-desktop-16
+
+  icon-example name="evo-icon-desktop-20"
+    evo-icon-desktop-20
+
+  icon-example name="evo-icon-desktop-24"
+    evo-icon-desktop-24
+
+  icon-example name="evo-icon-diamond-16"
+    evo-icon-diamond-16
+
+  icon-example name="evo-icon-diamond-24"
+    evo-icon-diamond-24
+
+  icon-example name="evo-icon-diners-12-colored"
+    evo-icon-diners-12-colored
+
+  icon-example name="evo-icon-diners-18-colored"
+    evo-icon-diners-18-colored
+
+  icon-example name="evo-icon-diners-24-colored"
+    evo-icon-diners-24-colored
+
+  icon-example name="evo-icon-diners-32-colored"
+    evo-icon-diners-32-colored
+
+  icon-example name="evo-icon-direct-debit-12-colored"
+    evo-icon-direct-debit-12-colored
+
+  icon-example name="evo-icon-direct-debit-18-colored"
+    evo-icon-direct-debit-18-colored
+
+  icon-example name="evo-icon-direct-debit-24-colored"
+    evo-icon-direct-debit-24-colored
+
+  icon-example name="evo-icon-direct-debit-32-colored"
+    evo-icon-direct-debit-32-colored
+
+  icon-example name="evo-icon-direct-from-brand-16"
+    evo-icon-direct-from-brand-16
+
+  icon-example name="evo-icon-direct-from-brand-24"
+    evo-icon-direct-from-brand-24
+
+  icon-example name="evo-icon-discord-24"
+    evo-icon-discord-24
+
+  icon-example name="evo-icon-discount-16"
+    evo-icon-discount-16
+
+  icon-example name="evo-icon-discount-24"
+    evo-icon-discount-24
+
+  icon-example name="evo-icon-discount-auto-16"
+    evo-icon-discount-auto-16
+
+  icon-example name="evo-icon-discount-auto-24"
+    evo-icon-discount-auto-24
+
+  icon-example name="evo-icon-discover-12-colored"
+    evo-icon-discover-12-colored
+
+  icon-example name="evo-icon-discover-18-colored"
+    evo-icon-discover-18-colored
+
+  icon-example name="evo-icon-discover-24-colored"
+    evo-icon-discover-24-colored
+
+  icon-example name="evo-icon-discover-32-colored"
+    evo-icon-discover-32-colored
+
+  icon-example name="evo-icon-dollar-16"
+    evo-icon-dollar-16
+
+  icon-example name="evo-icon-dollar-24"
+    evo-icon-dollar-24
+
+  icon-example name="evo-icon-dollar-off-24"
+    evo-icon-dollar-off-24
+
+  icon-example name="evo-icon-download-16"
+    evo-icon-download-16
+
+  icon-example name="evo-icon-download-20"
+    evo-icon-download-20
+
+  icon-example name="evo-icon-download-24"
+    evo-icon-download-24
+
+  icon-example name="evo-icon-drag-drop-16"
+    evo-icon-drag-drop-16
+
+  icon-example name="evo-icon-drag-drop-24"
+    evo-icon-drag-drop-24
+
+  icon-example name="evo-icon-ebay-balance-12-colored"
+    evo-icon-ebay-balance-12-colored
+
+  icon-example name="evo-icon-ebay-balance-18-colored"
+    evo-icon-ebay-balance-18-colored
+
+  icon-example name="evo-icon-ebay-balance-24-colored"
+    evo-icon-ebay-balance-24-colored
+
+  icon-example name="evo-icon-ebay-balance-32-colored"
+    evo-icon-ebay-balance-32-colored
+
+  icon-example name="evo-icon-ebay-bucks-logo-16-colored"
+    evo-icon-ebay-bucks-logo-16-colored
+
+  icon-example name="evo-icon-ebay-credit-card-black-12-colored"
+    evo-icon-ebay-credit-card-black-12-colored
+
+  icon-example name="evo-icon-ebay-credit-card-black-18-colored"
+    evo-icon-ebay-credit-card-black-18-colored
+
+  icon-example name="evo-icon-ebay-credit-card-black-24-colored"
+    evo-icon-ebay-credit-card-black-24-colored
+
+  icon-example name="evo-icon-ebay-credit-card-black-32-colored"
+    evo-icon-ebay-credit-card-black-32-colored
+
+  icon-example name="evo-icon-ebay-credit-card-purple-12-colored"
+    evo-icon-ebay-credit-card-purple-12-colored
+
+  icon-example name="evo-icon-ebay-credit-card-purple-18-colored"
+    evo-icon-ebay-credit-card-purple-18-colored
+
+  icon-example name="evo-icon-ebay-credit-card-purple-24-colored"
+    evo-icon-ebay-credit-card-purple-24-colored
+
+  icon-example name="evo-icon-ebay-credit-card-purple-32-colored"
+    evo-icon-ebay-credit-card-purple-32-colored
+
+  icon-example name="evo-icon-ebay-credit-card-white-12-colored"
+    evo-icon-ebay-credit-card-white-12-colored
+
+  icon-example name="evo-icon-ebay-credit-card-white-18-colored"
+    evo-icon-ebay-credit-card-white-18-colored
+
+  icon-example name="evo-icon-ebay-credit-card-white-24-colored"
+    evo-icon-ebay-credit-card-white-24-colored
+
+  icon-example name="evo-icon-ebay-credit-card-white-32-colored"
+    evo-icon-ebay-credit-card-white-32-colored
+
+  icon-example name="evo-icon-ebay-for-charity-16"
+    evo-icon-ebay-for-charity-16
+
+  icon-example name="evo-icon-ebay-for-charity-24"
+    evo-icon-ebay-for-charity-24
+
+  icon-example name="evo-icon-ebay-international-shipping-16"
+    evo-icon-ebay-international-shipping-16
+
+  icon-example name="evo-icon-ebay-international-shipping-24"
+    evo-icon-ebay-international-shipping-24
+
+  icon-example name="evo-icon-ebay-international-shipping-64"
+    evo-icon-ebay-international-shipping-64
+
+  icon-example name="evo-icon-ebay-live-16"
+    evo-icon-ebay-live-16
+
+  icon-example name="evo-icon-ebay-live-24"
+    evo-icon-ebay-live-24
+
+  icon-example name="evo-icon-ebay-logo-16-colored"
+    evo-icon-ebay-logo-16-colored
+
+  icon-example name="evo-icon-ebay-mastercard-12-colored"
+    evo-icon-ebay-mastercard-12-colored
+
+  icon-example name="evo-icon-ebay-mastercard-18-colored"
+    evo-icon-ebay-mastercard-18-colored
+
+  icon-example name="evo-icon-ebay-mastercard-24-colored"
+    evo-icon-ebay-mastercard-24-colored
+
+  icon-example name="evo-icon-ebay-mastercard-32-colored"
+    evo-icon-ebay-mastercard-32-colored
+
+  icon-example name="evo-icon-ebay-money-back-guarantee-logo-16-colored"
+    evo-icon-ebay-money-back-guarantee-logo-16-colored
+
+  icon-example name="evo-icon-ebay-plus-16"
+    evo-icon-ebay-plus-16
+
+  icon-example name="evo-icon-ebay-plus-24"
+    evo-icon-ebay-plus-24
+
+  icon-example name="evo-icon-ebay-plus-logo-16-colored"
+    evo-icon-ebay-plus-logo-16-colored
+
+  icon-example name="evo-icon-ebay-plus-logo-dark-16-colored"
+    evo-icon-ebay-plus-logo-dark-16-colored
+
+  icon-example name="evo-icon-ebay-preloved-16"
+    evo-icon-ebay-preloved-16
+
+  icon-example name="evo-icon-ebay-preloved-24"
+    evo-icon-ebay-preloved-24
+
+  icon-example name="evo-icon-ebay-refurbished-16"
+    evo-icon-ebay-refurbished-16
+
+  icon-example name="evo-icon-ebay-refurbished-24"
+    evo-icon-ebay-refurbished-24
+
+  icon-example name="evo-icon-eftpos-12-colored"
+    evo-icon-eftpos-12-colored
+
+  icon-example name="evo-icon-eftpos-18-colored"
+    evo-icon-eftpos-18-colored
+
+  icon-example name="evo-icon-eftpos-24-colored"
+    evo-icon-eftpos-24-colored
+
+  icon-example name="evo-icon-eftpos-32-colored"
+    evo-icon-eftpos-32-colored
+
+  icon-example name="evo-icon-elo-12-colored"
+    evo-icon-elo-12-colored
+
+  icon-example name="evo-icon-elo-18-colored"
+    evo-icon-elo-18-colored
+
+  icon-example name="evo-icon-elo-24-colored"
+    evo-icon-elo-24-colored
+
+  icon-example name="evo-icon-elo-32-colored"
+    evo-icon-elo-32-colored
+
+  icon-example name="evo-icon-escrow-card-12-colored"
+    evo-icon-escrow-card-12-colored
+
+  icon-example name="evo-icon-escrow-card-18-colored"
+    evo-icon-escrow-card-18-colored
+
+  icon-example name="evo-icon-escrow-card-24-colored"
+    evo-icon-escrow-card-24-colored
+
+  icon-example name="evo-icon-escrow-card-32-colored"
+    evo-icon-escrow-card-32-colored
+
+  icon-example name="evo-icon-euro-16"
+    evo-icon-euro-16
+
+  icon-example name="evo-icon-euro-24"
+    evo-icon-euro-24
+
+  icon-example name="evo-icon-european-conformity-48"
+    evo-icon-european-conformity-48
+
+  icon-example name="evo-icon-exclude-16"
+    evo-icon-exclude-16
+
+  icon-example name="evo-icon-exclude-24"
+    evo-icon-exclude-24
+
+  icon-example name="evo-icon-exclude-64"
+    evo-icon-exclude-64
+
+  icon-example name="evo-icon-expand-16"
+    evo-icon-expand-16
+
+  icon-example name="evo-icon-explore-16"
+    evo-icon-explore-16
+
+  icon-example name="evo-icon-explore-24"
+    evo-icon-explore-24
+
+  icon-example name="evo-icon-external-link-16"
+    evo-icon-external-link-16
+
+  icon-example name="evo-icon-external-link-20"
+    evo-icon-external-link-20
+
+  icon-example name="evo-icon-external-link-24"
+    evo-icon-external-link-24
+
+  icon-example name="evo-icon-eye-16"
+    evo-icon-eye-16
+
+  icon-example name="evo-icon-eye-24"
+    evo-icon-eye-24
+
+  icon-example name="evo-icon-face-happiest-24"
+    evo-icon-face-happiest-24
+
+  icon-example name="evo-icon-face-happy-16"
+    evo-icon-face-happy-16
+
+  icon-example name="evo-icon-face-happy-24"
+    evo-icon-face-happy-24
+
+  icon-example name="evo-icon-face-neutral-24"
+    evo-icon-face-neutral-24
+
+  icon-example name="evo-icon-face-sad-24"
+    evo-icon-face-sad-24
+
+  icon-example name="evo-icon-face-saddest-24"
+    evo-icon-face-saddest-24
+
+  icon-example name="evo-icon-facebook-24"
+    evo-icon-facebook-24
+
+  icon-example name="evo-icon-facebook-messenger-24"
+    evo-icon-facebook-messenger-24
+
+  icon-example name="evo-icon-fall-leaf-16"
+    evo-icon-fall-leaf-16
+
+  icon-example name="evo-icon-fall-leaf-24"
+    evo-icon-fall-leaf-24
+
+  icon-example name="evo-icon-fast-forward-16"
+    evo-icon-fast-forward-16
+
+  icon-example name="evo-icon-feedback-16"
+    evo-icon-feedback-16
+
+  icon-example name="evo-icon-feedback-20"
+    evo-icon-feedback-20
+
+  icon-example name="evo-icon-feedback-24"
+    evo-icon-feedback-24
+
+  icon-example name="evo-icon-feedback-error-16"
+    evo-icon-feedback-error-16
+
+  icon-example name="evo-icon-feedback-error-24"
+    evo-icon-feedback-error-24
+
+  icon-example name="evo-icon-feedback-negative-16"
+    evo-icon-feedback-negative-16
+
+  icon-example name="evo-icon-feedback-neutral-16"
+    evo-icon-feedback-neutral-16
+
+  icon-example name="evo-icon-feedback-positive-16"
+    evo-icon-feedback-positive-16
+
+  icon-example name="evo-icon-feedback-received-16"
+    evo-icon-feedback-received-16
+
+  icon-example name="evo-icon-feedback-received-24"
+    evo-icon-feedback-received-24
+
+  icon-example name="evo-icon-file-16"
+    evo-icon-file-16
+
+  icon-example name="evo-icon-file-24"
+    evo-icon-file-24
+
+  icon-example name="evo-icon-filter-16"
+    evo-icon-filter-16
+
+  icon-example name="evo-icon-filter-24"
+    evo-icon-filter-24
+
+  icon-example name="evo-icon-fingerprint-16"
+    evo-icon-fingerprint-16
+
+  icon-example name="evo-icon-fingerprint-24"
+    evo-icon-fingerprint-24
+
+  icon-example name="evo-icon-fingerprint-64"
+    evo-icon-fingerprint-64
+
+  icon-example name="evo-icon-flag-16"
+    evo-icon-flag-16
+
+  icon-example name="evo-icon-flag-24"
+    evo-icon-flag-24
+
+  icon-example name="evo-icon-flag-filled-16"
+    evo-icon-flag-filled-16
+
+  icon-example name="evo-icon-flag-filled-24"
+    evo-icon-flag-filled-24
+
+  icon-example name="evo-icon-flash-24"
+    evo-icon-flash-24
+
+  icon-example name="evo-icon-flash-auto-24"
+    evo-icon-flash-auto-24
+
+  icon-example name="evo-icon-flash-off-24"
+    evo-icon-flash-off-24
+
+  icon-example name="evo-icon-folder-16"
+    evo-icon-folder-16
+
+  icon-example name="evo-icon-folder-24"
+    evo-icon-folder-24
+
+  icon-example name="evo-icon-folder-add-16"
+    evo-icon-folder-add-16
+
+  icon-example name="evo-icon-folder-add-24"
+    evo-icon-folder-add-24
+
+  icon-example name="evo-icon-forklift-16"
+    evo-icon-forklift-16
+
+  icon-example name="evo-icon-forklift-24"
+    evo-icon-forklift-24
+
+  icon-example name="evo-icon-franc-16"
+    evo-icon-franc-16
+
+  icon-example name="evo-icon-franc-24"
+    evo-icon-franc-24
+
+  icon-example name="evo-icon-free-warranty-16"
+    evo-icon-free-warranty-16
+
+  icon-example name="evo-icon-free-warranty-24"
+    evo-icon-free-warranty-24
+
+  icon-example name="evo-icon-full-view-16"
+    evo-icon-full-view-16
+
+  icon-example name="evo-icon-full-view-24"
+    evo-icon-full-view-24
+
+  icon-example name="evo-icon-full-view-filled-16"
+    evo-icon-full-view-filled-16
+
+  icon-example name="evo-icon-full-view-filled-24"
+    evo-icon-full-view-filled-24
+
+  icon-example name="evo-icon-gallery-16"
+    evo-icon-gallery-16
+
+  icon-example name="evo-icon-gallery-24"
+    evo-icon-gallery-24
+
+  icon-example name="evo-icon-general-card-12-colored"
+    evo-icon-general-card-12-colored
+
+  icon-example name="evo-icon-general-card-18-colored"
+    evo-icon-general-card-18-colored
+
+  icon-example name="evo-icon-general-card-24-colored"
+    evo-icon-general-card-24-colored
+
+  icon-example name="evo-icon-general-card-32-colored"
+    evo-icon-general-card-32-colored
+
+  icon-example name="evo-icon-generic-card-12-colored"
+    evo-icon-generic-card-12-colored
+
+  icon-example name="evo-icon-generic-card-18-colored"
+    evo-icon-generic-card-18-colored
+
+  icon-example name="evo-icon-generic-card-24-colored"
+    evo-icon-generic-card-24-colored
+
+  icon-example name="evo-icon-generic-card-32-colored"
+    evo-icon-generic-card-32-colored
+
+  icon-example name="evo-icon-gift-16"
+    evo-icon-gift-16
+
+  icon-example name="evo-icon-gift-20"
+    evo-icon-gift-20
+
+  icon-example name="evo-icon-gift-24"
+    evo-icon-gift-24
+
+  icon-example name="evo-icon-gift-64"
+    evo-icon-gift-64
+
+  icon-example name="evo-icon-gift-card-12-colored"
+    evo-icon-gift-card-12-colored
+
+  icon-example name="evo-icon-gift-card-18-colored"
+    evo-icon-gift-card-18-colored
+
+  icon-example name="evo-icon-gift-card-24-colored"
+    evo-icon-gift-card-24-colored
+
+  icon-example name="evo-icon-gift-card-32-colored"
+    evo-icon-gift-card-32-colored
+
+  icon-example name="evo-icon-girocard-12-colored"
+    evo-icon-girocard-12-colored
+
+  icon-example name="evo-icon-girocard-18-colored"
+    evo-icon-girocard-18-colored
+
+  icon-example name="evo-icon-girocard-24-colored"
+    evo-icon-girocard-24-colored
+
+  icon-example name="evo-icon-girocard-32-colored"
+    evo-icon-girocard-32-colored
+
+  icon-example name="evo-icon-github-24"
+    evo-icon-github-24
+
+  icon-example name="evo-icon-glasses-24"
+    evo-icon-glasses-24
+
+  icon-example name="evo-icon-glasses-64"
+    evo-icon-glasses-64
+
+  icon-example name="evo-icon-google-24"
+    evo-icon-google-24
+
+  icon-example name="evo-icon-google-pay-12-colored"
+    evo-icon-google-pay-12-colored
+
+  icon-example name="evo-icon-google-pay-18-colored"
+    evo-icon-google-pay-18-colored
+
+  icon-example name="evo-icon-google-pay-24-colored"
+    evo-icon-google-pay-24-colored
+
+  icon-example name="evo-icon-google-pay-32-colored"
+    evo-icon-google-pay-32-colored
+
+  icon-example name="evo-icon-graph-16"
+    evo-icon-graph-16
+
+  icon-example name="evo-icon-graph-24"
+    evo-icon-graph-24
+
+  icon-example name="evo-icon-graph-64"
+    evo-icon-graph-64
+
+  icon-example name="evo-icon-graph-dynamic-16"
+    evo-icon-graph-dynamic-16
+
+  icon-example name="evo-icon-graph-dynamic-24"
+    evo-icon-graph-dynamic-24
+
+  icon-example name="evo-icon-grid-view-16"
+    evo-icon-grid-view-16
+
+  icon-example name="evo-icon-grid-view-24"
+    evo-icon-grid-view-24
+
+  icon-example name="evo-icon-grid-view-filled-16"
+    evo-icon-grid-view-filled-16
+
+  icon-example name="evo-icon-grid-view-filled-24"
+    evo-icon-grid-view-filled-24
+
+  icon-example name="evo-icon-guaranteed-fit-filled-16"
+    evo-icon-guaranteed-fit-filled-16
+
+  icon-example name="evo-icon-guaranteed-fit-filled-24"
+    evo-icon-guaranteed-fit-filled-24
+
+  icon-example name="evo-icon-hand-swipe-40"
+    evo-icon-hand-swipe-40
+
+  icon-example name="evo-icon-handbag-16"
+    evo-icon-handbag-16
+
+  icon-example name="evo-icon-handbag-24"
+    evo-icon-handbag-24
+
+  icon-example name="evo-icon-hanger-16"
+    evo-icon-hanger-16
+
+  icon-example name="evo-icon-hanger-24"
+    evo-icon-hanger-24
+
+  icon-example name="evo-icon-headlight-16"
+    evo-icon-headlight-16
+
+  icon-example name="evo-icon-headlight-24"
+    evo-icon-headlight-24
+
+  icon-example name="evo-icon-headphone-16"
+    evo-icon-headphone-16
+
+  icon-example name="evo-icon-headphone-24"
+    evo-icon-headphone-24
+
+  icon-example name="evo-icon-heart-16"
+    evo-icon-heart-16
+
+  icon-example name="evo-icon-heart-20"
+    evo-icon-heart-20
+
+  icon-example name="evo-icon-heart-24"
+    evo-icon-heart-24
+
+  icon-example name="evo-icon-heart-filled-16"
+    evo-icon-heart-filled-16
+
+  icon-example name="evo-icon-heart-filled-20"
+    evo-icon-heart-filled-20
+
+  icon-example name="evo-icon-heart-filled-24"
+    evo-icon-heart-filled-24
+
+  icon-example name="evo-icon-help-16"
+    evo-icon-help-16
+
+  icon-example name="evo-icon-help-20"
+    evo-icon-help-20
+
+  icon-example name="evo-icon-help-24"
+    evo-icon-help-24
+
+  icon-example name="evo-icon-help-outline-16"
+    evo-icon-help-outline-16
+
+  icon-example name="evo-icon-help-outline-20"
+    evo-icon-help-outline-20
+
+  icon-example name="evo-icon-help-outline-24"
+    evo-icon-help-outline-24
+
+  icon-example name="evo-icon-hide-16"
+    evo-icon-hide-16
+
+  icon-example name="evo-icon-hide-24"
+    evo-icon-hide-24
+
+  icon-example name="evo-icon-history-16"
+    evo-icon-history-16
+
+  icon-example name="evo-icon-history-24"
+    evo-icon-history-24
+
+  icon-example name="evo-icon-history-64"
+    evo-icon-history-64
+
+  icon-example name="evo-icon-home-16"
+    evo-icon-home-16
+
+  icon-example name="evo-icon-home-20"
+    evo-icon-home-20
+
+  icon-example name="evo-icon-home-24"
+    evo-icon-home-24
+
+  icon-example name="evo-icon-home-filled-24"
+    evo-icon-home-filled-24
+
+  icon-example name="evo-icon-image-16"
+    evo-icon-image-16
+
+  icon-example name="evo-icon-image-24"
+    evo-icon-image-24
+
+  icon-example name="evo-icon-image-64"
+    evo-icon-image-64
+
+  icon-example name="evo-icon-inbox-16"
+    evo-icon-inbox-16
+
+  icon-example name="evo-icon-inbox-24"
+    evo-icon-inbox-24
+
+  icon-example name="evo-icon-information-12"
+    evo-icon-information-12
+
+  icon-example name="evo-icon-information-16"
+    evo-icon-information-16
+
+  icon-example name="evo-icon-information-20"
+    evo-icon-information-20
+
+  icon-example name="evo-icon-information-24"
+    evo-icon-information-24
+
+  icon-example name="evo-icon-information-filled-16"
+    evo-icon-information-filled-16
+
+  icon-example name="evo-icon-information-filled-20"
+    evo-icon-information-filled-20
+
+  icon-example name="evo-icon-information-filled-24"
+    evo-icon-information-filled-24
+
+  icon-example name="evo-icon-inspect-16"
+    evo-icon-inspect-16
+
+  icon-example name="evo-icon-inspect-24"
+    evo-icon-inspect-24
+
+  icon-example name="evo-icon-inspect-64"
+    evo-icon-inspect-64
+
+  icon-example name="evo-icon-instagram-24"
+    evo-icon-instagram-24
+
+  icon-example name="evo-icon-interac-12-colored"
+    evo-icon-interac-12-colored
+
+  icon-example name="evo-icon-interac-18-colored"
+    evo-icon-interac-18-colored
+
+  icon-example name="evo-icon-interac-24-colored"
+    evo-icon-interac-24-colored
+
+  icon-example name="evo-icon-interac-32-colored"
+    evo-icon-interac-32-colored
+
+  icon-example name="evo-icon-item-list-16"
+    evo-icon-item-list-16
+
+  icon-example name="evo-icon-item-list-20"
+    evo-icon-item-list-20
+
+  icon-example name="evo-icon-item-list-24"
+    evo-icon-item-list-24
+
+  icon-example name="evo-icon-jcb-12-colored"
+    evo-icon-jcb-12-colored
+
+  icon-example name="evo-icon-jcb-18-colored"
+    evo-icon-jcb-18-colored
+
+  icon-example name="evo-icon-jcb-24-colored"
+    evo-icon-jcb-24-colored
+
+  icon-example name="evo-icon-jcb-32-colored"
+    evo-icon-jcb-32-colored
+
+  icon-example name="evo-icon-jet-ski-16"
+    evo-icon-jet-ski-16
+
+  icon-example name="evo-icon-jet-ski-24"
+    evo-icon-jet-ski-24
+
+  icon-example name="evo-icon-kakao-pay-12-colored"
+    evo-icon-kakao-pay-12-colored
+
+  icon-example name="evo-icon-kakao-pay-18-colored"
+    evo-icon-kakao-pay-18-colored
+
+  icon-example name="evo-icon-kakao-pay-24-colored"
+    evo-icon-kakao-pay-24-colored
+
+  icon-example name="evo-icon-kakao-pay-32-colored"
+    evo-icon-kakao-pay-32-colored
+
+  icon-example name="evo-icon-key-16"
+    evo-icon-key-16
+
+  icon-example name="evo-icon-key-24"
+    evo-icon-key-24
+
+  icon-example name="evo-icon-keyboard-16"
+    evo-icon-keyboard-16
+
+  icon-example name="evo-icon-keyboard-24"
+    evo-icon-keyboard-24
+
+  icon-example name="evo-icon-klarna-black-12-colored"
+    evo-icon-klarna-black-12-colored
+
+  icon-example name="evo-icon-klarna-black-18-colored"
+    evo-icon-klarna-black-18-colored
+
+  icon-example name="evo-icon-klarna-black-24-colored"
+    evo-icon-klarna-black-24-colored
+
+  icon-example name="evo-icon-klarna-black-32-colored"
+    evo-icon-klarna-black-32-colored
+
+  icon-example name="evo-icon-klarna-pink-12-colored"
+    evo-icon-klarna-pink-12-colored
+
+  icon-example name="evo-icon-klarna-pink-18-colored"
+    evo-icon-klarna-pink-18-colored
+
+  icon-example name="evo-icon-klarna-pink-24-colored"
+    evo-icon-klarna-pink-24-colored
+
+  icon-example name="evo-icon-klarna-pink-32-colored"
+    evo-icon-klarna-pink-32-colored
+
+  icon-example name="evo-icon-klarna-white-12-colored"
+    evo-icon-klarna-white-12-colored
+
+  icon-example name="evo-icon-klarna-white-18-colored"
+    evo-icon-klarna-white-18-colored
+
+  icon-example name="evo-icon-klarna-white-24-colored"
+    evo-icon-klarna-white-24-colored
+
+  icon-example name="evo-icon-klarna-white-32-colored"
+    evo-icon-klarna-white-32-colored
+
+  icon-example name="evo-icon-krona-16"
+    evo-icon-krona-16
+
+  icon-example name="evo-icon-krona-24"
+    evo-icon-krona-24
+
+  icon-example name="evo-icon-lamp-16"
+    evo-icon-lamp-16
+
+  icon-example name="evo-icon-lamp-24"
+    evo-icon-lamp-24
+
+  icon-example name="evo-icon-large-box-16"
+    evo-icon-large-box-16
+
+  icon-example name="evo-icon-large-box-24"
+    evo-icon-large-box-24
+
+  icon-example name="evo-icon-legacy-authenticity-guarantee-48-colored"
+    evo-icon-legacy-authenticity-guarantee-48-colored
+
+  icon-example name="evo-icon-legacy-click-to-call-48-colored"
+    evo-icon-legacy-click-to-call-48-colored
+
+  icon-example name="evo-icon-legacy-escrow-48-colored"
+    evo-icon-legacy-escrow-48-colored
+
+  icon-example name="evo-icon-legacy-free-warranty-48-colored"
+    evo-icon-legacy-free-warranty-48-colored
+
+  icon-example name="evo-icon-legacy-money-back-guarantee-chf-48-colored"
+    evo-icon-legacy-money-back-guarantee-chf-48-colored
+
+  icon-example name="evo-icon-legacy-money-back-guarantee-eu-48-colored"
+    evo-icon-legacy-money-back-guarantee-eu-48-colored
+
+  icon-example name="evo-icon-legacy-money-back-guarantee-uk-48-colored"
+    evo-icon-legacy-money-back-guarantee-uk-48-colored
+
+  icon-example name="evo-icon-legacy-money-back-guarantee-us-48-colored"
+    evo-icon-legacy-money-back-guarantee-us-48-colored
+
+  icon-example name="evo-icon-legacy-money-back-guarantee-zl-48-colored"
+    evo-icon-legacy-money-back-guarantee-zl-48-colored
+
+  icon-example name="evo-icon-legacy-top-rated-seller-48-colored"
+    evo-icon-legacy-top-rated-seller-48-colored
+
+  icon-example name="evo-icon-lightbulb-16"
+    evo-icon-lightbulb-16
+
+  icon-example name="evo-icon-lightbulb-24"
+    evo-icon-lightbulb-24
+
+  icon-example name="evo-icon-lightning-bolt-16"
+    evo-icon-lightning-bolt-16
+
+  icon-example name="evo-icon-lightning-bolt-24"
+    evo-icon-lightning-bolt-24
+
+  icon-example name="evo-icon-lightning-bolt-filled-12"
+    evo-icon-lightning-bolt-filled-12
+
+  icon-example name="evo-icon-lightning-bolt-filled-16"
+    evo-icon-lightning-bolt-filled-16
+
+  icon-example name="evo-icon-lightning-bolt-filled-24"
+    evo-icon-lightning-bolt-filled-24
+
+  icon-example name="evo-icon-link-16"
+    evo-icon-link-16
+
+  icon-example name="evo-icon-link-20"
+    evo-icon-link-20
+
+  icon-example name="evo-icon-link-24"
+    evo-icon-link-24
+
+  icon-example name="evo-icon-linkedin-24"
+    evo-icon-linkedin-24
+
+  icon-example name="evo-icon-list-view-16"
+    evo-icon-list-view-16
+
+  icon-example name="evo-icon-list-view-24"
+    evo-icon-list-view-24
+
+  icon-example name="evo-icon-list-view-filled-16"
+    evo-icon-list-view-filled-16
+
+  icon-example name="evo-icon-list-view-filled-24"
+    evo-icon-list-view-filled-24
+
+  icon-example name="evo-icon-live-bag-16"
+    evo-icon-live-bag-16
+
+  icon-example name="evo-icon-live-bag-20"
+    evo-icon-live-bag-20
+
+  icon-example name="evo-icon-live-bag-24"
+    evo-icon-live-bag-24
+
+  icon-example name="evo-icon-live-bag-filled-24"
+    evo-icon-live-bag-filled-24
+
+  icon-example name="evo-icon-live-bag-play-filled-16-colored"
+    evo-icon-live-bag-play-filled-16-colored
+
+  icon-example name="evo-icon-live-bag-play-filled-24-colored"
+    evo-icon-live-bag-play-filled-24-colored
+
+  icon-example name="evo-icon-live-bag-play-filled-64-colored"
+    evo-icon-live-bag-play-filled-64-colored
+
+  icon-example name="evo-icon-live-bag-thin-16"
+    evo-icon-live-bag-thin-16
+
+  icon-example name="evo-icon-live-broadcast-16"
+    evo-icon-live-broadcast-16
+
+  icon-example name="evo-icon-live-broadcast-20"
+    evo-icon-live-broadcast-20
+
+  icon-example name="evo-icon-live-broadcast-24"
+    evo-icon-live-broadcast-24
+
+  icon-example name="evo-icon-live-broadcast-filled-24"
+    evo-icon-live-broadcast-filled-24
+
+  icon-example name="evo-icon-live-broadcast-thin-16"
+    evo-icon-live-broadcast-thin-16
+
+  icon-example name="evo-icon-live-eye-16"
+    evo-icon-live-eye-16
+
+  icon-example name="evo-icon-live-eye-24"
+    evo-icon-live-eye-24
+
+  icon-example name="evo-icon-location-16"
+    evo-icon-location-16
+
+  icon-example name="evo-icon-location-24"
+    evo-icon-location-24
+
+  icon-example name="evo-icon-location-64"
+    evo-icon-location-64
+
+  icon-example name="evo-icon-location-arrow-16"
+    evo-icon-location-arrow-16
+
+  icon-example name="evo-icon-location-arrow-24"
+    evo-icon-location-arrow-24
+
+  icon-example name="evo-icon-lock-16"
+    evo-icon-lock-16
+
+  icon-example name="evo-icon-lock-24"
+    evo-icon-lock-24
+
+  icon-example name="evo-icon-lock-filled-16"
+    evo-icon-lock-filled-16
+
+  icon-example name="evo-icon-lock-filled-20"
+    evo-icon-lock-filled-20
+
+  icon-example name="evo-icon-lock-filled-24"
+    evo-icon-lock-filled-24
+
+  icon-example name="evo-icon-locker-16"
+    evo-icon-locker-16
+
+  icon-example name="evo-icon-locker-24"
+    evo-icon-locker-24
+
+  icon-example name="evo-icon-locker-64"
+    evo-icon-locker-64
+
+  icon-example name="evo-icon-maestro-12-colored"
+    evo-icon-maestro-12-colored
+
+  icon-example name="evo-icon-maestro-18-colored"
+    evo-icon-maestro-18-colored
+
+  icon-example name="evo-icon-maestro-24-colored"
+    evo-icon-maestro-24-colored
+
+  icon-example name="evo-icon-maestro-32-colored"
+    evo-icon-maestro-32-colored
+
+  icon-example name="evo-icon-mail-16"
+    evo-icon-mail-16
+
+  icon-example name="evo-icon-mail-20"
+    evo-icon-mail-20
+
+  icon-example name="evo-icon-mail-24"
+    evo-icon-mail-24
+
+  icon-example name="evo-icon-mail-64"
+    evo-icon-mail-64
+
+  icon-example name="evo-icon-mail-move-16"
+    evo-icon-mail-move-16
+
+  icon-example name="evo-icon-mail-move-24"
+    evo-icon-mail-move-24
+
+  icon-example name="evo-icon-mail-open-16"
+    evo-icon-mail-open-16
+
+  icon-example name="evo-icon-mail-open-24"
+    evo-icon-mail-open-24
+
+  icon-example name="evo-icon-mail-unread-16"
+    evo-icon-mail-unread-16
+
+  icon-example name="evo-icon-mail-unread-24"
+    evo-icon-mail-unread-24
+
+  icon-example name="evo-icon-map-16"
+    evo-icon-map-16
+
+  icon-example name="evo-icon-map-20"
+    evo-icon-map-20
+
+  icon-example name="evo-icon-map-24"
+    evo-icon-map-24
+
+  icon-example name="evo-icon-markdown-16"
+    evo-icon-markdown-16
+
+  icon-example name="evo-icon-markdown-20"
+    evo-icon-markdown-20
+
+  icon-example name="evo-icon-markdown-24"
+    evo-icon-markdown-24
+
+  icon-example name="evo-icon-masonry-view-16"
+    evo-icon-masonry-view-16
+
+  icon-example name="evo-icon-masonry-view-24"
+    evo-icon-masonry-view-24
+
+  icon-example name="evo-icon-masonry-view-filled-16"
+    evo-icon-masonry-view-filled-16
+
+  icon-example name="evo-icon-masonry-view-filled-24"
+    evo-icon-masonry-view-filled-24
+
+  icon-example name="evo-icon-mastercard-12-colored"
+    evo-icon-mastercard-12-colored
+
+  icon-example name="evo-icon-mastercard-18-colored"
+    evo-icon-mastercard-18-colored
+
+  icon-example name="evo-icon-mastercard-24-colored"
+    evo-icon-mastercard-24-colored
+
+  icon-example name="evo-icon-mastercard-32-colored"
+    evo-icon-mastercard-32-colored
+
+  icon-example name="evo-icon-medium-box-16"
+    evo-icon-medium-box-16
+
+  icon-example name="evo-icon-medium-box-24"
+    evo-icon-medium-box-24
+
+  icon-example name="evo-icon-megaphone-16"
+    evo-icon-megaphone-16
+
+  icon-example name="evo-icon-megaphone-24"
+    evo-icon-megaphone-24
+
+  icon-example name="evo-icon-menu-16"
+    evo-icon-menu-16
+
+  icon-example name="evo-icon-menu-20"
+    evo-icon-menu-20
+
+  icon-example name="evo-icon-menu-24"
+    evo-icon-menu-24
+
+  icon-example name="evo-icon-mercado-pago-12-colored"
+    evo-icon-mercado-pago-12-colored
+
+  icon-example name="evo-icon-mercado-pago-18-colored"
+    evo-icon-mercado-pago-18-colored
+
+  icon-example name="evo-icon-mercado-pago-24-colored"
+    evo-icon-mercado-pago-24-colored
+
+  icon-example name="evo-icon-mercado-pago-32-colored"
+    evo-icon-mercado-pago-32-colored
+
+  icon-example name="evo-icon-microphone-16"
+    evo-icon-microphone-16
+
+  icon-example name="evo-icon-microphone-24"
+    evo-icon-microphone-24
+
+  icon-example name="evo-icon-mobile-16"
+    evo-icon-mobile-16
+
+  icon-example name="evo-icon-mobile-20"
+    evo-icon-mobile-20
+
+  icon-example name="evo-icon-mobile-24"
+    evo-icon-mobile-24
+
+  icon-example name="evo-icon-mobile-signal-24"
+    evo-icon-mobile-signal-24
+
+  icon-example name="evo-icon-money-back-guarantee-16"
+    evo-icon-money-back-guarantee-16
+
+  icon-example name="evo-icon-money-back-guarantee-24"
+    evo-icon-money-back-guarantee-24
+
+  icon-example name="evo-icon-money-back-guarantee-filled-16"
+    evo-icon-money-back-guarantee-filled-16
+
+  icon-example name="evo-icon-money-back-guarantee-filled-16-colored"
+    evo-icon-money-back-guarantee-filled-16-colored
+
+  icon-example name="evo-icon-money-back-guarantee-filled-24"
+    evo-icon-money-back-guarantee-filled-24
+
+  icon-example name="evo-icon-money-back-guarantee-filled-24-colored"
+    evo-icon-money-back-guarantee-filled-24-colored
+
+  icon-example name="evo-icon-money-stack-16"
+    evo-icon-money-stack-16
+
+  icon-example name="evo-icon-money-stack-20"
+    evo-icon-money-stack-20
+
+  icon-example name="evo-icon-money-stack-24"
+    evo-icon-money-stack-24
+
+  icon-example name="evo-icon-money-stack-blue-12-colored"
+    evo-icon-money-stack-blue-12-colored
+
+  icon-example name="evo-icon-money-stack-blue-18-colored"
+    evo-icon-money-stack-blue-18-colored
+
+  icon-example name="evo-icon-money-stack-blue-24-colored"
+    evo-icon-money-stack-blue-24-colored
+
+  icon-example name="evo-icon-money-stack-blue-32-colored"
+    evo-icon-money-stack-blue-32-colored
+
+  icon-example name="evo-icon-monthly-invoice-12-colored"
+    evo-icon-monthly-invoice-12-colored
+
+  icon-example name="evo-icon-monthly-invoice-18-colored"
+    evo-icon-monthly-invoice-18-colored
+
+  icon-example name="evo-icon-monthly-invoice-24-colored"
+    evo-icon-monthly-invoice-24-colored
+
+  icon-example name="evo-icon-monthly-invoice-32-colored"
+    evo-icon-monthly-invoice-32-colored
+
+  icon-example name="evo-icon-moon-16"
+    evo-icon-moon-16
+
+  icon-example name="evo-icon-moon-20"
+    evo-icon-moon-20
+
+  icon-example name="evo-icon-moon-24"
+    evo-icon-moon-24
+
+  icon-example name="evo-icon-motorcycle-16"
+    evo-icon-motorcycle-16
+
+  icon-example name="evo-icon-motorcycle-24"
+    evo-icon-motorcycle-24
+
+  icon-example name="evo-icon-mountain-16"
+    evo-icon-mountain-16
+
+  icon-example name="evo-icon-mountain-24"
+    evo-icon-mountain-24
+
+  icon-example name="evo-icon-move-16"
+    evo-icon-move-16
+
+  icon-example name="evo-icon-move-24"
+    evo-icon-move-24
+
+  icon-example name="evo-icon-nectar-logo-24-colored"
+    evo-icon-nectar-logo-24-colored
+
+  icon-example name="evo-icon-negative-filled-16"
+    evo-icon-negative-filled-16
+
+  icon-example name="evo-icon-negative-filled-24"
+    evo-icon-negative-filled-24
+
+  icon-example name="evo-icon-neutral-16"
+    evo-icon-neutral-16
+
+  icon-example name="evo-icon-neutral-24"
+    evo-icon-neutral-24
+
+  icon-example name="evo-icon-nfc-16"
+    evo-icon-nfc-16
+
+  icon-example name="evo-icon-nfc-24"
+    evo-icon-nfc-24
+
+  icon-example name="evo-icon-nfc-card-12-colored"
+    evo-icon-nfc-card-12-colored
+
+  icon-example name="evo-icon-nfc-card-18-colored"
+    evo-icon-nfc-card-18-colored
+
+  icon-example name="evo-icon-nfc-card-24-colored"
+    evo-icon-nfc-card-24-colored
+
+  icon-example name="evo-icon-nfc-card-32-colored"
+    evo-icon-nfc-card-32-colored
+
+  icon-example name="evo-icon-no-children-zero-three-48"
+    evo-icon-no-children-zero-three-48
+
+  icon-example name="evo-icon-note-12"
+    evo-icon-note-12
+
+  icon-example name="evo-icon-note-16"
+    evo-icon-note-16
+
+  icon-example name="evo-icon-note-24"
+    evo-icon-note-24
+
+  icon-example name="evo-icon-notification-16"
+    evo-icon-notification-16
+
+  icon-example name="evo-icon-notification-20"
+    evo-icon-notification-20
+
+  icon-example name="evo-icon-notification-24"
+    evo-icon-notification-24
+
+  icon-example name="evo-icon-notification-64"
+    evo-icon-notification-64
+
+  icon-example name="evo-icon-notification-filled-16"
+    evo-icon-notification-filled-16
+
+  icon-example name="evo-icon-notification-filled-20"
+    evo-icon-notification-filled-20
+
+  icon-example name="evo-icon-notification-filled-24"
+    evo-icon-notification-filled-24
+
+  icon-example name="evo-icon-out-of-reach-48"
+    evo-icon-out-of-reach-48
+
+  icon-example name="evo-icon-overflow-horizontal-16"
+    evo-icon-overflow-horizontal-16
+
+  icon-example name="evo-icon-overflow-horizontal-20"
+    evo-icon-overflow-horizontal-20
+
+  icon-example name="evo-icon-overflow-horizontal-24"
+    evo-icon-overflow-horizontal-24
+
+  icon-example name="evo-icon-overflow-vertical-16"
+    evo-icon-overflow-vertical-16
+
+  icon-example name="evo-icon-overflow-vertical-20"
+    evo-icon-overflow-vertical-20
+
+  icon-example name="evo-icon-overflow-vertical-24"
+    evo-icon-overflow-vertical-24
+
+  icon-example name="evo-icon-package-16"
+    evo-icon-package-16
+
+  icon-example name="evo-icon-package-24"
+    evo-icon-package-24
+
+  icon-example name="evo-icon-package-64"
+    evo-icon-package-64
+
+  icon-example name="evo-icon-package-error-24"
+    evo-icon-package-error-24
+
+  icon-example name="evo-icon-panel-16"
+    evo-icon-panel-16
+
+  icon-example name="evo-icon-panel-20"
+    evo-icon-panel-20
+
+  icon-example name="evo-icon-panel-24"
+    evo-icon-panel-24
+
+  icon-example name="evo-icon-panel-close-16"
+    evo-icon-panel-close-16
+
+  icon-example name="evo-icon-panel-close-20"
+    evo-icon-panel-close-20
+
+  icon-example name="evo-icon-panel-close-24"
+    evo-icon-panel-close-24
+
+  icon-example name="evo-icon-panel-close-vertical-16"
+    evo-icon-panel-close-vertical-16
+
+  icon-example name="evo-icon-panel-close-vertical-20"
+    evo-icon-panel-close-vertical-20
+
+  icon-example name="evo-icon-panel-close-vertical-24"
+    evo-icon-panel-close-vertical-24
+
+  icon-example name="evo-icon-panel-open-16"
+    evo-icon-panel-open-16
+
+  icon-example name="evo-icon-panel-open-20"
+    evo-icon-panel-open-20
+
+  icon-example name="evo-icon-panel-open-24"
+    evo-icon-panel-open-24
+
+  icon-example name="evo-icon-panel-open-vertical-16"
+    evo-icon-panel-open-vertical-16
+
+  icon-example name="evo-icon-panel-open-vertical-20"
+    evo-icon-panel-open-vertical-20
+
+  icon-example name="evo-icon-panel-open-vertical-24"
+    evo-icon-panel-open-vertical-24
+
+  icon-example name="evo-icon-passkey-16"
+    evo-icon-passkey-16
+
+  icon-example name="evo-icon-passkey-24"
+    evo-icon-passkey-24
+
+  icon-example name="evo-icon-passkey-64"
+    evo-icon-passkey-64
+
+  icon-example name="evo-icon-pause-16"
+    evo-icon-pause-16
+
+  icon-example name="evo-icon-pause-20"
+    evo-icon-pause-20
+
+  icon-example name="evo-icon-pause-24"
+    evo-icon-pause-24
+
+  icon-example name="evo-icon-pause-filled-64-colored"
+    evo-icon-pause-filled-64-colored
+
+  icon-example name="evo-icon-pay-by-bank-12-colored"
+    evo-icon-pay-by-bank-12-colored
+
+  icon-example name="evo-icon-pay-by-bank-18-colored"
+    evo-icon-pay-by-bank-18-colored
+
+  icon-example name="evo-icon-pay-by-bank-24-colored"
+    evo-icon-pay-by-bank-24-colored
+
+  icon-example name="evo-icon-pay-by-bank-32-colored"
+    evo-icon-pay-by-bank-32-colored
+
+  icon-example name="evo-icon-pay-by-bank-be-24-colored"
+    evo-icon-pay-by-bank-be-24-colored
+
+  icon-example name="evo-icon-pay-by-bank-de-24-colored"
+    evo-icon-pay-by-bank-de-24-colored
+
+  icon-example name="evo-icon-pay-by-bank-fr-24-colored"
+    evo-icon-pay-by-bank-fr-24-colored
+
+  icon-example name="evo-icon-pay-by-bank-uk-24-colored"
+    evo-icon-pay-by-bank-uk-24-colored
+
+  icon-example name="evo-icon-payoneer-12-colored"
+    evo-icon-payoneer-12-colored
+
+  icon-example name="evo-icon-payoneer-18-colored"
+    evo-icon-payoneer-18-colored
+
+  icon-example name="evo-icon-payoneer-24-colored"
+    evo-icon-payoneer-24-colored
+
+  icon-example name="evo-icon-payoneer-32-colored"
+    evo-icon-payoneer-32-colored
+
+  icon-example name="evo-icon-payout-16"
+    evo-icon-payout-16
+
+  icon-example name="evo-icon-payout-20"
+    evo-icon-payout-20
+
+  icon-example name="evo-icon-payout-24"
+    evo-icon-payout-24
+
+  icon-example name="evo-icon-paypal-12-colored"
+    evo-icon-paypal-12-colored
+
+  icon-example name="evo-icon-paypal-18-colored"
+    evo-icon-paypal-18-colored
+
+  icon-example name="evo-icon-paypal-24-colored"
+    evo-icon-paypal-24-colored
+
+  icon-example name="evo-icon-paypal-32-colored"
+    evo-icon-paypal-32-colored
+
+  icon-example name="evo-icon-paypal-blue-12-colored"
+    evo-icon-paypal-blue-12-colored
+
+  icon-example name="evo-icon-paypal-blue-18-colored"
+    evo-icon-paypal-blue-18-colored
+
+  icon-example name="evo-icon-paypal-blue-24-colored"
+    evo-icon-paypal-blue-24-colored
+
+  icon-example name="evo-icon-paypal-blue-32-colored"
+    evo-icon-paypal-blue-32-colored
+
+  icon-example name="evo-icon-paypal-credit-12-colored"
+    evo-icon-paypal-credit-12-colored
+
+  icon-example name="evo-icon-paypal-credit-18-colored"
+    evo-icon-paypal-credit-18-colored
+
+  icon-example name="evo-icon-paypal-credit-24-colored"
+    evo-icon-paypal-credit-24-colored
+
+  icon-example name="evo-icon-paypal-credit-32-colored"
+    evo-icon-paypal-credit-32-colored
+
+  icon-example name="evo-icon-paypal-disabled-12-colored"
+    evo-icon-paypal-disabled-12-colored
+
+  icon-example name="evo-icon-paypal-disabled-18-colored"
+    evo-icon-paypal-disabled-18-colored
+
+  icon-example name="evo-icon-paypal-disabled-24-colored"
+    evo-icon-paypal-disabled-24-colored
+
+  icon-example name="evo-icon-paypal-disabled-32-colored"
+    evo-icon-paypal-disabled-32-colored
+
+  icon-example name="evo-icon-paypal-logo-16"
+    evo-icon-paypal-logo-16
+
+  icon-example name="evo-icon-paypay-12-colored"
+    evo-icon-paypay-12-colored
+
+  icon-example name="evo-icon-paypay-18-colored"
+    evo-icon-paypay-18-colored
+
+  icon-example name="evo-icon-paypay-24-colored"
+    evo-icon-paypay-24-colored
+
+  icon-example name="evo-icon-paypay-32-colored"
+    evo-icon-paypay-32-colored
+
+  icon-example name="evo-icon-pencil-16"
+    evo-icon-pencil-16
+
+  icon-example name="evo-icon-pencil-20"
+    evo-icon-pencil-20
+
+  icon-example name="evo-icon-pencil-24"
+    evo-icon-pencil-24
+
+  icon-example name="evo-icon-pencil-signed-24"
+    evo-icon-pencil-signed-24
+
+  icon-example name="evo-icon-people-16"
+    evo-icon-people-16
+
+  icon-example name="evo-icon-people-24"
+    evo-icon-people-24
+
+  icon-example name="evo-icon-peso-16"
+    evo-icon-peso-16
+
+  icon-example name="evo-icon-peso-24"
+    evo-icon-peso-24
+
+  icon-example name="evo-icon-phone-16"
+    evo-icon-phone-16
+
+  icon-example name="evo-icon-phone-24"
+    evo-icon-phone-24
+
+  icon-example name="evo-icon-pin-12"
+    evo-icon-pin-12
+
+  icon-example name="evo-icon-pin-16"
+    evo-icon-pin-16
+
+  icon-example name="evo-icon-pin-24"
+    evo-icon-pin-24
+
+  icon-example name="evo-icon-pin-filled-12"
+    evo-icon-pin-filled-12
+
+  icon-example name="evo-icon-pin-filled-16"
+    evo-icon-pin-filled-16
+
+  icon-example name="evo-icon-pin-filled-24"
+    evo-icon-pin-filled-24
+
+  icon-example name="evo-icon-pinterest-24"
+    evo-icon-pinterest-24
+
+  icon-example name="evo-icon-play-16"
+    evo-icon-play-16
+
+  icon-example name="evo-icon-play-20"
+    evo-icon-play-20
+
+  icon-example name="evo-icon-play-24"
+    evo-icon-play-24
+
+  icon-example name="evo-icon-play-disabled-16"
+    evo-icon-play-disabled-16
+
+  icon-example name="evo-icon-play-filled-16-colored"
+    evo-icon-play-filled-16-colored
+
+  icon-example name="evo-icon-play-filled-24-colored"
+    evo-icon-play-filled-24-colored
+
+  icon-example name="evo-icon-play-filled-64-colored"
+    evo-icon-play-filled-64-colored
+
+  icon-example name="evo-icon-postepay-12-colored"
+    evo-icon-postepay-12-colored
+
+  icon-example name="evo-icon-postepay-18-colored"
+    evo-icon-postepay-18-colored
+
+  icon-example name="evo-icon-postepay-24-colored"
+    evo-icon-postepay-24-colored
+
+  icon-example name="evo-icon-postepay-32-colored"
+    evo-icon-postepay-32-colored
+
+  icon-example name="evo-icon-potted-plant-16"
+    evo-icon-potted-plant-16
+
+  icon-example name="evo-icon-potted-plant-24"
+    evo-icon-potted-plant-24
+
+  icon-example name="evo-icon-pound-16"
+    evo-icon-pound-16
+
+  icon-example name="evo-icon-pound-24"
+    evo-icon-pound-24
+
+  icon-example name="evo-icon-print-16"
+    evo-icon-print-16
+
+  icon-example name="evo-icon-print-24"
+    evo-icon-print-24
+
+  icon-example name="evo-icon-profile-16"
+    evo-icon-profile-16
+
+  icon-example name="evo-icon-profile-20"
+    evo-icon-profile-20
+
+  icon-example name="evo-icon-profile-24"
+    evo-icon-profile-24
+
+  icon-example name="evo-icon-profile-filled-24"
+    evo-icon-profile-filled-24
+
+  icon-example name="evo-icon-profile-verification-16"
+    evo-icon-profile-verification-16
+
+  icon-example name="evo-icon-profile-verification-20"
+    evo-icon-profile-verification-20
+
+  icon-example name="evo-icon-profile-verification-24"
+    evo-icon-profile-verification-24
+
+  icon-example name="evo-icon-progress-current-24"
+    evo-icon-progress-current-24
+
+  icon-example name="evo-icon-progress-upcoming-24"
+    evo-icon-progress-upcoming-24
+
+  icon-example name="evo-icon-promotion-12"
+    evo-icon-promotion-12
+
+  icon-example name="evo-icon-promotion-16"
+    evo-icon-promotion-16
+
+  icon-example name="evo-icon-promotion-24"
+    evo-icon-promotion-24
+
+  icon-example name="evo-icon-psa-16"
+    evo-icon-psa-16
+
+  icon-example name="evo-icon-psa-16-colored"
+    evo-icon-psa-16-colored
+
+  icon-example name="evo-icon-psa-logo-16"
+    evo-icon-psa-logo-16
+
+  icon-example name="evo-icon-psa-logo-color-16-colored"
+    evo-icon-psa-logo-color-16-colored
+
+  icon-example name="evo-icon-psa-vault-16"
+    evo-icon-psa-vault-16
+
+  icon-example name="evo-icon-psa-vault-16-colored"
+    evo-icon-psa-vault-16-colored
+
+  icon-example name="evo-icon-psa-vault-24"
+    evo-icon-psa-vault-24
+
+  icon-example name="evo-icon-psa-vault-logo-16"
+    evo-icon-psa-vault-logo-16
+
+  icon-example name="evo-icon-psa-vault-logo-color-16-colored"
+    evo-icon-psa-vault-logo-color-16-colored
+
+  icon-example name="evo-icon-qr-code-16"
+    evo-icon-qr-code-16
+
+  icon-example name="evo-icon-qr-code-24"
+    evo-icon-qr-code-24
+
+  icon-example name="evo-icon-radio-checked-18"
+    evo-icon-radio-checked-18
+
+  icon-example name="evo-icon-radio-checked-24"
+    evo-icon-radio-checked-24
+
+  icon-example name="evo-icon-radio-unchecked-18"
+    evo-icon-radio-unchecked-18
+
+  icon-example name="evo-icon-radio-unchecked-24"
+    evo-icon-radio-unchecked-24
+
+  icon-example name="evo-icon-recovery-code-16"
+    evo-icon-recovery-code-16
+
+  icon-example name="evo-icon-recovery-code-24"
+    evo-icon-recovery-code-24
+
+  icon-example name="evo-icon-reddit-24"
+    evo-icon-reddit-24
+
+  icon-example name="evo-icon-refresh-16"
+    evo-icon-refresh-16
+
+  icon-example name="evo-icon-refresh-20"
+    evo-icon-refresh-20
+
+  icon-example name="evo-icon-refresh-24"
+    evo-icon-refresh-24
+
+  icon-example name="evo-icon-relaxed-grid-24"
+    evo-icon-relaxed-grid-24
+
+  icon-example name="evo-icon-relaxed-grid-filled-24"
+    evo-icon-relaxed-grid-filled-24
+
+  icon-example name="evo-icon-remove-12"
+    evo-icon-remove-12
+
+  icon-example name="evo-icon-remove-16"
+    evo-icon-remove-16
+
+  icon-example name="evo-icon-remove-24"
+    evo-icon-remove-24
+
+  icon-example name="evo-icon-reply-16"
+    evo-icon-reply-16
+
+  icon-example name="evo-icon-reply-24"
+    evo-icon-reply-24
+
+  icon-example name="evo-icon-reply-chat-12"
+    evo-icon-reply-chat-12
+
+  icon-example name="evo-icon-reply-chat-16"
+    evo-icon-reply-chat-16
+
+  icon-example name="evo-icon-reply-chat-24"
+    evo-icon-reply-chat-24
+
+  icon-example name="evo-icon-return-16"
+    evo-icon-return-16
+
+  icon-example name="evo-icon-return-24"
+    evo-icon-return-24
+
+  icon-example name="evo-icon-rewind-16"
+    evo-icon-rewind-16
+
+  icon-example name="evo-icon-ribbon-16"
+    evo-icon-ribbon-16
+
+  icon-example name="evo-icon-ribbon-24"
+    evo-icon-ribbon-24
+
+  icon-example name="evo-icon-rim-16"
+    evo-icon-rim-16
+
+  icon-example name="evo-icon-rim-24"
+    evo-icon-rim-24
+
+  icon-example name="evo-icon-ringgit-16"
+    evo-icon-ringgit-16
+
+  icon-example name="evo-icon-ringgit-24"
+    evo-icon-ringgit-24
+
+  icon-example name="evo-icon-rotate-16"
+    evo-icon-rotate-16
+
+  icon-example name="evo-icon-rotate-20"
+    evo-icon-rotate-20
+
+  icon-example name="evo-icon-rotate-24"
+    evo-icon-rotate-24
+
+  icon-example name="evo-icon-rotate-landscape-left-24"
+    evo-icon-rotate-landscape-left-24
+
+  icon-example name="evo-icon-rotate-landscape-right-24"
+    evo-icon-rotate-landscape-right-24
+
+  icon-example name="evo-icon-rotate-portrait-left-24"
+    evo-icon-rotate-portrait-left-24
+
+  icon-example name="evo-icon-rotate-portrait-right-24"
+    evo-icon-rotate-portrait-right-24
+
+  icon-example name="evo-icon-ruler-16"
+    evo-icon-ruler-16
+
+  icon-example name="evo-icon-ruler-24"
+    evo-icon-ruler-24
+
+  icon-example name="evo-icon-rupee-16"
+    evo-icon-rupee-16
+
+  icon-example name="evo-icon-rupee-24"
+    evo-icon-rupee-24
+
+  icon-example name="evo-icon-satchel-16"
+    evo-icon-satchel-16
+
+  icon-example name="evo-icon-satchel-24"
+    evo-icon-satchel-24
+
+  icon-example name="evo-icon-scan-16"
+    evo-icon-scan-16
+
+  icon-example name="evo-icon-scan-24"
+    evo-icon-scan-24
+
+  icon-example name="evo-icon-search-16"
+    evo-icon-search-16
+
+  icon-example name="evo-icon-search-20"
+    evo-icon-search-20
+
+  icon-example name="evo-icon-search-24"
+    evo-icon-search-24
+
+  icon-example name="evo-icon-search-64"
+    evo-icon-search-64
+
+  icon-example name="evo-icon-search-filled-24"
+    evo-icon-search-filled-24
+
+  icon-example name="evo-icon-search-similar-16"
+    evo-icon-search-similar-16
+
+  icon-example name="evo-icon-search-similar-20"
+    evo-icon-search-similar-20
+
+  icon-example name="evo-icon-search-similar-24"
+    evo-icon-search-similar-24
+
+  icon-example name="evo-icon-seasons-16"
+    evo-icon-seasons-16
+
+  icon-example name="evo-icon-seasons-24"
+    evo-icon-seasons-24
+
+  icon-example name="evo-icon-secure-purchase-16"
+    evo-icon-secure-purchase-16
+
+  icon-example name="evo-icon-secure-purchase-24"
+    evo-icon-secure-purchase-24
+
+  icon-example name="evo-icon-security-key-24"
+    evo-icon-security-key-24
+
+  icon-example name="evo-icon-select-all-24"
+    evo-icon-select-all-24
+
+  icon-example name="evo-icon-selling-12"
+    evo-icon-selling-12
+
+  icon-example name="evo-icon-selling-16"
+    evo-icon-selling-16
+
+  icon-example name="evo-icon-selling-20"
+    evo-icon-selling-20
+
+  icon-example name="evo-icon-selling-24"
+    evo-icon-selling-24
+
+  icon-example name="evo-icon-selling-filled-24"
+    evo-icon-selling-filled-24
+
+  icon-example name="evo-icon-send-24"
+    evo-icon-send-24
+
+  icon-example name="evo-icon-settings-16"
+    evo-icon-settings-16
+
+  icon-example name="evo-icon-settings-20"
+    evo-icon-settings-20
+
+  icon-example name="evo-icon-settings-24"
+    evo-icon-settings-24
+
+  icon-example name="evo-icon-share-android-16"
+    evo-icon-share-android-16
+
+  icon-example name="evo-icon-share-android-20"
+    evo-icon-share-android-20
+
+  icon-example name="evo-icon-share-android-24"
+    evo-icon-share-android-24
+
+  icon-example name="evo-icon-share-ios-16"
+    evo-icon-share-ios-16
+
+  icon-example name="evo-icon-share-ios-20"
+    evo-icon-share-ios-20
+
+  icon-example name="evo-icon-share-ios-24"
+    evo-icon-share-ios-24
+
+  icon-example name="evo-icon-sharpen-24"
+    evo-icon-sharpen-24
+
+  icon-example name="evo-icon-ship-and-local-16"
+    evo-icon-ship-and-local-16
+
+  icon-example name="evo-icon-ship-and-local-24"
+    evo-icon-ship-and-local-24
+
+  icon-example name="evo-icon-ship-and-safety-16"
+    evo-icon-ship-and-safety-16
+
+  icon-example name="evo-icon-ship-and-safety-24"
+    evo-icon-ship-and-safety-24
+
+  icon-example name="evo-icon-shirt-16"
+    evo-icon-shirt-16
+
+  icon-example name="evo-icon-shirt-24"
+    evo-icon-shirt-24
+
+  icon-example name="evo-icon-shoe-box-24"
+    evo-icon-shoe-box-24
+
+  icon-example name="evo-icon-shopping-event-16"
+    evo-icon-shopping-event-16
+
+  icon-example name="evo-icon-shopping-event-24"
+    evo-icon-shopping-event-24
+
+  icon-example name="evo-icon-shovel-16"
+    evo-icon-shovel-16
+
+  icon-example name="evo-icon-shovel-24"
+    evo-icon-shovel-24
+
+  icon-example name="evo-icon-show-16"
+    evo-icon-show-16
+
+  icon-example name="evo-icon-show-24"
+    evo-icon-show-24
+
+  icon-example name="evo-icon-skull-12"
+    evo-icon-skull-12
+
+  icon-example name="evo-icon-skull-16"
+    evo-icon-skull-16
+
+  icon-example name="evo-icon-skull-24"
+    evo-icon-skull-24
+
+  icon-example name="evo-icon-small-box-16"
+    evo-icon-small-box-16
+
+  icon-example name="evo-icon-small-box-24"
+    evo-icon-small-box-24
+
+  icon-example name="evo-icon-small-letter-24"
+    evo-icon-small-letter-24
+
+  icon-example name="evo-icon-sneaker-16"
+    evo-icon-sneaker-16
+
+  icon-example name="evo-icon-sneaker-24"
+    evo-icon-sneaker-24
+
+  icon-example name="evo-icon-snowflake-16"
+    evo-icon-snowflake-16
+
+  icon-example name="evo-icon-snowflake-24"
+    evo-icon-snowflake-24
+
+  icon-example name="evo-icon-snowmobile-16"
+    evo-icon-snowmobile-16
+
+  icon-example name="evo-icon-snowmobile-24"
+    evo-icon-snowmobile-24
+
+  icon-example name="evo-icon-sort-12"
+    evo-icon-sort-12
+
+  icon-example name="evo-icon-sort-16"
+    evo-icon-sort-16
+
+  icon-example name="evo-icon-sort-24"
+    evo-icon-sort-24
+
+  icon-example name="evo-icon-sort-down-12"
+    evo-icon-sort-down-12
+
+  icon-example name="evo-icon-sort-up-12"
+    evo-icon-sort-up-12
+
+  icon-example name="evo-icon-sparkline-down-16"
+    evo-icon-sparkline-down-16
+
+  icon-example name="evo-icon-sparkline-down-20"
+    evo-icon-sparkline-down-20
+
+  icon-example name="evo-icon-sparkline-down-24"
+    evo-icon-sparkline-down-24
+
+  icon-example name="evo-icon-sparkline-up-16"
+    evo-icon-sparkline-up-16
+
+  icon-example name="evo-icon-sparkline-up-20"
+    evo-icon-sparkline-up-20
+
+  icon-example name="evo-icon-sparkline-up-24"
+    evo-icon-sparkline-up-24
+
+  icon-example name="evo-icon-sparkline-up-filled-24"
+    evo-icon-sparkline-up-filled-24
+
+  icon-example name="evo-icon-speedometer-16"
+    evo-icon-speedometer-16
+
+  icon-example name="evo-icon-speedometer-24"
+    evo-icon-speedometer-24
+
+  icon-example name="evo-icon-spinner-20"
+    evo-icon-spinner-20
+
+  icon-example name="evo-icon-spinner-24"
+    evo-icon-spinner-24
+
+  icon-example name="evo-icon-spinner-30"
+    evo-icon-spinner-30
+
+  icon-example name="evo-icon-split-payment-16"
+    evo-icon-split-payment-16
+
+  icon-example name="evo-icon-split-payment-24"
+    evo-icon-split-payment-24
+
+  icon-example name="evo-icon-split-view-24"
+    evo-icon-split-view-24
+
+  icon-example name="evo-icon-split-view-filled-24"
+    evo-icon-split-view-filled-24
+
+  icon-example name="evo-icon-spring-leaf-16"
+    evo-icon-spring-leaf-16
+
+  icon-example name="evo-icon-spring-leaf-24"
+    evo-icon-spring-leaf-24
+
+  icon-example name="evo-icon-star-empty-16"
+    evo-icon-star-empty-16
+
+  icon-example name="evo-icon-star-empty-24"
+    evo-icon-star-empty-24
+
+  icon-example name="evo-icon-star-empty-40"
+    evo-icon-star-empty-40
+
+  icon-example name="evo-icon-star-filled-16"
+    evo-icon-star-filled-16
+
+  icon-example name="evo-icon-star-filled-24"
+    evo-icon-star-filled-24
+
+  icon-example name="evo-icon-star-filled-40"
+    evo-icon-star-filled-40
+
+  icon-example name="evo-icon-star-half-16-colored"
+    evo-icon-star-half-16-colored
+
+  icon-example name="evo-icon-star-half-24-colored"
+    evo-icon-star-half-24-colored
+
+  icon-example name="evo-icon-star-half-dark-16-colored"
+    evo-icon-star-half-dark-16-colored
+
+  icon-example name="evo-icon-star-half-dark-24-colored"
+    evo-icon-star-half-dark-24-colored
+
+  icon-example name="evo-icon-stepper-attention-24"
+    evo-icon-stepper-attention-24
+
+  icon-example name="evo-icon-stepper-confirmation-24"
+    evo-icon-stepper-confirmation-24
+
+  icon-example name="evo-icon-stepper-current-24"
+    evo-icon-stepper-current-24
+
+  icon-example name="evo-icon-stepper-upcoming-24"
+    evo-icon-stepper-upcoming-24
+
+  icon-example name="evo-icon-stop-16"
+    evo-icon-stop-16
+
+  icon-example name="evo-icon-stop-20"
+    evo-icon-stop-20
+
+  icon-example name="evo-icon-stop-24"
+    evo-icon-stop-24
+
+  icon-example name="evo-icon-store-16"
+    evo-icon-store-16
+
+  icon-example name="evo-icon-store-24"
+    evo-icon-store-24
+
+  icon-example name="evo-icon-store-64"
+    evo-icon-store-64
+
+  icon-example name="evo-icon-store-filled-24"
+    evo-icon-store-filled-24
+
+  icon-example name="evo-icon-suitcase-24"
+    evo-icon-suitcase-24
+
+  icon-example name="evo-icon-support-24"
+    evo-icon-support-24
+
+  icon-example name="evo-icon-swap-16"
+    evo-icon-swap-16
+
+  icon-example name="evo-icon-swap-24"
+    evo-icon-swap-24
+
+  icon-example name="evo-icon-switch-camera-24"
+    evo-icon-switch-camera-24
+
+  icon-example name="evo-icon-tablet-16"
+    evo-icon-tablet-16
+
+  icon-example name="evo-icon-tablet-20"
+    evo-icon-tablet-20
+
+  icon-example name="evo-icon-tablet-24"
+    evo-icon-tablet-24
+
+  icon-example name="evo-icon-target-16"
+    evo-icon-target-16
+
+  icon-example name="evo-icon-target-24"
+    evo-icon-target-24
+
+  icon-example name="evo-icon-td-12-colored"
+    evo-icon-td-12-colored
+
+  icon-example name="evo-icon-td-18-colored"
+    evo-icon-td-18-colored
+
+  icon-example name="evo-icon-td-24-colored"
+    evo-icon-td-24-colored
+
+  icon-example name="evo-icon-td-32-colored"
+    evo-icon-td-32-colored
+
+  icon-example name="evo-icon-text-messaging-16"
+    evo-icon-text-messaging-16
+
+  icon-example name="evo-icon-text-messaging-20"
+    evo-icon-text-messaging-20
+
+  icon-example name="evo-icon-text-messaging-24"
+    evo-icon-text-messaging-24
+
+  icon-example name="evo-icon-text-messaging-64"
+    evo-icon-text-messaging-64
+
+  icon-example name="evo-icon-text-size-16"
+    evo-icon-text-size-16
+
+  icon-example name="evo-icon-text-size-24"
+    evo-icon-text-size-24
+
+  icon-example name="evo-icon-the-ebay-vault-16"
+    evo-icon-the-ebay-vault-16
+
+  icon-example name="evo-icon-the-ebay-vault-24"
+    evo-icon-the-ebay-vault-24
+
+  icon-example name="evo-icon-thumb-down-16"
+    evo-icon-thumb-down-16
+
+  icon-example name="evo-icon-thumb-down-20"
+    evo-icon-thumb-down-20
+
+  icon-example name="evo-icon-thumb-down-24"
+    evo-icon-thumb-down-24
+
+  icon-example name="evo-icon-thumb-down-filled-16"
+    evo-icon-thumb-down-filled-16
+
+  icon-example name="evo-icon-thumb-down-filled-20"
+    evo-icon-thumb-down-filled-20
+
+  icon-example name="evo-icon-thumb-down-filled-24"
+    evo-icon-thumb-down-filled-24
+
+  icon-example name="evo-icon-thumb-up-16"
+    evo-icon-thumb-up-16
+
+  icon-example name="evo-icon-thumb-up-20"
+    evo-icon-thumb-up-20
+
+  icon-example name="evo-icon-thumb-up-24"
+    evo-icon-thumb-up-24
+
+  icon-example name="evo-icon-thumb-up-64"
+    evo-icon-thumb-up-64
+
+  icon-example name="evo-icon-thumb-up-filled-16"
+    evo-icon-thumb-up-filled-16
+
+  icon-example name="evo-icon-thumb-up-filled-20"
+    evo-icon-thumb-up-filled-20
+
+  icon-example name="evo-icon-thumb-up-filled-24"
+    evo-icon-thumb-up-filled-24
+
+  icon-example name="evo-icon-tick-12"
+    evo-icon-tick-12
+
+  icon-example name="evo-icon-tick-16"
+    evo-icon-tick-16
+
+  icon-example name="evo-icon-tick-24"
+    evo-icon-tick-24
+
+  icon-example name="evo-icon-tiktok-24"
+    evo-icon-tiktok-24
+
+  icon-example name="evo-icon-tire-16"
+    evo-icon-tire-16
+
+  icon-example name="evo-icon-tire-24"
+    evo-icon-tire-24
+
+  icon-example name="evo-icon-toggle-mode-bottom-24"
+    evo-icon-toggle-mode-bottom-24
+
+  icon-example name="evo-icon-toggle-mode-top-24"
+    evo-icon-toggle-mode-top-24
+
+  icon-example name="evo-icon-top-rated-plus-16"
+    evo-icon-top-rated-plus-16
+
+  icon-example name="evo-icon-top-rated-plus-24"
+    evo-icon-top-rated-plus-24
+
+  icon-example name="evo-icon-top-rated-seller-16"
+    evo-icon-top-rated-seller-16
+
+  icon-example name="evo-icon-top-rated-seller-24"
+    evo-icon-top-rated-seller-24
+
+  icon-example name="evo-icon-top-service-16"
+    evo-icon-top-service-16
+
+  icon-example name="evo-icon-top-service-24"
+    evo-icon-top-service-24
+
+  icon-example name="evo-icon-top-service-filled-16"
+    evo-icon-top-service-filled-16
+
+  icon-example name="evo-icon-top-service-filled-16-colored"
+    evo-icon-top-service-filled-16-colored
+
+  icon-example name="evo-icon-top-service-filled-24"
+    evo-icon-top-service-filled-24
+
+  icon-example name="evo-icon-top-service-filled-24-colored"
+    evo-icon-top-service-filled-24-colored
+
+  icon-example name="evo-icon-trading-card-16"
+    evo-icon-trading-card-16
+
+  icon-example name="evo-icon-trading-card-24"
+    evo-icon-trading-card-24
+
+  icon-example name="evo-icon-trading-card-edition-24"
+    evo-icon-trading-card-edition-24
+
+  icon-example name="evo-icon-trading-card-grade-16"
+    evo-icon-trading-card-grade-16
+
+  icon-example name="evo-icon-trading-card-grade-24"
+    evo-icon-trading-card-grade-24
+
+  icon-example name="evo-icon-transaction-24"
+    evo-icon-transaction-24
+
+  icon-example name="evo-icon-translate-16"
+    evo-icon-translate-16
+
+  icon-example name="evo-icon-translate-20"
+    evo-icon-translate-20
+
+  icon-example name="evo-icon-translate-24"
+    evo-icon-translate-24
+
+  icon-example name="evo-icon-trend-down-16-fit"
+    evo-icon-trend-down-16-fit
+
+  icon-example name="evo-icon-trend-up-16-fit"
+    evo-icon-trend-up-16-fit
+
+  icon-example name="evo-icon-trophy-16"
+    evo-icon-trophy-16
+
+  icon-example name="evo-icon-trophy-24"
+    evo-icon-trophy-24
+
+  icon-example name="evo-icon-truck-16"
+    evo-icon-truck-16
+
+  icon-example name="evo-icon-truck-24"
+    evo-icon-truck-24
+
+  icon-example name="evo-icon-truck-64"
+    evo-icon-truck-64
+
+  icon-example name="evo-icon-truck-shipped-12"
+    evo-icon-truck-shipped-12
+
+  icon-example name="evo-icon-truck-shipped-16"
+    evo-icon-truck-shipped-16
+
+  icon-example name="evo-icon-truck-shipped-24"
+    evo-icon-truck-shipped-24
+
+  icon-example name="evo-icon-twitter-24"
+    evo-icon-twitter-24
+
+  icon-example name="evo-icon-undo-16"
+    evo-icon-undo-16
+
+  icon-example name="evo-icon-undo-24"
+    evo-icon-undo-24
+
+  icon-example name="evo-icon-unionpay-12-colored"
+    evo-icon-unionpay-12-colored
+
+  icon-example name="evo-icon-unionpay-18-colored"
+    evo-icon-unionpay-18-colored
+
+  icon-example name="evo-icon-unionpay-24-colored"
+    evo-icon-unionpay-24-colored
+
+  icon-example name="evo-icon-unionpay-32-colored"
+    evo-icon-unionpay-32-colored
+
+  icon-example name="evo-icon-unlock-16"
+    evo-icon-unlock-16
+
+  icon-example name="evo-icon-unlock-24"
+    evo-icon-unlock-24
+
+  icon-example name="evo-icon-unselect-all-24"
+    evo-icon-unselect-all-24
+
+  icon-example name="evo-icon-upload-16"
+    evo-icon-upload-16
+
+  icon-example name="evo-icon-upload-24"
+    evo-icon-upload-24
+
+  icon-example name="evo-icon-usaa-12-colored"
+    evo-icon-usaa-12-colored
+
+  icon-example name="evo-icon-usaa-18-colored"
+    evo-icon-usaa-18-colored
+
+  icon-example name="evo-icon-usaa-24-colored"
+    evo-icon-usaa-24-colored
+
+  icon-example name="evo-icon-usaa-32-colored"
+    evo-icon-usaa-32-colored
+
+  icon-example name="evo-icon-venmo-12-colored"
+    evo-icon-venmo-12-colored
+
+  icon-example name="evo-icon-venmo-18-colored"
+    evo-icon-venmo-18-colored
+
+  icon-example name="evo-icon-venmo-24-colored"
+    evo-icon-venmo-24-colored
+
+  icon-example name="evo-icon-venmo-32-colored"
+    evo-icon-venmo-32-colored
+
+  icon-example name="evo-icon-verified-condition-16"
+    evo-icon-verified-condition-16
+
+  icon-example name="evo-icon-verified-condition-24"
+    evo-icon-verified-condition-24
+
+  icon-example name="evo-icon-video-24"
+    evo-icon-video-24
+
+  icon-example name="evo-icon-visa-12-colored"
+    evo-icon-visa-12-colored
+
+  icon-example name="evo-icon-visa-18-colored"
+    evo-icon-visa-18-colored
+
+  icon-example name="evo-icon-visa-24-colored"
+    evo-icon-visa-24-colored
+
+  icon-example name="evo-icon-visa-32-colored"
+    evo-icon-visa-32-colored
+
+  icon-example name="evo-icon-wallet-16"
+    evo-icon-wallet-16
+
+  icon-example name="evo-icon-wallet-24"
+    evo-icon-wallet-24
+
+  icon-example name="evo-icon-wallet-64"
+    evo-icon-wallet-64
+
+  icon-example name="evo-icon-wallet-balance-12-colored"
+    evo-icon-wallet-balance-12-colored
+
+  icon-example name="evo-icon-wallet-balance-18-colored"
+    evo-icon-wallet-balance-18-colored
+
+  icon-example name="evo-icon-wallet-balance-24-colored"
+    evo-icon-wallet-balance-24-colored
+
+  icon-example name="evo-icon-wallet-balance-32-colored"
+    evo-icon-wallet-balance-32-colored
+
+  icon-example name="evo-icon-watch-16"
+    evo-icon-watch-16
+
+  icon-example name="evo-icon-watch-24"
+    evo-icon-watch-24
+
+  icon-example name="evo-icon-wells-fargo-12-colored"
+    evo-icon-wells-fargo-12-colored
+
+  icon-example name="evo-icon-wells-fargo-18-colored"
+    evo-icon-wells-fargo-18-colored
+
+  icon-example name="evo-icon-wells-fargo-24-colored"
+    evo-icon-wells-fargo-24-colored
+
+  icon-example name="evo-icon-wells-fargo-32-colored"
+    evo-icon-wells-fargo-32-colored
+
+  icon-example name="evo-icon-whatsapp-24"
+    evo-icon-whatsapp-24
+
+  icon-example name="evo-icon-wire-transfer-16"
+    evo-icon-wire-transfer-16
+
+  icon-example name="evo-icon-wire-transfer-24"
+    evo-icon-wire-transfer-24
+
+  icon-example name="evo-icon-wire-transfer-card-12-colored"
+    evo-icon-wire-transfer-card-12-colored
+
+  icon-example name="evo-icon-wire-transfer-card-18-colored"
+    evo-icon-wire-transfer-card-18-colored
+
+  icon-example name="evo-icon-wire-transfer-card-24-colored"
+    evo-icon-wire-transfer-card-24-colored
+
+  icon-example name="evo-icon-wire-transfer-card-32-colored"
+    evo-icon-wire-transfer-card-32-colored
+
+  icon-example name="evo-icon-won-16"
+    evo-icon-won-16
+
+  icon-example name="evo-icon-won-24"
+    evo-icon-won-24
+
+  icon-example name="evo-icon-wrench-16"
+    evo-icon-wrench-16
+
+  icon-example name="evo-icon-wrench-24"
+    evo-icon-wrench-24
+
+  icon-example name="evo-icon-youtube-24"
+    evo-icon-youtube-24
+
+  icon-example name="evo-icon-yuan-16"
+    evo-icon-yuan-16
+
+  icon-example name="evo-icon-yuan-24"
+    evo-icon-yuan-24
+
+  icon-example name="evo-icon-zip-pay-12-colored"
+    evo-icon-zip-pay-12-colored
+
+  icon-example name="evo-icon-zip-pay-18-colored"
+    evo-icon-zip-pay-18-colored
+
+  icon-example name="evo-icon-zip-pay-24-colored"
+    evo-icon-zip-pay-24-colored
+
+  icon-example name="evo-icon-zip-pay-32-colored"
+    evo-icon-zip-pay-32-colored
+
+  icon-example name="evo-icon-zloty-16"
+    evo-icon-zloty-16
+
+  icon-example name="evo-icon-zloty-24"
+    evo-icon-zloty-24
+
+  icon-example name="evo-icon-zoom-in-16"
+    evo-icon-zoom-in-16
+
+  icon-example name="evo-icon-zoom-in-24"
+    evo-icon-zoom-in-24
+
+  icon-example name="evo-icon-zoom-out-16"
+    evo-icon-zoom-out-16
+
+  icon-example name="evo-icon-zoom-out-24"
+    evo-icon-zoom-out-24

--- a/packages/evo-marko/src/tags/evo-icon/examples/tags/icon-example.marko
+++ b/packages/evo-marko/src/tags/evo-icon/examples/tags/icon-example.marko
@@ -49,7 +49,6 @@ export interface Input {
         class=(styles as any).tooltip>
         <@host
             as="button"
-            type="button"
             aria-label=input.name
             class=(styles as any).host
             onClick() {

--- a/packages/evo-marko/src/tags/evo-icon/examples/tags/icon-example.marko
+++ b/packages/evo-marko/src/tags/evo-icon/examples/tags/icon-example.marko
@@ -49,6 +49,7 @@ export interface Input {
         class=(styles as any).tooltip>
         <@host
             as="button"
+            type="button"
             aria-label=input.name
             class=(styles as any).host
             onClick() {

--- a/packages/evo-marko/src/tags/evo-icon/examples/tags/icon-example.marko
+++ b/packages/evo-marko/src/tags/evo-icon/examples/tags/icon-example.marko
@@ -1,0 +1,61 @@
+export interface Input {
+    name: string;
+    content: Marko.Body;
+}
+
+<style/styles>
+    .cell {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        height: 72px;
+    }
+
+    .cell .tooltip {
+        display: flex;
+        width: 100%;
+        height: 100%;
+    }
+
+    .cell .host {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        width: 100%;
+        height: 100%;
+        margin: 0;
+        padding: 0;
+        border: 0;
+        background-color: transparent;
+        border-radius: 8px;
+        cursor: pointer;
+        color: inherit;
+    }
+
+    .cell .host:hover {
+        background-color: var(--color-background-faint);
+    }
+</style>
+
+<let/open=false>
+
+<div class=(styles as any).cell>
+    <evo-tooltip
+        noHover
+        open=open
+        openChange(value) {
+            open = open && value;
+        }
+        class=(styles as any).tooltip>
+        <@host
+            as="button"
+            aria-label=input.name
+            class=(styles as any).host
+            onClick() {
+                open = !open;
+            }>
+            <${input.content}/>
+        </@host>
+        ${`<${input.name}/>`}
+    </evo-tooltip>
+</div>

--- a/packages/evo-marko/src/tags/evo-icon/examples/tags/icon-grid.marko
+++ b/packages/evo-marko/src/tags/evo-icon/examples/tags/icon-grid.marko
@@ -1,0 +1,15 @@
+export interface Input {
+    content?: Marko.Body;
+}
+
+<style/styles>
+    .grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(72px, 1fr));
+        gap: 4px;
+    }
+</style>
+
+<div class=(styles as any).grid>
+    <${input.content}/>
+</div>


### PR DESCRIPTION
Replaces the evo-marko all-icons Storybook example (a spread-out grid of labeled tiles) with a dense grid: each icon is a button that toggles an `evo-tooltip` showing its selectable tag name (`<evo-icon-foo/>`), closing on focus out. The cells are generated by `importSVG` as a local `icon-example` tag with scoped styles, so nothing leaks into the global Storybook CSS and the generated example shrinks to three lines per icon. Storybook-only; no changeset.

![Dense icon grid with an open tooltip showing <evo-icon-ai-camera-24/>](https://raw.githubusercontent.com/eBay/evo-web/llavalva-M451495HWX-evo-compact-icon-examples-rb8fdd-icon-grid-assets/icon-grid.png)

In Safari, closing by clicking elsewhere relies on the click-to-focus fix in #884.

🤖 Generated with [Claude Code](https://claude.com/claude-code)