### PR TITLE
feat: add strategy prop to date-textbox

### DIFF
--- a/.changeset/date-textbox-strategy.md
+++ b/.changeset/date-textbox-strategy.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ui-core-react": minor
+---
+
+Add `strategy` prop to `EbayDateTextbox` to control calendar popover positioning (`absolute` or `fixed`) via `useFloatingDropdown`.

--- a/packages/ebayui-core-react/src/ebay-date-textbox/__tests__/index.spec.tsx
+++ b/packages/ebayui-core-react/src/ebay-date-textbox/__tests__/index.spec.tsx
@@ -20,6 +20,12 @@ describe("<EbayDateTextbox />", () => {
 
         expect(container.querySelector(".date-textbox__popover")).not.toHaveAttribute("hidden");
     });
+    it("should position the popover with the given strategy", () => {
+        const { container } = render(<EbayDateTextbox strategy="fixed" />);
+        fireEvent.click(screen.getByLabelText("open calendar"));
+
+        expect(container.querySelector(".date-textbox__popover")).toHaveStyle({ position: "fixed" });
+    });
     it("should open the calendar when clicking on the postfix icon with children", () => {
         const { container } = render(
             <EbayDateTextbox>

--- a/packages/ebayui-core-react/src/ebay-date-textbox/__tests__/index.stories.tsx
+++ b/packages/ebayui-core-react/src/ebay-date-textbox/__tests__/index.stories.tsx
@@ -120,6 +120,12 @@ or import styles using SCSS/CSS
             description: "Text to be read by screen readers for the button that opens the calendar popover",
             control: "text",
         },
+        strategy: {
+            description:
+                "Swap between `fixed` and `absolute` positioning strategy. Use `fixed` when dropdown is in contained in an overflow and needs to be visible as you scroll the screen.",
+            options: ["fixed", "absolute"],
+            control: { type: "select" },
+        },
         onChange: {
             description: "Triggered when the selection changes",
             action: "onChange",
@@ -234,6 +240,13 @@ export const RangeWithFloatingLabel: StoryFn<EbayDateTextboxProps> = (args) => {
     };
 
     return <Component />;
+};
+
+export const WithFixedStrategy: StoryObj<EbayDateTextboxProps> = {
+    args: {
+        strategy: "fixed",
+        locale: "en-CA",
+    },
 };
 
 export const LocalizedGerman: StoryObj<EbayDateTextboxProps> = {

--- a/packages/ebayui-core-react/src/ebay-date-textbox/date-textbox.tsx
+++ b/packages/ebayui-core-react/src/ebay-date-textbox/date-textbox.tsx
@@ -40,6 +40,7 @@ export type EbayDateTextboxProps = Omit<EbayCalendarProps, "interactive" | "navi
         inputPlaceholderText?: string | string[];
         a11yOpenPopoverText?: string;
         locale?: string;
+        strategy?: "absolute" | "fixed";
         onChange?: EbayChangeEventHandler<HTMLInputElement, EventData> &
             EbayMouseEventHandler<HTMLInputElement, EventData> &
             EbayFocusEventHandler<HTMLInputElement, EventData>;
@@ -61,6 +62,7 @@ const EbayDateTextbox: FC<EbayDateTextboxProps> = ({
     defaultRangeEnd,
     collapseOnSelect,
     locale,
+    strategy,
     children,
     onChange = () => {},
     onInputChange = () => {},
@@ -94,6 +96,9 @@ const EbayDateTextbox: FC<EbayDateTextboxProps> = ({
 
     const { overlayStyles, refs } = useFloatingDropdown({
         open: isPopoverOpen,
+        options: {
+            strategy,
+        },
     });
 
     const containerRef = refs.host as React.MutableRefObject<HTMLSpanElement>;


### PR DESCRIPTION
- Fixes an internal ticket (business craft 1310)

## Description

Add `strategy` prop to `date-textbox` similar to what `listbox-button` have. This is helpful in case the component is used in a container that has `overflow: auto` or `hidden` which can clip the popover.

## Notes

## Screenshots

Default:

<img width="1786" height="935" alt="Screenshot 2026-08-18 at 18 17 06" src="https://github.com/user-attachments/assets/444db3ee-726a-4aba-b9e6-ce5f68e6f026" />

Fixed:

<img width="1793" height="986" alt="Screenshot 2026-08-18 at 18 18 05" src="https://github.com/user-attachments/assets/e0f60960-de0a-4d7b-a31c-6454abbab97b" />

## Checklist

<!-- For all PR types -->

- [x] I verify the linked issue has been triaged ("Needs Triage" label removed)
- [x] I verify all changes are within scope of the linked issue
- [x] I added/updated/removed testing (Storybook in Skin) coverage as appropriate

<!-- For CSS changes -->

- [ ] I tested the UI in all supported browsers
- [ ] I tested the UI in dark mode and RTL mode
