### PR TITLE
fix(percy): restore PERCY_PARTIAL_BUILD for scoped PR snapshot checks

### DIFF
--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -81,6 +81,10 @@ jobs:
           PERCY_COMMIT: ${{ github.event.workflow_run.head_sha }}
           PERCY_BRANCH: ${{ github.event.workflow_run.head_branch }}
           PERCY_PULL_REQUEST: ${{ steps.meta.outputs.pr }}
+          # Required: without this, Percy's own missing-snapshot check treats scoped
+          # builds as incomplete full builds and fails the PR check with a
+          # "missing snapshots" error, even though the scoping is intentional.
+          PERCY_PARTIAL_BUILD: 1
           STORIES: ${{ steps.meta.outputs.components }}
         run: npx percy storybook ./storybook-static --include "$STORIES" -c packages/skin/.percy.yml
 


### PR DESCRIPTION
## Summary

Percy's PR checks are failing on scoped (component-specific) builds with a `1008 missing snapshots found` error, blocking merge — even though the build itself completes successfully and only the intended, changed components were meant to be snapshotted.

## Root cause

Percy has no way to tell, on its own, whether a build with fewer snapshots than the full baseline (1,012 stories) is:
- a deliberate scoped/partial build (only some components changed), or
- a full build that silently lost most of its snapshots due to a bug.

`PERCY_PARTIAL_BUILD=1` is the signal that disambiguates the two — it marks a build as intentionally partial so Percy doesn't compare it against the full baseline and flag the rest as missing.

This flag was present on the old `npm run snapshots` invocation used for scoped PR builds, but was dropped when that step was rewritten to call `npx percy storybook` directly against a static Storybook artifact (as part of splitting Percy CI into a two-stage, secret-isolated workflow). The flag's removal wasn't a deliberate design decision — it just didn't carry over when the step was rewritten — and nothing caught the gap until scoped builds started failing this check.

## Fix

Adds `PERCY_PARTIAL_BUILD: 1` back to the `env:` block of the **"Run Percy (Partial)"** step only, in the `percy-pr` job.

Scope, confirmed:
- **"Run Percy (All)"** (full builds triggered from a PR/branch) — untouched, has its own separate `env:` block without this flag, and its `if:` condition is mutually exclusive with the Partial step's.
- **`percy-main`** (the push-to-`main` baseline rebuild) — untouched, separate job, doesn't call `npx percy storybook` at all.
- No other lines in the workflow changed — triggers, config flags (`-c packages/skin/.percy.yml`), and the PR status-reporting step are all unaffected.

## Test plan

- [ ] Confirm this PR's own Percy PR check (scoped build) passes without a "missing snapshots" error
- [ ] Confirm a full-build PR (e.g. a global token/mixin change) still runs and reports normally
- [ ] Confirm a push to `main` still runs the full baseline build via `percy-main` unaffected