### PR TITLE
fix(skin): use solid tokens for calendar range fill and accent for selected days

### DIFF
--- a/.changeset/calendar-range-solid-fill.md
+++ b/.changeset/calendar-range-solid-fill.md
@@ -2,4 +2,4 @@
 "@ebay/skin": patch
 ---
 
-calendar: use a solid background token for day hover and range fills so they match and no longer stack translucent state layers, and switch the selected-day background and the current-day border to the accent (blue) color
+calendar: use a solid background token for day hover and range fills so they match and no longer stack translucent state layers, and switch the selected-day background and the current-day border and text to the accent (blue) color

--- a/.changeset/calendar-range-solid-fill.md
+++ b/.changeset/calendar-range-solid-fill.md
@@ -2,4 +2,4 @@
 "@ebay/skin": patch
 ---
 
-calendar: use a solid background token for range fills so the inner half of a hovered, unselected range endpoint no longer renders darker from stacked translucent state layers, and switch selected days to the accent (blue) background
+calendar: use a solid background token for day hover and range fills so they match and no longer stack translucent state layers, and switch selected days to the accent (blue) background

--- a/.changeset/calendar-range-solid-fill.md
+++ b/.changeset/calendar-range-solid-fill.md
@@ -1,0 +1,5 @@
+---
+"@ebay/skin": patch
+---
+
+calendar: use a solid background token for range fills so the inner half of a hovered, unselected range endpoint no longer renders darker from stacked translucent state layers, and switch selected days to the accent (blue) background

--- a/.changeset/calendar-range-solid-fill.md
+++ b/.changeset/calendar-range-solid-fill.md
@@ -2,4 +2,4 @@
 "@ebay/skin": patch
 ---
 
-calendar: use a solid background token for day hover and range fills so they match and no longer stack translucent state layers, and switch selected days to the accent (blue) background
+calendar: use a solid background token for day hover and range fills so they match and no longer stack translucent state layers, and switch the selected-day background and the current-day border to the accent (blue) color

--- a/packages/skin/dist/calendar/calendar.css
+++ b/packages/skin/dist/calendar/calendar.css
@@ -86,6 +86,7 @@
         var(--color-border-accent)
     );
     border-style: solid;
+    color: var(--calendar-day-today-color, var(--color-foreground-accent));
 }
 .calendar__month td > .calendar__cell--disabled,
 .calendar__month td > :disabled {

--- a/packages/skin/dist/calendar/calendar.css
+++ b/packages/skin/dist/calendar/calendar.css
@@ -83,7 +83,7 @@
     > [aria-current="date"]:not(:disabled) {
     border-color: var(
         --calendar-day-today-border-color,
-        var(--color-foreground-primary)
+        var(--color-border-accent)
     );
     border-style: solid;
 }

--- a/packages/skin/dist/calendar/calendar.css
+++ b/packages/skin/dist/calendar/calendar.css
@@ -136,16 +136,19 @@
 .calendar__month td.calendar__cell--selected > * {
     background-color: var(
         --calendar-day-selected-background-color,
-        var(--color-background-inverse)
+        var(--color-background-accent)
     );
     color: var(
         --calendar-day-selected-color,
-        var(--color-foreground-on-inverse)
+        var(--color-foreground-on-accent)
     );
     font-weight: 700;
 }
 .calendar__range {
-    background-color: var(--color-state-layer-pressed);
+    background-color: var(
+        --calendar-range-background-color,
+        var(--color-background-secondary)
+    );
     position: relative;
 }
 .calendar__range:before {
@@ -169,14 +172,22 @@
     background: linear-gradient(
         to right,
         transparent 50%,
-        var(--color-state-layer-pressed) 50%
+        var(
+                --calendar-range-background-color,
+                var(--color-background-secondary)
+            )
+            50%
     );
 }
 .calendar__range--end {
     background: linear-gradient(
         to left,
         transparent 50%,
-        var(--color-state-layer-pressed) 50%
+        var(
+                --calendar-range-background-color,
+                var(--color-background-secondary)
+            )
+            50%
     );
 }
 .calendar__range--start.calendar__range--end {
@@ -186,5 +197,8 @@
     > :not(:disabled, [aria-disabled="true"]),
 .calendar__range--start:not(.calendar__cell--selected)
     > :not(:disabled, [aria-disabled="true"]) {
-    background-color: var(--color-state-layer-pressed);
+    background-color: var(
+        --calendar-range-background-color,
+        var(--color-background-secondary)
+    );
 }

--- a/packages/skin/dist/calendar/calendar.css
+++ b/packages/skin/dist/calendar/calendar.css
@@ -130,6 +130,22 @@
 }
 .calendar__month
     td:not(.calendar__range, .calendar__cell--selected)
+    > button:not(:disabled, [aria-disabled="true"]):hover {
+    background-color: var(
+        --calendar-day-highlight-background-color,
+        var(--color-background-secondary)
+    );
+}
+.calendar__month
+    td:not(.calendar__range, .calendar__cell--selected)
+    > button:not(:disabled, [aria-disabled="true"]):hover:not(
+        :active,
+        :focus-visible
+    ):after {
+    background-color: initial;
+}
+.calendar__month
+    td:not(.calendar__range, .calendar__cell--selected)
     > button:not(:disabled):active {
     font-weight: 700;
 }
@@ -146,7 +162,7 @@
 }
 .calendar__range {
     background-color: var(
-        --calendar-range-background-color,
+        --calendar-day-highlight-background-color,
         var(--color-background-secondary)
     );
     position: relative;
@@ -173,7 +189,7 @@
         to right,
         transparent 50%,
         var(
-                --calendar-range-background-color,
+                --calendar-day-highlight-background-color,
                 var(--color-background-secondary)
             )
             50%
@@ -184,7 +200,7 @@
         to left,
         transparent 50%,
         var(
-                --calendar-range-background-color,
+                --calendar-day-highlight-background-color,
                 var(--color-background-secondary)
             )
             50%
@@ -198,7 +214,7 @@
 .calendar__range--start:not(.calendar__cell--selected)
     > :not(:disabled, [aria-disabled="true"]) {
     background-color: var(
-        --calendar-range-background-color,
+        --calendar-day-highlight-background-color,
         var(--color-background-secondary)
     );
 }

--- a/packages/skin/dist/calendar/calendar.css
+++ b/packages/skin/dist/calendar/calendar.css
@@ -81,10 +81,7 @@
 .calendar__month
     td:not(.calendar__cell--selected)
     > [aria-current="date"]:not(:disabled) {
-    border-color: var(
-        --calendar-day-today-border-color,
-        var(--color-border-accent)
-    );
+    border-color: var(--calendar-day-today-border-color, currentcolor);
     border-style: solid;
     color: var(--calendar-day-today-color, var(--color-foreground-accent));
 }

--- a/packages/skin/src/sass/calendar/calendar.scss
+++ b/packages/skin/src/sass/calendar/calendar.scss
@@ -124,7 +124,7 @@
     > .calendar__cell--current:not(.calendar__cell--disabled) {
     @include token-mixins.border-color-token(
         calendar-day-today-border-color,
-        color-foreground-primary
+        color-border-accent
     );
 
     border-style: solid;

--- a/packages/skin/src/sass/calendar/calendar.scss
+++ b/packages/skin/src/sass/calendar/calendar.scss
@@ -144,6 +144,24 @@
 
 .calendar__month
     td:not(.calendar__range, .calendar__cell--selected)
+    > button:not(:disabled, [aria-disabled="true"]):hover {
+    background-color: var(
+        --calendar-day-highlight-background-color,
+        var(--color-background-secondary)
+    );
+}
+
+.calendar__month
+    td:not(.calendar__range, .calendar__cell--selected)
+    > button:not(:disabled, [aria-disabled="true"]):hover:not(
+        :active,
+        :focus-visible
+    )::after {
+    background-color: transparent;
+}
+
+.calendar__month
+    td:not(.calendar__range, .calendar__cell--selected)
     > button:not(:disabled):active {
     font-weight: bold;
 }
@@ -167,7 +185,7 @@
 
 .calendar__range {
     background-color: var(
-        --calendar-range-background-color,
+        --calendar-day-highlight-background-color,
         var(--color-background-secondary)
     );
     position: relative;
@@ -201,7 +219,7 @@
         to right,
         transparent 50%,
         var(
-                --calendar-range-background-color,
+                --calendar-day-highlight-background-color,
                 var(--color-background-secondary)
             )
             50%
@@ -213,7 +231,7 @@
         to left,
         transparent 50%,
         var(
-                --calendar-range-background-color,
+                --calendar-day-highlight-background-color,
                 var(--color-background-secondary)
             )
             50%
@@ -229,7 +247,7 @@
 .calendar__range--end:not(.calendar__cell--selected)
     > :not(:disabled, [aria-disabled="true"]) {
     background-color: var(
-        --calendar-range-background-color,
+        --calendar-day-highlight-background-color,
         var(--color-background-secondary)
     );
 }

--- a/packages/skin/src/sass/calendar/calendar.scss
+++ b/packages/skin/src/sass/calendar/calendar.scss
@@ -151,11 +151,11 @@
 .calendar__month td.calendar__cell--selected > * {
     @include token-mixins.background-color-token(
         calendar-day-selected-background-color,
-        color-background-inverse
+        color-background-accent
     );
     @include token-mixins.color-token(
         calendar-day-selected-color,
-        color-foreground-on-inverse
+        color-foreground-on-accent
     );
 
     font-weight: bold;
@@ -166,7 +166,10 @@
  ************/
 
 .calendar__range {
-    background-color: var(--color-state-layer-pressed);
+    background-color: var(
+        --calendar-range-background-color,
+        var(--color-background-secondary)
+    );
     position: relative;
 }
 
@@ -197,7 +200,11 @@
     background: linear-gradient(
         to right,
         transparent 50%,
-        var(--color-state-layer-pressed) 50%
+        var(
+                --calendar-range-background-color,
+                var(--color-background-secondary)
+            )
+            50%
     );
 }
 
@@ -205,7 +212,11 @@
     background: linear-gradient(
         to left,
         transparent 50%,
-        var(--color-state-layer-pressed) 50%
+        var(
+                --calendar-range-background-color,
+                var(--color-background-secondary)
+            )
+            50%
     );
 }
 
@@ -217,5 +228,8 @@
     > :not(:disabled, [aria-disabled="true"]),
 .calendar__range--end:not(.calendar__cell--selected)
     > :not(:disabled, [aria-disabled="true"]) {
-    background-color: var(--color-state-layer-pressed);
+    background-color: var(
+        --calendar-range-background-color,
+        var(--color-background-secondary)
+    );
 }

--- a/packages/skin/src/sass/calendar/calendar.scss
+++ b/packages/skin/src/sass/calendar/calendar.scss
@@ -122,15 +122,12 @@
 .calendar__month
     td:not(.calendar__cell--selected)
     > .calendar__cell--current:not(.calendar__cell--disabled) {
-    @include token-mixins.border-color-token(
-        calendar-day-today-border-color,
-        color-border-accent
-    );
     @include token-mixins.color-token(
         calendar-day-today-color,
         color-foreground-accent
     );
 
+    border-color: var(--calendar-day-today-border-color, currentcolor);
     border-style: solid;
 }
 

--- a/packages/skin/src/sass/calendar/calendar.scss
+++ b/packages/skin/src/sass/calendar/calendar.scss
@@ -126,6 +126,10 @@
         calendar-day-today-border-color,
         color-border-accent
     );
+    @include token-mixins.color-token(
+        calendar-day-today-color,
+        color-foreground-accent
+    );
 
     border-style: solid;
 }


### PR DESCRIPTION
Calendar day hover and range fills now share one solid background token instead of translucent state layers that stacked, and the selected-day background plus the current-day border and text use the accent color.

🤖 Generated with [Claude Code](https://claude.com/claude-code)