### PR TITLE
feat(ai): add agent reliability layer alongside agent-feedback

### DIFF
--- a/.claude/AGENT-RELIABILITY.md
+++ b/.claude/AGENT-RELIABILITY.md
@@ -1,0 +1,82 @@
+# Agent Reliability: What Enforces What
+
+A technical reference mapping every mechanism that keeps an AI agent working reliably in this
+repo against the failure modes it actually defends against. Built from the agent-tooling work in
+`.claude/hooks/`, `.claude/skills/`, `.claude/settings.json`, `CLAUDE.md`, `agent-feedback/`, and
+`agent-lessons/`: every row and cell below names a real file.
+
+This is the technical reference. For the plain-language version, same system, written for a
+wider audience, see [`docs/ai/AGENT-RELIABILITY-OVERVIEW.md`](../docs/ai/AGENT-RELIABILITY-OVERVIEW.md).
+
+---
+
+## The core idea
+
+Every mechanism here sits somewhere on an axis from **asked** to **guaranteed**:
+
+- **Asked**: a standing instruction the model has to retrieve from context, interpret correctly,
+  and choose to follow. Nothing catches it if any of those three steps fails.
+- **Checked**: deterministic code that runs regardless of what the model is thinking, and reports
+  what it found. The model still has to act on the report, but the report itself doesn't depend on
+  the model's judgment.
+- **Blocked**: the action is unreachable at the tool layer before any model reasoning happens at
+  all.
+
+Four tiers exist in this repo today, roughly weakest to strongest guarantee:
+
+1. **CLAUDE.md prose**: asked.
+2. **Skills** (`.claude/skills/`): asked, but triggered by name/intent-match rather than passively
+   sitting in context, which makes retrieval more reliable than a buried CLAUDE.md line.
+3. **Hooks** (`.claude/hooks/`): checked.
+4. **Permissions** (`.claude/settings.json` → `permissions.deny`): blocked.
+
+There is no fifth "dated guards" tier in this repo. One was built and then deliberately reverted
+(see [Why some cells are empty](#why-some-cells-are-empty)); don't re-add it here without
+re-adding the mechanism.
+
+---
+
+## The matrix
+
+| Mechanism           | Hallucination                                                                                                                     | Context rot / lost-in-the-middle                                                                                                | Silent tool/process failure                                                                                                                                                                                                                                                                                                                                               | Scope creep                                                                                                                         | Irreversible action taken without review                                                                                                                                                                |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **CLAUDE.md prose** | ✅ `<correctness_guards>`: Marko 5→6 syntax, AttrTag generics, BEM, React package differences, kept inline on purpose (see below) | ✅ same section: inline placement in the primacy zone is the entire reason it wasn't extracted to a linked file                 | —                                                                                                                                                                                                                                                                                                                                                                         | ✅ `Agent Feedback` / `Agent Lessons` sections point out-of-scope findings/corrections at a named home instead of an unrelated diff | —                                                                                                                                                                                                       |
+| **Skills**          | — (skills point back to `<correctness_guards>` rather than restating syntax)                                                      | ⚠️ partial: invoked by name/intent rather than passively read, but still competes for attention once loaded into a long session | —                                                                                                                                                                                                                                                                                                                                                                         | ✅ `evo-file-item`: operationalizes filing so a finding doesn't expand the current diff or get silently dropped                     | ✅ `evo-triage-lessons`: requires per-item human confirmation before turning a lesson into a hook, permission, or CLAUDE.md change; never batch-applies                                                 |
+| **Hooks**           | —                                                                                                                                 | —                                                                                                                               | ✅ `check-pipeline-stop.js`: was an inline one-liner swallowing errors with `catch(e){}`; now a real file that exits 1 only when it can't enumerate components at all, and exits 2 (aggregating every per-component finding, including unreadable state files, so one bad file never hides another component's real in-progress state) whenever any real problem is found | —                                                                                                                                   | ✅ `check-pipeline-stop.js` blocks `Stop` while a component pipeline is mid-run; `session-start-context.js` surfaces unfinished work and backlog counts at session start so it isn't silently forgotten |
+| **Permissions**     | —                                                                                                                                 | —                                                                                                                               | —                                                                                                                                                                                                                                                                                                                                                                         | —                                                                                                                                   | ✅ `settings.json` `permissions.deny`: `git commit`/`git push`, and edits to generated icon files and `packages/skin/dist/`, are unreachable before the model ever reasons about them                   |
+
+---
+
+## Why some cells are empty
+
+Empty cells are not omissions, they're honest gaps, worth stating rather than papering over:
+
+- **Nothing below the prose tier defends hallucination or context rot.** You cannot mechanically
+  block "the model wrote Marko 5 syntax" the way you can block a `git push`, that would require a
+  linter or a compiler-level check, which doesn't exist yet. As long as this gap is real, the
+  guards in `<correctness_guards>` have to stay inline and in the primacy zone; moving them to a
+  linked file would remove the one defense this repo has for that failure mode. See the reasoning
+  in this session's history: Anthropic's own guidance and the Liu et al. "Lost in the Middle"
+  research (Stanford/UC Berkeley, 2024) both support keeping version-specific syntax examples
+  inline rather than referenced.
+- **There is no "dated guards" tier.** An attempt was made to extract `<correctness_guards>` into a
+  separate, dated `framework-guards.md` file with re-verify checks per entry, modeled on a step in
+  an external planning document. It was reverted in full once cross-checked against the research
+  above, because extraction-with-a-link is exactly the anti-pattern that research warns against for
+  this category of content. If a dated-guards mechanism gets rebuilt in the future, it needs its own
+  row here; don't assume it already exists because a plan once described it.
+- **Skills only partially defend context rot.** Being invoked by name is better than sitting
+  passively in a long context, but a skill's own instructions can still be forgotten or
+  misapplied deep into a long-running session. Nothing currently re-injects a skill's rules
+  mid-task the way `SessionStart` re-injects pipeline/backlog state at the start of one.
+
+---
+
+## Reading this table
+
+- A ✅ names the actual file responsible. If the file moves or is renamed, this table goes stale;
+  treat a stale entry here the same as any other agent-lessons-worthy correction.
+- A ⚠️ means partial coverage; read the note, don't treat it as equivalent to a ✅.
+- A `—` is a real gap. If you're about to build something new for a failure mode marked `—`, check
+  first whether the gap is structural (nothing _can_ mechanically defend it, per the note above) or
+  just hasn't been built yet.

--- a/.claude/hooks/check-pipeline-stop.js
+++ b/.claude/hooks/check-pipeline-stop.js
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+"use strict";
+
+/**
+ * Stop hook: blocks Claude Code from ending a session while a component
+ * pipeline run has a step still marked in-progress.
+ *
+ * Exit codes:
+ *   0 — safe to stop (nothing in-progress, or nothing to check)
+ *   1 — hook could not complete its check (treat as NOT verified — do not stop)
+ *   2 — an in-progress or corrupt/unverifiable step was found — do not stop
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const REPO_ROOT = path.resolve(__dirname, "../..");
+const COMPONENTS_BASE = path.join(REPO_ROOT, "src/routes/_index/components");
+
+function fail(message) {
+  process.stderr.write(
+    "\n🔴 Stop-hook check failed — could not verify pipeline state.\n" +
+      "  " +
+      message +
+      "\n" +
+      "  Treat this as unverified: do not stop until you can confirm no pipeline step is in-progress.\n",
+  );
+  process.exit(1);
+}
+
+function main() {
+  if (!fs.existsSync(COMPONENTS_BASE)) {
+    process.exit(0);
+  }
+
+  let components;
+  try {
+    components = fs
+      .readdirSync(COMPONENTS_BASE, { withFileTypes: true })
+      .filter((d) => d.isDirectory())
+      .map((d) => d.name);
+  } catch (e) {
+    return fail("Could not read " + COMPONENTS_BASE + ": " + e.message);
+  }
+
+  let blockStop = false;
+
+  for (const name of components) {
+    const statePath = path.join(COMPONENTS_BASE, name, "pipeline-state.json");
+    if (!fs.existsSync(statePath)) continue;
+
+    let raw;
+    try {
+      raw = fs.readFileSync(statePath, "utf8");
+    } catch (e) {
+      blockStop = true;
+      process.stdout.write(
+        '\n⚠️  pipeline-state.json could not be read for component "' +
+          name +
+          '" — do not stop.\n' +
+          "  Path: " +
+          statePath +
+          "\n" +
+          "  Error: " +
+          e.message +
+          "\n" +
+          "  An unreadable state file is not a known-safe state. Fix the error, then re-run\n" +
+          "  this check before stopping — other components are still checked below.\n",
+      );
+      continue;
+    }
+
+    let state;
+    try {
+      state = JSON.parse(raw);
+    } catch (e) {
+      blockStop = true;
+      process.stdout.write(
+        '\n⚠️  pipeline-state.json is corrupt for component "' +
+          name +
+          '" — do not stop.\n' +
+          "  Path: " +
+          statePath +
+          "\n" +
+          "  Corrupt state is not a known-safe state. Read the file, then fix or reset it\n" +
+          "  (see evo-pipeline SKILL.md) before stopping.\n",
+      );
+      continue;
+    }
+
+    const steps = state.steps || {};
+    const inProgress = Object.entries(steps).filter(
+      ([, v]) => v.status === "in-progress",
+    );
+    if (inProgress.length) {
+      blockStop = true;
+      process.stdout.write(
+        "\n⚠️  PIPELINE IN-PROGRESS — do not stop.\n" +
+          "  Component: " +
+          (state.component || name) +
+          "\n" +
+          "  Step " +
+          inProgress.map(([k]) => k).join(", ") +
+          " is still in-progress.\n" +
+          "  Read pipeline-state.json and advance to the next step before stopping.\n",
+      );
+    }
+  }
+
+  if (blockStop) process.exit(2);
+  process.exit(0);
+}
+
+main();

--- a/.claude/hooks/session-start-context.js
+++ b/.claude/hooks/session-start-context.js
@@ -68,6 +68,53 @@ function countMarkdownFiles(dir) {
   }
 }
 
+// Extracts a single `key: value` line from a file's leading `---`-fenced
+// frontmatter block. Returns null if there's no frontmatter, or the key
+// isn't present in it — callers treat null the same as "open" (fail open,
+// so a lesson never silently drops out of the count).
+function readFrontmatterField(filePath, key) {
+  let raw;
+  try {
+    raw = fs.readFileSync(filePath, "utf8");
+  } catch (e) {
+    return null;
+  }
+
+  const match = raw.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) return null;
+
+  const fieldMatch = match[1].match(
+    new RegExp("^" + key + ":\\s*(\\S+)", "m"),
+  );
+  return fieldMatch ? fieldMatch[1].trim() : null;
+}
+
+// agent-lessons entries carry a disposition (applied | declined | open).
+// Unlike agent-feedback, a resolved entry can stay on disk (declined
+// entries are kept as the record of the decision — see
+// agent-lessons/README.md), so a plain file count would overcount "open"
+// once any entry is ever declined. Anything not explicitly applied or
+// declined counts as open, including a file with no disposition field or
+// one that can't be read at all — surfacing an ambiguous entry is safer
+// than silently excluding it.
+function countOpenLessons(dir) {
+  if (!fs.existsSync(dir)) return 0;
+  let files;
+  try {
+    files = fs.readdirSync(dir).filter((f) => f.endsWith(".md"));
+  } catch (e) {
+    return 0;
+  }
+
+  return files.filter((f) => {
+    const disposition = readFrontmatterField(
+      path.join(dir, f),
+      "disposition",
+    );
+    return disposition !== "applied" && disposition !== "declined";
+  }).length;
+}
+
 function main() {
   const lines = [];
 
@@ -106,7 +153,7 @@ function main() {
     );
   }
 
-  const lessonsCount = countMarkdownFiles(AGENT_LESSONS_ITEMS);
+  const lessonsCount = countOpenLessons(AGENT_LESSONS_ITEMS);
   if (lessonsCount > 0) {
     lines.push(
       "ℹ️  agent-lessons/items/ has " +

--- a/.claude/hooks/session-start-context.js
+++ b/.claude/hooks/session-start-context.js
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+"use strict";
+
+/**
+ * SessionStart hook: surfaces short, high-decay context a fresh session has
+ * no other way to discover — unfinished pipeline work, and a nudge toward
+ * the agent-feedback and agent-lessons backlogs. Fires on every session
+ * start/resume/fork, so this must stay a cheap filesystem check, never a
+ * build or lint.
+ *
+ * Output contract: plain stdout on exit 0 is added directly to Claude's
+ * context for this event (no JSON envelope needed). This hook never blocks —
+ * unlike the Stop hook, SessionStart has no equivalent of exit-2 blocking;
+ * it can only inform.
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const REPO_ROOT = path.resolve(__dirname, "../..");
+const COMPONENTS_BASE = path.join(REPO_ROOT, "src/routes/_index/components");
+const AGENT_FEEDBACK_ITEMS = path.join(REPO_ROOT, "agent-feedback/items");
+const AGENT_LESSONS_ITEMS = path.join(REPO_ROOT, "agent-lessons/items");
+
+function findInProgressPipelines() {
+  if (!fs.existsSync(COMPONENTS_BASE)) return [];
+
+  let components;
+  try {
+    components = fs
+      .readdirSync(COMPONENTS_BASE, { withFileTypes: true })
+      .filter((d) => d.isDirectory())
+      .map((d) => d.name);
+  } catch (e) {
+    return [];
+  }
+
+  const inProgress = [];
+  for (const name of components) {
+    const statePath = path.join(COMPONENTS_BASE, name, "pipeline-state.json");
+    if (!fs.existsSync(statePath)) continue;
+
+    let state;
+    try {
+      state = JSON.parse(fs.readFileSync(statePath, "utf8"));
+    } catch (e) {
+      inProgress.push({ name, corrupt: true });
+      continue;
+    }
+
+    const steps = state.steps || {};
+    const steppedNames = Object.entries(steps)
+      .filter(([, v]) => v.status === "in-progress")
+      .map(([k]) => k);
+    if (steppedNames.length) {
+      inProgress.push({ name: state.component || name, steps: steppedNames });
+    }
+  }
+  return inProgress;
+}
+
+function countMarkdownFiles(dir) {
+  if (!fs.existsSync(dir)) return 0;
+  try {
+    return fs.readdirSync(dir).filter((f) => f.endsWith(".md")).length;
+  } catch (e) {
+    return 0;
+  }
+}
+
+function main() {
+  const lines = [];
+
+  const inProgress = findInProgressPipelines();
+  if (inProgress.length) {
+    lines.push("⚠️  Unfinished component pipeline work found:");
+    for (const p of inProgress) {
+      if (p.corrupt) {
+        lines.push(
+          "  - " +
+            p.name +
+            ": pipeline-state.json is corrupt — treat as unresolved, see evo-pipeline SKILL.md.",
+        );
+      } else {
+        lines.push(
+          "  - " +
+            p.name +
+            ": step(s) " +
+            p.steps.join(", ") +
+            " still in-progress. Run /evo-pipeline " +
+            p.name +
+            " to resume.",
+        );
+      }
+    }
+  }
+
+  const feedbackCount = countMarkdownFiles(AGENT_FEEDBACK_ITEMS);
+  if (feedbackCount > 0) {
+    lines.push(
+      "ℹ️  agent-feedback/items/ has " +
+        feedbackCount +
+        " unresolved item" +
+        (feedbackCount === 1 ? "" : "s") +
+        " — not urgent, but worth a glance if you have a lull: see agent-feedback/README.md.",
+    );
+  }
+
+  const lessonsCount = countMarkdownFiles(AGENT_LESSONS_ITEMS);
+  if (lessonsCount > 0) {
+    lines.push(
+      "ℹ️  agent-lessons/items/ has " +
+        lessonsCount +
+        " open entr" +
+        (lessonsCount === 1 ? "y" : "ies") +
+        " — see agent-lessons/README.md.",
+    );
+  }
+
+  if (lines.length) {
+    process.stdout.write("\n" + lines.join("\n") + "\n");
+  }
+
+  process.exit(0);
+}
+
+main();

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,10 +5,39 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node -e \"const fs=require('fs'),path=require('path');const base='src/routes/_index/components';if(!fs.existsSync(base))process.exit(0);const comps=fs.readdirSync(base,{withFileTypes:true}).filter(d=>d.isDirectory()).map(d=>d.name);let found=false;comps.forEach(c=>{const p=path.join(base,c,'pipeline-state.json');if(!fs.existsSync(p))return;try{const s=JSON.parse(fs.readFileSync(p,'utf8'));const ip=Object.entries(s.steps||{}).filter(([,v])=>v.status==='in-progress');if(ip.length){found=true;process.stdout.write('\\n⚠️  PIPELINE IN-PROGRESS — do not stop.\\n  Component: '+s.component+'\\n  Step '+ip.map(([k])=>k).join(', ')+' is still in-progress.\\n  Read pipeline-state.json and advance to the next step before stopping.\\n');}}catch(e){}});if(found)process.exit(2);\" 2>/dev/null"
+            "command": "node .claude/hooks/check-pipeline-stop.js"
           }
         ]
       }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|fork",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .claude/hooks/session-start-context.js"
+          }
+        ]
+      }
+    ]
+  },
+  "permissions": {
+    "deny": [
+      "Bash(git commit:*)",
+      "Bash(git push:*)",
+      "Edit(packages/skin/dist/**)",
+      "Write(packages/skin/dist/**)",
+      "Edit(packages/evo-react/src/icon/icons/**)",
+      "Write(packages/evo-react/src/icon/icons/**)",
+      "Edit(packages/ebayui-core-react/src/ebay-icon/icons/**)",
+      "Write(packages/ebayui-core-react/src/ebay-icon/icons/**)",
+      "Edit(packages/evo-marko/src/tags/evo-icon/tags/**)",
+      "Write(packages/evo-marko/src/tags/evo-icon/tags/**)",
+      "Edit(packages/ebayui-core/src/components/ebay-icon/icons/**)",
+      "Write(packages/ebayui-core/src/components/ebay-icon/icons/**)",
+      "Edit(packages/skin/src/sass/mixins/private/_generated-icon-mixins.scss)",
+      "Write(packages/skin/src/sass/mixins/private/_generated-icon-mixins.scss)"
     ]
   }
 }

--- a/.claude/skills/evo-file-item/SKILL.md
+++ b/.claude/skills/evo-file-item/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: evo-file-item
+description: >
+  Files an entry in agent-feedback/ (a code finding: bug, a11y gap, cleanup, perf,
+  dx friction, unclear code) or agent-lessons/ (a correction about how the agent
+  should work — not the code). Enforces both queues' own rules: category selection,
+  dedupe-first, verify-before-record, correct entry format, and (for agent-lessons)
+  a mandatory disposition. Use whenever the user says "file this", "add a feedback
+  item", "log this as a lesson", "record this finding", or whenever you notice
+  something actionable but out of scope for the current task and are about to write
+  an item into either queue.
+---
+
+# Filing agent-feedback / agent-lessons entries
+
+This skill operationalizes the rules already stated in
+[`agent-feedback/README.md`](../../../agent-feedback/README.md) and
+[`agent-lessons/README.md`](../../../agent-lessons/README.md). Those READMEs are the
+source of truth — if this skill and a README ever disagree, the README wins. This
+skill exists so the rules get applied the same way every time, not re-derived from
+memory mid-task.
+
+## Step 1 — Route to the right queue
+
+Apply the test `agent-lessons/README.md` states: **would this entry still make sense in a repo with
+none of this project's source in it?**
+
+- **Yes** → it's about how the agent works, not the code → `agent-lessons/`.
+  Examples: a correction someone gave that shouldn't be needed twice, a wrong turn
+  that cost real rework, a guardrail that fired.
+- **No** → it's about the actual codebase → `agent-feedback/`. Pick a category:
+  `bug`, `a11y`, `cleanup`, `perf`, `dx`, or `unclear`.
+
+State which queue and category you're filing into before writing anything. If you're
+unsure, re-read the relevant README's "When to file" / "What does not go here"
+sections rather than guessing.
+
+## Step 2 — Dedupe first
+
+Before creating a new file, search both queues:
+
+```bash
+grep -ril '<slug or symbol>' agent-feedback/items agent-lessons/items
+```
+
+If an existing entry already covers this, do not create a second one. Edit the
+existing file, and only append a new sentence if it adds information the original
+entry didn't have.
+
+## Step 3 — Verify before recording
+
+A guess is not feedback, in either queue.
+
+- **`agent-feedback`:** the entry must end with a command, input, or observation
+  someone else can run to reproduce the claim. "Read the code and you'll see" does
+  not count.
+- **`agent-lessons`:** the entry must describe something that actually happened — an
+  actual correction given, an actual observed cost (time lost, work redone, a review
+  cycle wasted) — not a hypothetical "this could go wrong."
+
+Also check the code site for an intent comment before filing an `agent-feedback` item
+— deliberate behavior isn't a bug.
+
+## Step 4 — Write the entry
+
+One file per item, `items/YYYY-MM-DD-<slug>.md`.
+
+**`agent-feedback` format:**
+
+```md
+---
+type: bug | a11y | cleanup | perf | dx | unclear
+impact: high | med | low
+effort: high | med | low
+site: <path/to/file.ts> › <nearestStableSymbol>
+---
+
+# <one-line imperative title>
+
+<2-6 sentences: the problem, why it matters, a concrete direction. Note every package
+the item spans if it's a component (skin, ebayui-core, evo-marko, ebayui-core-react,
+evo-react) and which you actually checked.>
+
+Check: <command, input, or observation that reproduces the claim>
+```
+
+**`agent-lessons` format:**
+
+```md
+---
+source: correction | observed-failure | guardrail-fired
+disposition: applied | declined | open
+---
+
+# <the lesson, stated as the rule it produced>
+
+<2-4 sentences: what happened, what it cost, and why the general rule follows from
+it. Quote the correction directly if there was one.>
+
+Disposition: applied to `<file or setting>` | declined, because <reason> | open —
+<owner>, raised <date>
+```
+
+## Step 5 — agent-lessons entries need a disposition
+
+Unlike `agent-feedback`, every `agent-lessons` entry carries a `disposition` from the
+moment it's filed:
+
+- If you already know the fix (e.g. you're filing this alongside building a hook or
+  permission in the same session), file it as `applied`, naming exactly where the
+  change landed.
+- If it needs a human decision you can't make, file it as `open`, and name who has to
+  answer it and the date raised. Never leave this blank — an unowned open question is
+  exactly the failure mode the README warns against.
+- Never mark something `declined` yourself — that's a maintainer's call. If you
+  believe an item should be declined, file it as `open` and say so.
+
+## Step 6 — Report back
+
+State which file you created or edited, and its category. Filing an item is not
+something to do silently in the background of an unrelated task — the user (or a
+future triage pass) needs to know it happened.
+
+## What this skill does not do
+
+It does not fix `agent-feedback` items (that's normal task work, done when someone's
+already in that area of the code) and it does not resolve `agent-lessons` items into
+hooks/permissions/CLAUDE.md changes — that's [`/evo-triage-lessons`](../evo-triage-lessons/SKILL.md),
+run on request, separately.

--- a/.claude/skills/evo-triage-lessons/SKILL.md
+++ b/.claude/skills/evo-triage-lessons/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: evo-triage-lessons
+description: >
+  On-request review of open agent-lessons/ entries. For each disposition: open item,
+  proposes whether it should become a hook, a permission, a CLAUDE.md line, or be
+  declined — and requires human confirmation before applying anything. Scoped to
+  agent-lessons/ only (agent-behavior corrections), not agent-feedback/ (code
+  findings, which get fixed as part of normal task work). Invoke with
+  /evo-triage-lessons, or when the user says "triage the lessons queue", "review
+  open lessons", or "what should we do with the agent-lessons entries".
+---
+
+# Triaging agent-lessons
+
+`agent-lessons/` has no scheduled review — there is no cron mechanism inside
+`.claude/`, and building one is explicitly out of scope for this repo's tooling (see
+`agent-lessons/README.md` and the reasoning behind why `SessionStart` only surfaces a
+_count_, never auto-triages). This skill is the deliberate, on-request substitute: a
+human runs it when they want a review, the same way `/evo-release-workflow` is run
+when someone wants to release.
+
+This skill only touches `agent-lessons/`. It never reads or modifies
+`agent-feedback/` — code findings get fixed as part of normal task work, not through
+this triage flow. If an item turns out to be a misfiled code finding, say so and
+suggest re-filing it with `/evo-file-item` — do not move it or attempt a fix
+yourself.
+
+## Step 1 — Enumerate
+
+List every file in `agent-lessons/items/` whose frontmatter has `disposition: open`.
+Skip anything already `applied` or `declined` — those are resolved, not this skill's
+job.
+
+Report the count first. If zero, say so and stop — there is nothing to triage.
+
+## Step 2 — Classify each open entry
+
+For every open entry, decide which bucket it falls into. Use the same
+mechanism-vs-judgment split behind every hook and permission already in this repo:
+
+- **Mechanically checkable by a script** → propose a **hook**. Point to
+  `.claude/hooks/check-pipeline-stop.js` and `.claude/hooks/session-start-context.js`
+  as the pattern to follow: a real file (not an inline one-liner), tested against
+  real and edge-case scenarios, fails loudly if it can't complete its check rather
+  than silently passing.
+- **A specific action that should simply never happen** → propose a **permission**
+  deny rule. Point to the existing `permissions.deny` block in `.claude/settings.json`
+  as the pattern.
+- **A standing fact or convention with no way to check it mechanically** → propose a
+  **CLAUDE.md** line, in whichever existing section it actually belongs
+  (`<agent_constraints>`, `<correctness_guards>`, etc.). Never invent a new top-level
+  CLAUDE.md section without asking first — adding sections changes the file's
+  structure and is worth a deliberate decision, not something to do inline mid-triage.
+- **Not worth fixing, or already covered by an existing hook/permission/rule** →
+  propose **declined**, with the one-sentence reason.
+
+State the proposed bucket and a concrete sketch of the change for every entry before
+moving to confirmation — don't just name the bucket, show what the hook/permission/
+CLAUDE.md line would actually say.
+
+## Step 3 — Confirm before applying anything
+
+Present every proposal and wait for explicit approval. Never batch-apply changes
+across multiple entries in one go, and never apply a single proposal without
+confirmation first — this mirrors how every hook and permission in this repo so far
+was built: proposed, reviewed, then written, one at a time.
+
+If a proposal is approved and it's a **hook** or **permission**, building and testing
+it is its own follow-up task — write the file, test it against real and edge-case
+scenarios the way the existing hooks were tested, don't just describe it and mark the
+lesson `applied` before the actual mechanism exists.
+
+If a proposal is approved and it's a **CLAUDE.md** line, make the smallest addition
+that states the rule — do not restate something already covered elsewhere in the
+file (check `<correctness_guards>`, `<agent_constraints>`, and any other relevant
+section first).
+
+## Step 4 — Resolve the entry: delete on apply, keep on decline
+
+`agent-lessons/` is a staging area, not a permanent home. A lesson's job is to exist
+just long enough to get promoted into a real enforcement surface — CLAUDE.md, a skill,
+a hook, or a permission. Once that surface exists and actually carries the rule,
+leaving the original lesson file in place too is exactly the same "wasteful,
+copy-pasted duplication" flagged elsewhere in this repo's own guidance — the same
+correction stated twice, with no reason for the second copy to exist. Nothing in
+`agent-lessons/` is delivered to a session automatically (see
+`.claude/hooks/session-start-context.js` — it only ever reports an open-item _count_,
+never content); the moment a lesson is promoted, its file is the only thing left
+saying the rule, and it is not being read by anyone or anything. This mirrors
+`agent-feedback/README.md`'s own rule exactly: **"Resolve by deleting the file... git
+history is the archive."**
+
+- **Applied** — once the change actually lands (the hook is written and tested, the
+  permission is added, or the CLAUDE.md line is written), **delete the entry file.**
+  Do not mark it `applied` and leave it in place — an `applied` file sitting in
+  `agent-lessons/items/` forever is not a record, it's an inert second copy of a rule
+  that now lives somewhere a session actually reads. If the promotion is a multi-step
+  follow-up (e.g. approved now, hook built later), leave the entry `open` with that
+  follow-up named as the next step — do not mark `applied` before the surface exists.
+- **Declined** — edit the entry's `Disposition:` line to state the reason, and leave
+  the file in place. A declined lesson is not promoted anywhere else, so its file is
+  still the only record of the decision — deleting it would lose the reasoning, the
+  same way deleting an `agent-feedback` item without a fix would.
+
+Never leave an entry `open` after a triage pass unless the user explicitly defers a
+decision — in that case, restate it as an open question with a named owner and the
+date raised, per `agent-lessons/README.md`'s own rule. An open question with nobody
+named to answer it is the exact failure mode the queue's design exists to prevent.
+
+## What this skill does not do
+
+- Does not run on a schedule — there is no mechanism for that here, by design.
+- Does not touch `agent-feedback/`.
+- Does not write hooks, permissions, or CLAUDE.md changes without a human confirming
+  each one individually.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -287,6 +287,12 @@ Anything actionable but out of scope for the current task (suspected bug, a11y g
 
 ---
 
+## Agent Lessons
+
+A correction about how you should work — not the code — belongs in [`agent-lessons/`](agent-lessons/README.md): a correction you shouldn't need twice, a wrong turn that cost real rework, or a guardrail that fired. If the rule is mechanically checkable, it belongs in a hook or permission instead, not here.
+
+---
+
 ## Skills
 
 For specialized workflows:

--- a/agent-lessons/README.md
+++ b/agent-lessons/README.md
@@ -1,0 +1,63 @@
+# Agent Lessons
+
+How we work with the agent, and what it gets wrong. **Not** findings about the code — those go in
+[`agent-feedback/`](../agent-feedback/README.md). The test: would this entry still make sense in a
+repo with none of our source in it? If yes, it belongs here. If it's about a bug, a gap, or
+cleanup in the actual codebase, it belongs there instead.
+
+**No named owner.** This queue is surfaced automatically at the start of every session (see the
+`SessionStart` hook in `.claude/settings.json`) — visibility is the enforcement mechanism, not a
+person who has to remember to check a file.
+
+## When to file
+
+1. A correction someone gave the agent that it should not need to hear twice.
+2. A failure with an observed cost: a wrong turn taken, work that had to be redone, a wasted
+   review cycle.
+3. A guardrail (hook, permission, dated guard) that fired, and whether it was right to.
+
+## What does not go here
+
+Anything that can be enforced mechanically. If a rule is checkable by a script, it belongs in a
+hook or a permission instead — an entry here is only worth writing if it explains _why_ that check
+exists, not as a substitute for building the check.
+
+## Every entry ends with a decision
+
+No entry stays open indefinitely. Exactly one of:
+
+- **Applied** — the correction now lives somewhere a session actually reads: a CLAUDE.md line, a
+  hook, a permission, or a skill. **Delete the entry file once that surface exists and carries the
+  rule** — nothing in `agent-lessons/` is delivered to a session automatically (see
+  `.claude/hooks/session-start-context.js`; it reports an open-item _count_, never content), so a
+  lesson marked `applied` but left in place is an inert second copy of a rule nobody reads from
+  here anymore. Same rule as `agent-feedback/README.md`: resolve by deleting, git history is the
+  archive. Most entries end here.
+- **Declined** — with the reason, and the file stays in place (this is the only surviving record
+  of the decision). A legitimate outcome, not a failure to resolve.
+- **Open question** — with who has to answer it and the date it was raised. Only for genuinely
+  unresolved judgment calls, not a place to park things nobody got to.
+
+A file of observations that never resolve into a decision is a diary, and nobody reads a diary.
+
+## Entry format
+
+One file per lesson in `items/`, named `YYYY-MM-DD-<slug>.md`:
+
+```md
+---
+source: correction | observed-failure | guardrail-fired
+disposition: applied | declined | open
+---
+
+# <the lesson, stated as the rule it produced>
+
+<2-4 sentences: what happened, what it cost, and why the general rule follows from it. Quote the
+correction directly if there was one — the original wording is usually sharper than a paraphrase.>
+
+Disposition: applied to `<file or setting>` | declined, because <reason> | open — <owner>, raised <date>
+```
+
+## Entries
+
+See `items/` for individual entries.

--- a/agent-lessons/README.md
+++ b/agent-lessons/README.md
@@ -14,7 +14,7 @@ person who has to remember to check a file.
 1. A correction someone gave the agent that it should not need to hear twice.
 2. A failure with an observed cost: a wrong turn taken, work that had to be redone, a wasted
    review cycle.
-3. A guardrail (hook, permission, dated guard) that fired, and whether it was right to.
+3. A guardrail (hook or permission) that fired, and whether it was right to.
 
 ## What does not go here
 

--- a/docs/ai/AGENT-RELIABILITY-OVERVIEW.md
+++ b/docs/ai/AGENT-RELIABILITY-OVERVIEW.md
@@ -1,0 +1,180 @@
+# Agent Reliability: How the Pieces Work Together
+
+**Overview for engineers and stakeholders**
+
+---
+
+## Why This Document Exists
+
+This document is a record of system design decisions and the reasoning behind them, written in plain language for easier understanding by engineers and stakeholders. It is meant to relay why the changes that accompany the implementation of agent reliability were made, and how the different pieces work together to achieve that goal.
+
+**This is a reading aid, not a second source of truth.** The technical reference,
+[`.claude/AGENT-RELIABILITY.md`](../../.claude/AGENT-RELIABILITY.md), is what's authoritative:
+it names real files and gets checked against the actual repo state. This document exists only to
+explain that same material in plain language. If the two ever disagree, the technical reference is
+right and this one is out of date.
+
+**Keeping it current is everyone's job, not a one-time write.** When a new layer, hook, or skill
+gets added, this document should get a matching update, the same way the technical reference does.
+A stale plain-language explanation is exactly the kind of thing `agent-lessons/` exists to catch:
+worth filing rather than letting it quietly drift further from what's actually running.
+
+---
+
+## What This Is
+
+`agent-feedback/` already existed: a shared to-do list where anyone working on the code, human
+or AI, can jot down a real problem they noticed but didn't have time to fix, so it doesn't get
+lost or drag their current task off-track. It works well and nothing here replaces it.
+
+What it doesn't cover is a different kind of problem: keeping the _agent itself_ reliable, making
+sure it doesn't stop mid-task without saying so, doesn't forget unfinished work between sessions,
+doesn't run something risky without a person seeing it first, and has somewhere to put a
+correction about its own behavior instead of it being said once and then relying on memory next
+time. This document explains, in plain language, the small set of pieces added to cover that, and
+how each one leans on `agent-feedback`'s own proven pattern rather than reinventing it.
+
+The technical version of this same material, every real file name, every exact behavior, lives
+in [`.claude/AGENT-RELIABILITY.md`](../../.claude/AGENT-RELIABILITY.md). This document is the
+plain-language version of that one.
+
+---
+
+## The Core Idea, in One Paragraph
+
+There's a real difference between _telling_ an AI agent to do something and _making sure_ it
+happens. Telling it works most of the time, but "most of the time" isn't good enough for things
+that are expensive to get wrong, like accidentally committing code nobody reviewed, or an
+unfinished task quietly falling through the cracks. So four different layers were built, each one
+a step stronger than the last, and the strongest layer that made sense was used for each specific
+problem. Weaker layers aren't a downgrade: they're the right tool for things that genuinely need
+a person's judgment, not a switch that can be flipped for them.
+
+## The Four Layers
+
+### 1. Written instructions (`CLAUDE.md`)
+
+This is the plainest layer: a standing set of instructions the agent reads at the start of every
+session. Think of it as a policy document: it's always there, but following it still depends on
+the agent remembering it, understanding it correctly, and choosing to comply. That's not a flaw;
+it's simply the nature of an instruction. It's the right layer for things that need a person's
+own judgment to write once, like the exact syntax to use for a specific version of a framework,
+because that kind of correction genuinely can't be turned into a yes/no rule a computer can check.
+
+### 2. Skills (specialized instruction sets, invoked by name)
+
+A skill is a more detailed set of instructions that the agent pulls in only when it's actually
+doing that specific job: filing something, reviewing a change, releasing a package. Because it's
+summoned by name rather than sitting passively in the background the whole time, it's less likely
+to get lost in a long conversation. Two new skills were built this round: one that files things
+correctly into either backlog (more on that below), and one that reviews open items in the newer
+backlog and decides what, if anything, should be promoted into a stronger layer.
+
+### 3. Automatic checks ("hooks")
+
+This is where things stop being just instructions and start being code that runs on its own,
+whether or not the agent remembers to ask for it. One check runs every time the agent is about to
+stop responding, and it looks at whether a multi-step component build was left mid-way; if so, it
+refuses to let the agent walk away quietly. Another check runs at the very start of every new
+conversation, and it reports two things automatically: whether any unfinished work is sitting on
+disk from a previous session, and how many items are waiting in either backlog. Neither of these
+depends on the agent choosing to look; they just run.
+
+### 4. Hard blocks (permissions)
+
+This is the strongest layer: certain actions are switched off entirely, before the agent ever gets
+a chance to reason about whether to do them. Right now that covers things like committing or
+pushing code without being asked, and editing files that are supposed to be auto-generated (a
+build regenerates them anyway, so a hand-edit there just gets silently thrown away the next time
+someone runs a build; this stops that from happening in the first place). There's no scenario
+where the agent "forgets" this rule, because it's not a rule the agent is following: it's a door
+that's simply locked.
+
+---
+
+## How Each Layer Complements `agent-feedback`
+
+`agent-feedback` solved one specific, real problem well: don't let a stray finding balloon an
+unrelated pull request, and don't lose it either. Everything added this round exists because that
+same good pattern, a shared, disciplined backlog, didn't yet cover a few other things:
+
+- **A twin backlog, `agent-lessons`, for corrections about the agent's _behavior_ rather than the
+  code.** `agent-feedback` is about what's wrong with the codebase. `agent-lessons` is about what
+  the agent got wrong and the correction that followed, a mistake that shouldn't need to be
+  pointed out twice. It uses the exact same discipline `agent-feedback` already proved works: one
+  file per item, a clear resolution, nothing left open forever. The one real difference: once a
+  lesson is actually promoted into a stronger layer above (a written rule, a skill, a hard block),
+  its file gets deleted, the same way `agent-feedback` already deletes an item once it's fixed. A
+  lesson's job is to exist only until it's been folded into something that's actually enforced;
+  keeping it around after that would just be the same correction sitting in two places.
+- **A way to _notice_ both backlogs exist, automatically.** Filing something into either backlog
+  was always something a person or the agent had to actively do. Nothing ever told a fresh session
+  "by the way, there are open items waiting." Now the very first thing a new conversation sees
+  includes a one-line count of anything open in either backlog, not the content, just enough of a
+  nudge that it's never silently forgotten the way a to-do list in a drawer can be.
+- **A companion skill that keeps filing quality consistent.** `agent-feedback` already has good
+  rules: check for duplicates first, verify before writing anything down, always include a way to
+  confirm the problem is real. Those rules only work if they're actually followed the same way
+  every time. The new filing skill is exactly that checklist, applied automatically whenever
+  something is being filed into either backlog, so quality doesn't quietly drift depending on who
+  (or which session) is doing the filing.
+
+None of this changes what `agent-feedback` does or how it works. It's additive: the same idea,
+extended to cover the two things a code-findings backlog was never meant to handle, the agent's
+own behavior, and making sure nobody has to remember to go check either list.
+
+---
+
+## How This Adds Up to Better Model Performance
+
+Every one of these layers is aimed at the same underlying issue: a large language model has a
+limited ability to hold onto everything relevant in a long conversation, and it will always
+default to whatever's most familiar from its training, even when that's outdated or wrong for
+this specific codebase. That's not a bug to be embarrassed about; it's just how the technology
+works, the same way a very well-read person can still misremember a fact under pressure. The fix
+isn't to hope it remembers better; it's to stop relying on memory for the things that matter most.
+
+Concretely:
+
+- **Fewer silent failures.** Before this work, a script whose job was to catch a stalled
+  multi-step build could fail quietly and nobody would know the safety check itself had broken.
+  Now that failure is loud and impossible to miss.
+- **Less repeated correction.** Right now, if someone corrects the agent mid-task, that correction
+  usually only helps for the rest of that one conversation. `agent-lessons` gives that correction
+  somewhere permanent to go, and a real path for it to become a rule the agent can't help but
+  follow, instead of something a person has to keep re-explaining every time it comes up again.
+- **Fewer surprises at review time.** A hard block means a risky action was never possible in the
+  first place, rather than something a reviewer has to catch after the fact. That's less mental
+  load on the human reviewing the work, and it means the agent's mistakes cost less when they do
+  happen.
+- **A session picks up where the last one left off.** New conversations used to start from zero
+  awareness of anything left unfinished. Now the very first moment of a new session already knows
+  about open work and open backlog items, without anyone having to re-explain the state of things.
+
+---
+
+## A Few Things Worth Knowing
+
+**This isn't about not trusting the agent.** It's the same reason a good engineering team writes
+automated tests instead of just trusting everyone to remember to check things by hand: it's not
+a judgment on anyone's diligence, it's just a more reliable way to get consistent results at scale,
+across many sessions and many different people using it.
+
+**Stronger isn't always better; matching the right layer to the right problem matters.** A hard
+block is not appropriate for something that genuinely requires a person's judgment call, and a
+written instruction isn't strong enough for something that must never happen. Part of the work
+here was correctly matching each real problem to the right layer, not reflexively reaching for the
+strongest one available every time.
+
+**Two changes were deliberately reversed partway through this work**, once checked against
+research on how these models actually behave. One attempt moved some version-specific coding
+guidance out of the main instructions and into a separate linked file, and it turned out that
+actively hurts reliability for that particular kind of content (it needs to stay front-and-center,
+not tucked away behind a link). I caught it, undid it, and moved on. That's worth mentioning
+because it's a good example of the whole approach: build it, then genuinely check it, rather than
+assume something sounds reasonable and ship it anyway.
+
+**This is a foundation, not a finished system.** A few refinements are already identified for a
+future round, for example, giving the open-items backlog a hard cap and a decide-by date so
+nothing can sit unanswered indefinitely, the same way a well-run project doesn't let a review
+queue grow forever. Those are deliberately left for later rather than rushed into this round.


### PR DESCRIPTION
## Summary

Adds a small set of agent-tooling mechanisms that complement the existing `agent-feedback/` backlog, aimed at keeping the agent itself reliable across sessions rather than just tracking code findings:

- **`agent-lessons/`** — a twin backlog for corrections about agent *behavior* (not code), following the same discipline as `agent-feedback` (one file per item, resolved by deletion).
- **`.claude/hooks/check-pipeline-stop.js`** — replaces a previous inline, error-swallowing one-liner. Blocks `Stop` while a component pipeline is mid-run, and now aggregates every per-component finding (including unreadable state files) instead of silently hiding one problem behind another.
- **`.claude/hooks/session-start-context.js`** — reports unfinished pipeline work and open backlog counts (`agent-feedback` + `agent-lessons`) automatically at the start of every new session.
- **`.claude/settings.json`** — adds a `permissions.deny` block (no unattended `git commit`/`git push`, no edits to generated icon files or `packages/skin/dist/`) and wires up the `SessionStart` hook.
- **`.claude/skills/evo-file-item/`** — operationalizes both backlogs' filing rules (routing, dedupe, verify-before-record, correct format) so filing quality doesn't drift by session.
- **`.claude/skills/evo-triage-lessons/`** — on-request review of open `agent-lessons` entries; proposes promoting each into a hook, permission, or CLAUDE.md line, and requires per-item human confirmation before applying anything.
- **`.claude/AGENT-RELIABILITY.md`** — technical reference mapping every mechanism above to the specific failure mode it defends against (hallucination, context rot, silent failure, scope creep, unreviewed irreversible actions), and stating plainly where gaps still exist.
- **`docs/ai/AGENT-RELIABILITY-OVERVIEW.md`** — plain-language companion to the technical reference, for engineers and stakeholders who want the reasoning without the file-level detail.

None of this changes what `agent-feedback` does. It's additive, covering what a code-findings backlog was never meant to handle.

## Test plan

- [ ] `.claude/settings.json` is valid JSON and the `Stop`/`SessionStart` hooks fire as expected in a live session
- [ ] `check-pipeline-stop.js` correctly blocks `Stop` on an in-progress `pipeline-state.json` and surfaces (not hides) an unreadable state file alongside a real finding
- [ ] `session-start-context.js` reports accurate `agent-feedback`/`agent-lessons` counts and unfinished pipeline work at session start
- [ ] `permissions.deny` blocks `git commit`/`git push` and edits to the listed generated files
- [ ] Cross-links between `.claude/AGENT-RELIABILITY.md` and `docs/ai/AGENT-RELIABILITY-OVERVIEW.md` resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)