### PR TITLE
agent-feedback: adopt shared agent-feedback skills convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -283,7 +283,7 @@ npx vitest run packages/ebayui-core/src/components/ebay-button/test/test.browser
 
 ## Agent Feedback
 
-Anything actionable but out of scope for the current task — a suspected bug, an a11y gap, cleanup, a perf/size win, tooling friction, or code that was confusing — must be recorded in [`agent-feedback/`](agent-feedback/README.md) before finishing. Don't silently drop it, and don't fix it inside an unrelated diff. Read that README for the entry format; resolved entries are deleted in the same PR as the fix.
+Anything actionable but out of scope for the current task (suspected bug, a11y gap, cleanup, perf or size win, tooling friction, confusing code) must be filed in [`agent-feedback/`](agent-feedback/README.md) before finishing. Never drop it silently. Never fix it inside an unrelated diff.
 
 ---
 

--- a/agent-feedback/README.md
+++ b/agent-feedback/README.md
@@ -1,44 +1,54 @@
 # Agent Feedback
 
-Actionable observations that were **out of scope for the task that surfaced them**. If something is in scope, fix it instead. Do not expand a task's diff to fix issues recorded here.
+Actionable observations that were out of scope for the task that surfaced them. In scope: fix it. Out of scope: file it here. Never expand a task's diff to fix an item recorded here.
 
-## When to add an entry
+One item per file in `items/`, named `YYYY-MM-DD-<slug>.md`. Convention and triage skill: [DylanPiercey/skills](https://github.com/DylanPiercey/skills).
 
-While working on any task, record anything a future contributor should act on:
+## When to file
 
-- a suspected bug left unpursued → `bugs.md`
-- a WCAG 2.2 AA / ARIA / keyboard / RTL / dark-mode gap → `a11y.md`
-- duplication, dead code, inconsistency, refactor opportunities → `cleanup.md`
-- runtime speed, bundle size, or CSS output size opportunities → `perf.md`
-- friction in builds, tests, Storybook, or repo workflows → `dx.md`
-- code or docs that were confusing, and what would have clarified them → `unclear.md`
+Anything a future contributor should act on:
+
+- `bug`: a suspected defect left unpursued
+- `a11y`: a WCAG 2.2 AA / ARIA / keyboard / RTL / dark-mode gap
+- `cleanup`: duplication, dead code, inconsistency, refactor opportunity
+- `perf`: runtime speed, bundle size, or CSS output size
+- `dx`: friction in builds, tests, Storybook, or repo workflows
+- `unclear`: code or docs that were confusing, and what would have clarified them
 
 ## Rules
 
-1. **Search the category file first.** If an entry already covers it, don't duplicate; append a corroborating sentence only when it adds new information.
-2. **Be self-contained.** Include enough detail (paths, symbols, reasoning) that someone can act without re-discovering the analysis behind it. Never reference "my earlier analysis" or conversation context.
-3. **Cite by stable symbol, not line number.** Line numbers rot with the next edit; anchor the primary citation to the nearest enclosing stable symbol — an exported component or function, a `<tag>` in a `.marko` template, a BEM selector or mixin in SCSS, or a heading for docs. A line number may appear in the body as a secondary hint.
-4. **Note every package the entry spans.** A component usually exists in `skin`, `ebayui-core`, `evo-marko`, `ebayui-core-react` and `evo-react`; say which of them the defect reaches and which you actually checked.
-5. **Append to the end** of the category file.
-6. Entries are **removed when resolved** (delete, don't mark done; git history is the archive), in **the same PR as the fix**, never a follow-up PR. A partial fix rewrites the entry to what remains.
-7. **Verify before recording.** A guess is not feedback.
-8. **An entry is work to do, not documentation.** State the defect and the check that proves it. Never describe what already works, and never narrate what a landed fix changed.
+1. **Verify first.** A guess is not feedback. Every item ends with a check that reproduces the claim.
+2. **Dedupe first.** `grep -ril '<path or symbol>' agent-feedback/items`. If a file covers it, edit that file only when you add new information.
+3. **Check the code site.** An intent comment there means the behavior is deliberate. Do not file it.
+4. **Self-contained.** Paths, symbols, reasoning. Never reference conversation context or "earlier analysis".
+5. **Cite by stable symbol**, never line number — an exported component or function, a `<tag>` in a `.marko` template, a BEM selector or mixin in SCSS, or a heading for docs.
+6. **State the defect and the check.** Never describe what works. Never narrate a landed fix.
+7. **Direction is preventive for `unclear` and `dx`.** Name what would have stopped the trip: a comment, a doc line, a lint rule, a compile error, a debug-only warning. The goal is that the next agent does not hit it.
+8. **Resolve by deleting the file in the same PR as the fix.** A partial fix rewrites the file to what remains.
+9. **Won't-fix is a maintainer's call, never an agent's.** Add a comment (two lines max) at the code site stating the behavior and why it is deliberate, then delete the file. The comment is what stops re-filing. Never consult git history to learn whether something was resolved; if it is not in `items/` and not commented at the site, it is unresolved.
 
-## Resolving a "won't fix" item
+## Item format
 
-When a maintainer has explicitly deemed an item "won't fix" / "not worth it", resolve it by adding a brief inline comment at the code site that captures the decision (so it is not re-filed), then remove the entry. Only on such an explicit call, never on an agent's own initiative.
-
-## Entry format
+`items/YYYY-MM-DD-<slug>.md`:
 
 ```md
-## <one-line imperative summary>
+---
+type: bug | a11y | cleanup | perf | dx | unclear
+impact: high | med | low
+effort: high | med | low
+site: <path/to/file.ts> › <nearestStableSymbol>
+---
 
-`<primary/file/path.ts>` › `<nearestStableSymbol>` | <YYYY-MM-DD> | impact:<low|med|high> | effort:<low|med|high>
+# <one-line imperative title>
 
-<2-6 sentences: the problem, why it matters, and a concrete suggested direction,
-ending with the check that re-verifies the claim (a command, input, or
-observation). Cut evidence beyond what a fixer needs to act; further detail is
-re-derived from the citation. Additional file paths inline as needed.>
+<2-6 sentences: the problem, why it matters, a concrete direction. Cut evidence a fixer can re-derive from the site.>
+
+Check: <command, input, or observation that reproduces the claim>
 ```
 
-A re-verification check is a command someone else can run — `npx vitest run <path>`, `npm run build`, `npm run lint`, a Storybook story plus the interaction that exposes it, or a rendered-markup/computed-style observation. "Read the code and you'll see" is not a check.
+`impact`: what breaks or is lost if ignored. `effort`: expected size of the fix. Both are the filer's estimate; triage re-judges.
+
+## Repo notes
+
+- **Note every package the item spans.** A component usually exists in `skin`, `ebayui-core`, `evo-marko`, `ebayui-core-react` and `evo-react`; say which of them the defect reaches and which you actually checked.
+- A check is a command someone else can run — `npx vitest run <path>`, `npm run build`, `npm run lint`, a Storybook story plus the interaction that exposes it, or a rendered-markup/computed-style observation. "Read the code and you'll see" is not a check.

--- a/agent-feedback/a11y.md
+++ b/agent-feedback/a11y.md
@@ -1,3 +1,0 @@
-# Accessibility
-
-WCAG 2.2 AA gaps: ARIA misuse, keyboard operability, focus states, contrast, zoom to 400%, RTL, dark mode. Format and rules: [README.md](README.md).

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -1,3 +1,0 @@
-# Suspected Bugs
-
-Out-of-scope defects noticed while working on something else. Format and rules: [README.md](README.md).

--- a/agent-feedback/cleanup.md
+++ b/agent-feedback/cleanup.md
@@ -1,3 +1,0 @@
-# Cleanup
-
-Duplication, dead code, inconsistencies, refactor opportunities. Format and rules: [README.md](README.md).

--- a/agent-feedback/dx.md
+++ b/agent-feedback/dx.md
@@ -1,3 +1,0 @@
-# Developer Experience
-
-Friction in builds, tests, Storybook, or repo workflows. Format and rules: [README.md](README.md).

--- a/agent-feedback/perf.md
+++ b/agent-feedback/perf.md
@@ -1,3 +1,0 @@
-# Performance
-
-Runtime speed, bundle size, and CSS output size opportunities. Format and rules: [README.md](README.md).

--- a/agent-feedback/unclear.md
+++ b/agent-feedback/unclear.md
@@ -1,3 +1,0 @@
-# Unclear Code & Docs
-
-Things that were hard to understand, and what would have clarified them. Format and rules: [README.md](README.md).


### PR DESCRIPTION
Migrates `agent-feedback/` from in-house per-category files (`bugs.md`, `a11y.md`, …) to the shared one-file-per-item convention from DylanPiercey/skills, matching the migration marko already landed. The README now describes the `items/YYYY-MM-DD-<slug>.md` format with frontmatter (type/impact/effort/site), keeps evo's extra `a11y` type and cross-package repo notes, and the CLAUDE.md pointer is updated to match. All category files were empty, so no entries needed converting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)