### PR TITLE
feat(evo-react): add evo-progress-bar

### DIFF
--- a/.changeset/bright-progress-bars.md
+++ b/.changeset/bright-progress-bars.md
@@ -3,3 +3,4 @@
 ---
 
 Add EvoProgressBarExpressive component.
+Add EvoProgressBar component.

--- a/.changeset/deep-days-learn.md
+++ b/.changeset/deep-days-learn.md
@@ -1,0 +1,5 @@
+---
+"@evo-web/react": patch
+---
+
+Add EvoProgressBar component

--- a/.claude/skills/evo-app-migrate-react/SKILL.md
+++ b/.claude/skills/evo-app-migrate-react/SKILL.md
@@ -83,6 +83,7 @@ When migrating a listed component, read the linked file completely and apply the
 - `ebay-lightbox-dialog`: [evo-dialog.md](components/evo-dialog.md)
 - `ebay-menu`: [evo-menu.md](components/evo-menu.md)
 - `ebay-progress-bar-expressive`: [evo-progress-bar-expressive.md](components/evo-progress-bar-expressive.md)
+- `ebay-progress-bar`: [evo-progress-bar.md](components/evo-progress-bar.md)
 - `ebay-progress-spinner`: [evo-progress-spinner.md](components/evo-progress-spinner.md)
 - `ebay-radio`: [evo-radio.md](components/evo-radio.md)
 - `ebay-tabs`: [evo-tabs.md](components/evo-tabs.md)

--- a/.claude/skills/evo-app-migrate-react/components/evo-progress-bar.md
+++ b/.claude/skills/evo-app-migrate-react/components/evo-progress-bar.md
@@ -1,0 +1,52 @@
+# evo-progress-bar migration guide
+
+## Changed props
+
+### `aria-label` → `a11yText`
+
+`aria-label` is renamed to the required `a11yText` prop. The component maps `a11yText` to `aria-label`.
+
+```diff
+- <EbayProgressBar aria-label="Task progress" value={50} />
++ <EvoProgressBar a11yText="Task progress" value={50} />
+```
+
+### Previously unlabeled progress bars
+
+Previously unlabeled usages must now provide an accessible label through `a11yText`.
+
+```diff
+- <EbayProgressBar value={50} />
++ <EvoProgressBar a11yText="Task progress" value={50} />
+```
+
+### `a11yText={null}` with alternative naming
+
+Use `a11yText={null}` only when another accessible naming method is present, such as `aria-labelledby`.
+
+```diff
+- <EbayProgressBar aria-labelledby="upload-label" value={50} />
++ <EvoProgressBar
++   a11yText={null}
++   aria-labelledby="upload-label"
++   value={50}
++ />
+```
+
+### Indeterminate progress
+
+Omitting `value` now renders native indeterminate progress instead of a zero-percent determinate bar.
+
+```diff
+- <EbayProgressBar aria-label="Loading" />
++ <EvoProgressBar a11yText="Loading" />
+```
+
+### Preserving the old zero-percent default
+
+Consumers that need the old zero-percent default must pass `value={0}` explicitly.
+
+```diff
+- <EbayProgressBar aria-label="Task progress" />
++ <EvoProgressBar a11yText="Task progress" value={0} />
+```

--- a/packages/evo-react/src/progress-bar/README.md
+++ b/packages/evo-react/src/progress-bar/README.md
@@ -1,0 +1,5 @@
+# EvoProgressBar
+
+## Documentation
+
+[Storybook](https://opensource.ebay.com/evo-web/react/?path=/docs/progress-evo-progress-bar--documentation)

--- a/packages/evo-react/src/progress-bar/index.ts
+++ b/packages/evo-react/src/progress-bar/index.ts
@@ -1,0 +1,2 @@
+export { EvoProgressBar } from "./progress-bar";
+export type { EvoProgressBarProps } from "./types";

--- a/packages/evo-react/src/progress-bar/progress-bar.stories.tsx
+++ b/packages/evo-react/src/progress-bar/progress-bar.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { EvoProgressBar } from "./progress-bar";
+
+const meta: Meta<typeof EvoProgressBar> = {
+  title: "progress/evo-progress-bar",
+  component: EvoProgressBar,
+  tags: ["autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component: `
+The progress bar gives an immediate, real-time visualisation of the current task completion status.
+
+## Usage
+
+\`\`\`tsx
+import { EvoProgressBar } from "@evo-web/react/progress-bar";
+\`\`\`
+        `,
+      },
+    },
+  },
+  argTypes: {
+    value: {
+      control: "number",
+      description: "Current progress value. Omit for indeterminate progress.",
+    },
+    max: {
+      control: "number",
+      description: "Maximum progress value. Defaults to 100.",
+    },
+    fluid: {
+      control: "boolean",
+    },
+    a11yText: {
+      type: { name: "string", required: true },
+      control: "text",
+    },
+  },
+  args: {
+    a11yText: "Task progress",
+    value: 50,
+    max: 100,
+    fluid: false,
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof EvoProgressBar>;
+
+export const Default: Story = {};

--- a/packages/evo-react/src/progress-bar/progress-bar.tsx
+++ b/packages/evo-react/src/progress-bar/progress-bar.tsx
@@ -1,0 +1,26 @@
+import classNames from "classnames";
+import type { EvoProgressBarProps } from "./types";
+import "@ebay/skin/progress-bar.mjs";
+
+export function EvoProgressBar({
+  a11yText,
+  value,
+  max = 100,
+  fluid,
+  className,
+  ref,
+  ...rest
+}: EvoProgressBarProps) {
+  return (
+    <progress
+      {...rest}
+      ref={ref}
+      aria-label={a11yText ?? undefined}
+      className={classNames("progress-bar", className, {
+        "progress-bar--fluid": fluid,
+      })}
+      value={value}
+      max={max}
+    />
+  );
+}

--- a/packages/evo-react/src/progress-bar/progress-bar.tsx
+++ b/packages/evo-react/src/progress-bar/progress-bar.tsx
@@ -3,7 +3,7 @@ import type { EvoProgressBarProps } from "./types";
 import "@ebay/skin/progress-bar.mjs";
 
 export function EvoProgressBar({
-  a11yText,
+  a11yText = "Progress",
   value,
   max = 100,
   fluid,

--- a/packages/evo-react/src/progress-bar/test/__snapshots__/test.server.tsx.snap
+++ b/packages/evo-react/src/progress-bar/test/__snapshots__/test.server.tsx.snap
@@ -1,0 +1,11 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`EvoProgressBar SSR > passes through native attributes and a custom class 1`] = `"<progress id="upload-progress" title="Upload status" aria-label="Upload progress" class="progress-bar custom-class" max="100"></progress>"`;
+
+exports[`EvoProgressBar SSR > renders the provided label and an indeterminate progress bar 1`] = `"<progress aria-label="Task progress" class="progress-bar" max="100"></progress>"`;
+
+exports[`EvoProgressBar SSR > renders with a custom max and value 1`] = `"<progress aria-label="Task progress" class="progress-bar" value="50" max="200"></progress>"`;
+
+exports[`EvoProgressBar SSR > renders with the fluid modifier 1`] = `"<progress aria-label="Task progress" class="progress-bar progress-bar--fluid" max="100"></progress>"`;
+
+exports[`EvoProgressBar SSR > renders without aria-label when an alternative label is supplied 1`] = `"<span id="upload-progress-label">Upload progress</span><progress aria-labelledby="upload-progress-label" class="progress-bar" value="50" max="100"></progress>"`;

--- a/packages/evo-react/src/progress-bar/test/test.browser.tsx
+++ b/packages/evo-react/src/progress-bar/test/test.browser.tsx
@@ -1,0 +1,110 @@
+import { createRef } from "react";
+import { describe, expect, it } from "vitest";
+import { render } from "vitest-browser-react";
+import { EvoProgressBar } from "../progress-bar";
+
+describe("evo-progress-bar", () => {
+  it("uses the provided label and max for indeterminate progress", async () => {
+    const screen = await render(<EvoProgressBar a11yText="Task progress" />);
+    const progress = screen.getByRole("progressbar", {
+      name: "Task progress",
+    });
+
+    await expect
+      .element(progress)
+      .toHaveAttribute("aria-label", "Task progress");
+    await expect.element(progress).not.toHaveAttribute("value");
+    await expect.element(progress).toHaveAttribute("max", "100");
+    await expect.element(progress).toHaveClass("progress-bar");
+    await expect.element(progress).not.toHaveClass("progress-bar--fluid");
+  });
+
+  it("supports a zero progress value", async () => {
+    const screen = await render(
+      <EvoProgressBar a11yText="Task progress" value={0} />,
+    );
+    const progress = screen.getByRole("progressbar", {
+      name: "Task progress",
+    });
+
+    await expect.element(progress).toHaveAttribute("value", "0");
+  });
+
+  it("maps a11yText to the accessible name and aria-label", async () => {
+    const screen = await render(
+      <EvoProgressBar a11yText="Upload progress" value={50} />,
+    );
+    const progress = screen.getByRole("progressbar", {
+      name: "Upload progress",
+    });
+
+    await expect
+      .element(progress)
+      .toHaveAttribute("aria-label", "Upload progress");
+  });
+
+  it("supports an alternative accessible name when a11yText is null", async () => {
+    const screen = await render(
+      <>
+        <span id="upload-progress-label">Upload progress</span>
+        <EvoProgressBar
+          a11yText={null}
+          aria-labelledby="upload-progress-label"
+          value={50}
+        />
+      </>,
+    );
+    const progress = screen.getByRole("progressbar", {
+      name: "Upload progress",
+    });
+
+    await expect.element(progress).not.toHaveAttribute("aria-label");
+    await expect
+      .element(progress)
+      .toHaveAttribute("aria-labelledby", "upload-progress-label");
+  });
+
+  it("renders a determinate progress bar with custom value and max", async () => {
+    const screen = await render(
+      <EvoProgressBar a11yText="Task progress" value={50} max={200} />,
+    );
+    const progress = screen.getByRole("progressbar", {
+      name: "Task progress",
+    });
+
+    await expect.element(progress).toHaveAttribute("value", "50");
+    await expect.element(progress).toHaveAttribute("max", "200");
+  });
+
+  it("applies the fluid modifier", async () => {
+    const screen = await render(
+      <EvoProgressBar a11yText="Task progress" value={50} fluid />,
+    );
+    const progress = screen.getByRole("progressbar", {
+      name: "Task progress",
+    });
+
+    await expect.element(progress).toHaveClass("progress-bar--fluid");
+  });
+
+  it("passes through native attributes, custom class, and ref", async () => {
+    const ref = createRef<HTMLProgressElement>();
+    const screen = await render(
+      <EvoProgressBar
+        a11yText="Upload progress"
+        className="custom-class"
+        id="upload-progress"
+        ref={ref}
+        title="Upload status"
+      />,
+    );
+    const progress = screen.getByRole("progressbar", {
+      name: "Upload progress",
+    });
+
+    await expect.element(progress).toHaveAttribute("id", "upload-progress");
+    await expect.element(progress).toHaveAttribute("title", "Upload status");
+    await expect.element(progress).toHaveClass("custom-class");
+    expect(ref.current).toBe(progress.element());
+  });
+});

--- a/packages/evo-react/src/progress-bar/test/test.server.tsx
+++ b/packages/evo-react/src/progress-bar/test/test.server.tsx
@@ -1,0 +1,53 @@
+import { renderToString } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { EvoProgressBar } from "../progress-bar";
+
+describe("EvoProgressBar SSR", () => {
+  it("renders the provided label and an indeterminate progress bar", () => {
+    expect(
+      renderToString(<EvoProgressBar a11yText="Task progress" />),
+    ).toMatchSnapshot();
+  });
+
+  it("renders with a custom max and value", () => {
+    expect(
+      renderToString(
+        <EvoProgressBar a11yText="Task progress" value={50} max={200} />,
+      ),
+    ).toMatchSnapshot();
+  });
+
+  it("renders without aria-label when an alternative label is supplied", () => {
+    expect(
+      renderToString(
+        <>
+          <span id="upload-progress-label">Upload progress</span>
+          <EvoProgressBar
+            a11yText={null}
+            aria-labelledby="upload-progress-label"
+            value={50}
+          />
+        </>,
+      ),
+    ).toMatchSnapshot();
+  });
+
+  it("renders with the fluid modifier", () => {
+    expect(
+      renderToString(<EvoProgressBar a11yText="Task progress" fluid />),
+    ).toMatchSnapshot();
+  });
+
+  it("passes through native attributes and a custom class", () => {
+    expect(
+      renderToString(
+        <EvoProgressBar
+          a11yText="Upload progress"
+          className="custom-class"
+          id="upload-progress"
+          title="Upload status"
+        />,
+      ),
+    ).toMatchSnapshot();
+  });
+});

--- a/packages/evo-react/src/progress-bar/types.ts
+++ b/packages/evo-react/src/progress-bar/types.ts
@@ -1,0 +1,14 @@
+import type { ComponentProps } from "react";
+
+export type EvoProgressBarProps = Omit<
+  ComponentProps<"progress">,
+  "aria-label"
+> & {
+  /**
+   * Accessible label for the progress bar. Callers must provide a localized accessible label.
+   * Pass `null` explicitly _only_ if alternative accessibility information is present.
+   */
+  a11yText: string | null;
+  /** Fills the container width. */
+  fluid?: boolean;
+};

--- a/packages/evo-react/src/progress-bar/types.ts
+++ b/packages/evo-react/src/progress-bar/types.ts
@@ -2,7 +2,7 @@ import type { ComponentProps } from "react";
 
 export type EvoProgressBarProps = Omit<
   ComponentProps<"progress">,
-  "aria-label"
+  "aria-label" | "children"
 > & {
   /**
    * Accessible label for the progress bar. Callers must provide a localized accessible label.

--- a/packages/evo-react/src/progress-bar/types.ts
+++ b/packages/evo-react/src/progress-bar/types.ts
@@ -5,7 +5,7 @@ export type EvoProgressBarProps = Omit<
   "aria-label" | "children"
 > & {
   /**
-   * Accessible label for the progress bar. Callers must provide a localized accessible label.
+   * Accessible label for the progress bar, mapped to `aria-label`. English default to be overridden is `"Progress"`.
    * Pass `null` explicitly _only_ if alternative accessibility information is present.
    */
   a11yText: string | null;


### PR DESCRIPTION
- Fixes #836

## Description

Migrates `ebay-progress-bar` to the React 19 `EvoProgressBar` component. The component imports Skin directly, supports determinate and native indeterminate progress, keeps the `fluid` modifier, requires accessible labeling, and passes native progress attributes and refs through.

Adds browser and SSR coverage, Storybook documentation, consumer migration guidance, and an `@evo-web/react` patch changeset.

## Notes

- Omitting `value` renders native indeterminate progress.
- Consumers must provide `a11yText`, or pass `null` when another accessible naming method such as `aria-labelledby` is present.
- No hooks were bypassed. The pre-push hook completed the full repository build successfully.

## Screenshots

N/A. This migration uses the existing Skin progress-bar styles and does not change CSS.

## Checklist

- [ ] I verify the linked issue has been triaged ("Needs Triage" label removed)
- [ ] I verify all changes are within scope of the linked issue
- [ ] I added/updated/removed testing (Storybook in Skin) coverage as appropriate
