### PR TITLE
docs: inform date format for ebay-date-textbox disableBefore disableAfter

### DIFF
--- a/packages/ebayui-core-react/src/ebay-date-textbox/__tests__/index.stories.tsx
+++ b/packages/ebayui-core-react/src/ebay-date-textbox/__tests__/index.stories.tsx
@@ -3,7 +3,6 @@ import { StoryFn, Meta, StoryObj } from "@storybook/react-vite";
 import { EbayDateTextbox, EbayDateTextboxProps } from "../index";
 import { EbayButton } from "../../ebay-button";
 import { EbayTextbox } from "../../ebay-textbox";
-import { toISO } from "../../ebay-calendar/date-utils";
 
 const story: Meta<typeof EbayDateTextbox> = {
     component: EbayDateTextbox,
@@ -62,8 +61,8 @@ or import styles using SCSS/CSS
             description: "Whether the calendar should collapse after a date is selected",
             control: "boolean",
         },
-        disableBefore: { description: "First date that may be selected", control: "text" },
-        disableAfter: { description: "Last date that may be selected", control: "text" },
+        disableBefore: { description: "First date that may be selected (`YYYY-MM-DD`)", control: "text" },
+        disableAfter: { description: "Last date that may be selected (`YYYY-MM-DD`)", control: "text" },
         disableWeekdays: {
             description:
                 "List of weekdays that are disabled. Must be an array of numbers, where Sunday is `0` and Saturday is `6`",
@@ -247,13 +246,6 @@ export const WithFixedStrategy: StoryObj<EbayDateTextboxProps> = {
     args: {
         strategy: "fixed",
         locale: "en-CA",
-    },
-};
-
-export const WithDisableBefore: StoryObj<EbayDateTextboxProps> = {
-    args: {
-        locale: "en-CA",
-        disableBefore: toISO(new Date()),
     },
 };
 

--- a/packages/ebayui-core-react/src/ebay-date-textbox/__tests__/index.stories.tsx
+++ b/packages/ebayui-core-react/src/ebay-date-textbox/__tests__/index.stories.tsx
@@ -3,6 +3,7 @@ import { StoryFn, Meta, StoryObj } from "@storybook/react-vite";
 import { EbayDateTextbox, EbayDateTextboxProps } from "../index";
 import { EbayButton } from "../../ebay-button";
 import { EbayTextbox } from "../../ebay-textbox";
+import { toISO } from "../../ebay-calendar/date-utils";
 
 const story: Meta<typeof EbayDateTextbox> = {
     component: EbayDateTextbox,
@@ -246,6 +247,13 @@ export const WithFixedStrategy: StoryObj<EbayDateTextboxProps> = {
     args: {
         strategy: "fixed",
         locale: "en-CA",
+    },
+};
+
+export const WithDisableBefore: StoryObj<EbayDateTextboxProps> = {
+    args: {
+        locale: "en-CA",
+        disableBefore: toISO(new Date()),
     },
 };
 


### PR DESCRIPTION
## Description

Update `ebay-date-textbox` docs for `disableBefore` and `disableAfter` to inform the date format.

## Notes

FYI not touching marko stories docs, just React

## Screenshots

<img width="1588" height="245" alt="Screenshot 2026-08-21 at 15 39 26" src="https://github.com/user-attachments/assets/74abfb03-7729-44f0-8b02-1d21a9cdc124" />

## Checklist

- [ ] I verify the linked issue has been triaged ("Needs Triage" label removed)
- [x] I verify all changes are within scope of the linked issue
- [ ] I added/updated/removed testing (Storybook in Skin) coverage as appropriate
