### PR TITLE
feat: add strategy prop to date-textbox

### DIFF
--- a/.changeset/date-textbox-strategy.md
+++ b/.changeset/date-textbox-strategy.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ui-core-react": minor
+---
+
+Add `strategy` prop to `EbayDateTextbox` to control calendar popover positioning (`absolute` or `fixed`) via `useFloatingDropdown`.

--- a/.changeset/date-textbox-strategy.md
+++ b/.changeset/date-textbox-strategy.md
@@ -1,5 +1,7 @@
 ---
+"@ebay/ebayui-core": minor
+"@ebay/skin": minor
 "@ebay/ui-core-react": minor
 ---
 
-Add `strategy` prop to `EbayDateTextbox` to control calendar popover positioning (`absolute` or `fixed`) via `useFloatingDropdown`.
+Add a `strategy` input to date textbox components to control calendar popover positioning (`absolute` or `fixed`).

--- a/packages/ebayui-core-react/src/ebay-date-textbox/__tests__/index.spec.tsx
+++ b/packages/ebayui-core-react/src/ebay-date-textbox/__tests__/index.spec.tsx
@@ -20,6 +20,12 @@ describe("<EbayDateTextbox />", () => {
 
         expect(container.querySelector(".date-textbox__popover")).not.toHaveAttribute("hidden");
     });
+    it("should position the popover with the given strategy", () => {
+        const { container } = render(<EbayDateTextbox strategy="fixed" />);
+        fireEvent.click(screen.getByLabelText("open calendar"));
+
+        expect(container.querySelector(".date-textbox__popover")).toHaveStyle({ position: "fixed" });
+    });
     it("should open the calendar when clicking on the postfix icon with children", () => {
         const { container } = render(
             <EbayDateTextbox>

--- a/packages/ebayui-core-react/src/ebay-date-textbox/__tests__/index.spec.tsx
+++ b/packages/ebayui-core-react/src/ebay-date-textbox/__tests__/index.spec.tsx
@@ -24,6 +24,7 @@ describe("<EbayDateTextbox />", () => {
         const { container } = render(<EbayDateTextbox strategy="fixed" />);
         fireEvent.click(screen.getByLabelText("open calendar"));
 
+        expect(container.querySelector(".date-textbox__popover")).toHaveClass("date-textbox__popover--fixed");
         expect(container.querySelector(".date-textbox__popover")).toHaveStyle({ position: "fixed" });
     });
     it("should open the calendar when clicking on the postfix icon with children", () => {

--- a/packages/ebayui-core-react/src/ebay-date-textbox/__tests__/index.stories.tsx
+++ b/packages/ebayui-core-react/src/ebay-date-textbox/__tests__/index.stories.tsx
@@ -122,7 +122,7 @@ or import styles using SCSS/CSS
         },
         strategy: {
             description:
-                "Swap between `fixed` and `absolute` positioning strategy. Use `fixed` when dropdown is in contained in an overflow and needs to be visible as you scroll the screen.",
+                "Swap between `fixed` and `absolute` positioning strategy. Use `fixed` when the dropdown is contained in an overflow and needs to remain visible as you scroll the screen.",
             options: ["fixed", "absolute"],
             control: { type: "select" },
         },

--- a/packages/ebayui-core-react/src/ebay-date-textbox/__tests__/index.stories.tsx
+++ b/packages/ebayui-core-react/src/ebay-date-textbox/__tests__/index.stories.tsx
@@ -120,6 +120,12 @@ or import styles using SCSS/CSS
             description: "Text to be read by screen readers for the button that opens the calendar popover",
             control: "text",
         },
+        strategy: {
+            description:
+                "Swap between `fixed` and `absolute` positioning strategy. Use `fixed` when dropdown is in contained in an overflow and needs to be visible as you scroll the screen.",
+            options: ["fixed", "absolute"],
+            control: { type: "select" },
+        },
         onChange: {
             description: "Triggered when the selection changes",
             action: "onChange",
@@ -234,6 +240,13 @@ export const RangeWithFloatingLabel: StoryFn<EbayDateTextboxProps> = (args) => {
     };
 
     return <Component />;
+};
+
+export const WithFixedStrategy: StoryObj<EbayDateTextboxProps> = {
+    args: {
+        strategy: "fixed",
+        locale: "en-CA",
+    },
 };
 
 export const LocalizedGerman: StoryObj<EbayDateTextboxProps> = {

--- a/packages/ebayui-core-react/src/ebay-date-textbox/date-textbox.tsx
+++ b/packages/ebayui-core-react/src/ebay-date-textbox/date-textbox.tsx
@@ -290,7 +290,12 @@ const EbayDateTextbox: FC<EbayDateTextboxProps> = ({
                 <EbayTextboxPostfixIcon icon={<EbayIconCalendar24 />} buttonAriaLabel={a11yOpenPopoverText} />,
             )}
 
-            <div hidden={!isPopoverOpen} ref={refs.setOverlay} style={overlayStyles} className="date-textbox__popover">
+            <div
+                hidden={!isPopoverOpen}
+                ref={refs.setOverlay}
+                style={overlayStyles}
+                className={classNames("date-textbox__popover", strategy === "fixed" && "date-textbox__popover--fixed")}
+            >
                 <EbayCalendar
                     {...rest}
                     locale={locale}

--- a/packages/ebayui-core-react/src/ebay-date-textbox/date-textbox.tsx
+++ b/packages/ebayui-core-react/src/ebay-date-textbox/date-textbox.tsx
@@ -40,6 +40,7 @@ export type EbayDateTextboxProps = Omit<EbayCalendarProps, "interactive" | "navi
         inputPlaceholderText?: string | string[];
         a11yOpenPopoverText?: string;
         locale?: string;
+        strategy?: "absolute" | "fixed";
         onChange?: EbayChangeEventHandler<HTMLInputElement, EventData> &
             EbayMouseEventHandler<HTMLInputElement, EventData> &
             EbayFocusEventHandler<HTMLInputElement, EventData>;
@@ -61,6 +62,7 @@ const EbayDateTextbox: FC<EbayDateTextboxProps> = ({
     defaultRangeEnd,
     collapseOnSelect,
     locale,
+    strategy,
     children,
     onChange = () => {},
     onInputChange = () => {},
@@ -94,6 +96,9 @@ const EbayDateTextbox: FC<EbayDateTextboxProps> = ({
 
     const { overlayStyles, refs } = useFloatingDropdown({
         open: isPopoverOpen,
+        options: {
+            strategy,
+        },
     });
 
     const containerRef = refs.host as React.MutableRefObject<HTMLSpanElement>;

--- a/packages/ebayui-core/src/components/ebay-date-textbox/component.ts
+++ b/packages/ebayui-core/src/components/ebay-date-textbox/component.ts
@@ -67,7 +67,7 @@ class DateTextbox extends Marko.Component<Input, State> {
         this.dropdownUtil = new DropdownUtil(
             this.el as HTMLElement,
             this.getEl("popover"),
-            { strategy: this.input.strategy },
+            { strategy: this.input.strategy ?? "absolute" },
         );
     }
 

--- a/packages/ebayui-core/src/components/ebay-date-textbox/component.ts
+++ b/packages/ebayui-core/src/components/ebay-date-textbox/component.ts
@@ -21,6 +21,7 @@ interface DateTextboxInput extends Omit<CalendarInput, `on${string}`> {
     rangeEnd?: Date | number | string;
     textbox?: Marko.AttrTag<TextboxInput>;
     disabled?: boolean;
+    strategy?: "absolute" | "fixed";
     /** @deprecated use `@textbox-input` instead */
     "input-placeholder-text"?: string | [string, string];
     "collapse-on-select"?: boolean;
@@ -66,6 +67,7 @@ class DateTextbox extends Marko.Component<Input, State> {
         this.dropdownUtil = new DropdownUtil(
             this.el as HTMLElement,
             this.getEl("popover"),
+            { strategy: this.input.strategy },
         );
     }
 

--- a/packages/ebayui-core/src/components/ebay-date-textbox/date-textbox.stories.ts
+++ b/packages/ebayui-core/src/components/ebay-date-textbox/date-textbox.stories.ts
@@ -87,6 +87,12 @@ export default {
                 },
             },
         },
+        strategy: {
+            options: ["fixed", "absolute"],
+            control: { type: "select" },
+            description:
+                "Swap between fixed and absolute positioning strategy. Use fixed when the popover is contained in an overflow and needs to remain visible as the page scrolls.",
+        },
         disabled: {
             type: "boolean",
             control: { type: "boolean" },
@@ -280,6 +286,11 @@ Default.parameters = {
             code: tagToString("ebay-date-textbox", {}),
         },
     },
+};
+
+export const WithFixedStrategy = Template.bind({});
+WithFixedStrategy.args = {
+    strategy: "fixed",
 };
 
 export const Localized = buildExtensionTemplate(

--- a/packages/ebayui-core/src/components/ebay-date-textbox/index.marko
+++ b/packages/ebayui-core/src/components/ebay-date-textbox/index.marko
@@ -5,6 +5,7 @@ $ const {
     range,
     inputPlaceholderText = placeholder(input.locale),
     disabled,
+    strategy,
     textbox,
     ...calendarInput
 } = input;
@@ -50,7 +51,14 @@ $ const formatValue = (date: DayISO | null) => {
             <ebay-calendar-24-icon/>
         </@postfix-icon>
     </ebay-textbox>
-    <div hidden=!state.popover key="popover" class="date-textbox__popover">
+    <div
+        hidden=!state.popover
+        key="popover"
+        class=[
+            "date-textbox__popover",
+            strategy === "fixed" && "date-textbox__popover--fixed",
+        ]
+    >
         <if(state.popover)>
             <subscribe to=window onResize("calculateNumMonths")/>
         </if>

--- a/packages/ebayui-core/src/components/ebay-date-textbox/marko-tag.json
+++ b/packages/ebayui-core/src/components/ebay-date-textbox/marko-tag.json
@@ -10,6 +10,9 @@
         "value": "expression",
         "rangeEnd": "expression",
         "range": "boolean",
+        "strategy": {
+            "enum": ["absolute", "fixed"]
+        },
         "todayISO": "expression",
         "disableBefore": "expression",
         "disableAfter": "expression",

--- a/packages/ebayui-core/src/components/ebay-date-textbox/test/test.browser.js
+++ b/packages/ebayui-core/src/components/ebay-date-textbox/test/test.browser.js
@@ -33,6 +33,21 @@ describe("ebay-date-textbox", () => {
         });
     });
 
+    describe("with fixed strategy", () => {
+        beforeEach(async () => {
+            component = await render(Default, { strategy: "fixed" });
+        });
+
+        it("positions the popover with the fixed strategy", () => {
+            const popover = component.container.querySelector(
+                ".date-textbox__popover",
+            );
+
+            expect(popover).toHaveClass("date-textbox__popover--fixed");
+            expect(popover).toHaveStyle({ position: "fixed" });
+        });
+    });
+
     describe("previous month selected", () => {
         beforeEach(async () => {
             component = await render(Default, { value: "01/27/2024" });

--- a/packages/skin/dist/date-textbox/date-textbox.css
+++ b/packages/skin/dist/date-textbox/date-textbox.css
@@ -20,6 +20,9 @@
     position: absolute;
     z-index: 1;
 }
+.date-textbox__popover--fixed {
+    position: fixed;
+}
 .date-textbox__popover[hidden] {
     display: none;
 }

--- a/packages/skin/src/sass/date-textbox/date-textbox.scss
+++ b/packages/skin/src/sass/date-textbox/date-textbox.scss
@@ -27,6 +27,10 @@
     z-index: 1;
 }
 
+.date-textbox__popover--fixed {
+    position: fixed;
+}
+
 .date-textbox__popover[hidden] {
     display: none;
 }


### PR DESCRIPTION
- Fixes #895

## Description

Add a `strategy` input to the React and legacy Marko date-textbox components, similar to listbox-button. This supports `absolute` and `fixed` calendar popover positioning for containers whose overflow would otherwise clip the popover.

Add the corresponding Skin fixed-position modifier, use it in both framework implementations, and cover the behavior in tests and Storybook.

## Notes

This replaces #892 so the branch is hosted in `eBay/evo-web` instead of a fork. It retains Giovanni Pires's original React implementation and extends it to Skin and legacy Marko.

## Screenshots

Default:

<img width="1786" height="935" alt="Default date textbox positioning" src="https://github.com/user-attachments/assets/444db3ee-726a-4aba-b9e6-ce5f68e6f026" />

Fixed:

<img width="1793" height="986" alt="Fixed date textbox positioning" src="https://github.com/user-attachments/assets/e0f60960-de0a-4d7b-a31c-6454abbab97b" />

## Checklist

- [ ] I verify the linked issue has been triaged ("Needs Triage" label removed)
- [ ] I verify all changes are within scope of the linked issue
- [ ] I added/updated/removed testing (Storybook in Skin) coverage as appropriate

- [ ] I tested the UI in all supported browsers
- [ ] I tested the UI in dark mode and RTL mode
