### PR TITLE
fix(evo-menu, evo-menu-button): keyboard accessibility for the menu button pattern

### DIFF
--- a/.changeset/menu-button-keyboard-a11y.md
+++ b/.changeset/menu-button-keyboard-a11y.md
@@ -6,6 +6,6 @@ Fix keyboard accessibility of `evo-menu` and `evo-menu-button`. The menu button
 now moves focus into the menu when it is opened, to the first item or, when
 opened with ArrowUp, the last one, and returns focus to the button when it is
 closed with Escape or by selecting an item. Menu items now activate on
-Enter/Space, support Home/End, ignore Left/Right, and no longer respond to
+Enter/Space, support Home/End, and no longer respond to
 clicks while disabled. Fixes a roving tabindex bug that left no item focusable after arrow
 navigation when items had no explicit `value`.

--- a/.changeset/menu-button-keyboard-a11y.md
+++ b/.changeset/menu-button-keyboard-a11y.md
@@ -1,0 +1,11 @@
+---
+"@evo-web/marko": patch
+---
+
+Fix keyboard accessibility of `evo-menu` and `evo-menu-button`. The menu button
+now moves focus into the menu when it is opened, to the first item or, when
+opened with ArrowUp, the last one, and returns focus to the button when it is
+closed with Escape or by selecting an item. Menu items now activate on
+Enter/Space, support Home/End, ignore Left/Right, and no longer respond to
+clicks while disabled. Fixes a roving tabindex bug that left no item focusable after arrow
+navigation when items had no explicit `value`.

--- a/.changeset/menu-button-keyboard-a11y.md
+++ b/.changeset/menu-button-keyboard-a11y.md
@@ -3,8 +3,7 @@
 ---
 
 Fix keyboard accessibility of `evo-menu` and `evo-menu-button`. The menu button
-now moves focus into the menu when it is opened, to the first item or, when
-opened with ArrowUp, the last one, and returns focus to the button when it is
+now moves focus into the menu when it is opened, and returns focus to the button when it is
 closed with Escape or by selecting an item. Menu items now activate on
 Enter/Space, support Home/End, and no longer respond to
 clicks while disabled. Fixes a roving tabindex bug that left no item focusable after arrow

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ _site
 .claude/projects/
 .worktrees/
 .auto
+
+# vitest browser-mode screenshot attachments
+.vitest-attachments/

--- a/agent-feedback/items/2026-08-31-evo-fake-menu-button-keyboard.md
+++ b/agent-feedback/items/2026-08-31-evo-fake-menu-button-keyboard.md
@@ -1,0 +1,22 @@
+---
+type: a11y
+impact: med
+effort: med
+site: packages/evo-marko/src/tags/evo-fake-menu-button/index.marko › evo-fake-menu-button
+---
+
+# Give evo-fake-menu-button the menu button keyboard behaviors
+
+The trigger only toggles `open` from its `onClick`, so focus is never moved into
+the popup: Enter/Space leave focus on the button, ArrowDown/ArrowUp do not open
+it, and Escape closes it without returning focus to the button. The trigger
+also carries no `aria-haspopup`. Its popup is a
+list of links/buttons rather than `role="menu"` items, so it needs its own focus
+handling rather than the `focusItem` input that `evo-menu` exposes; the opening
+keys, Escape-restores-focus and Tab-closes handling in `evo-menu-button` can be
+followed. Only `@evo-web/marko` was checked; `@ebay/ebayui-core`,
+`@evo-web/react` and `@ebay/ui-core-react` may carry the same gap.
+
+Check: open the `buttons/evo-fake-menu-button` "Default" Storybook story, focus
+the button and press Enter — the popup expands while `document.activeElement`
+stays on the button, and the arrow keys then do nothing.

--- a/agent-feedback/items/2026-08-31-menu-button-menu-unlabelled.md
+++ b/agent-feedback/items/2026-08-31-menu-button-menu-unlabelled.md
@@ -1,0 +1,23 @@
+---
+type: a11y
+impact: low
+effort: med
+site: packages/skin/src/sass/menu-button/stories/base.stories.js › .menu-button__items
+---
+
+# Decide whether a menu button's `role="menu"` should be labelled
+
+The popup rendered by a menu button has no accessible name in any layer: the
+skin markup emits a bare `<div class="menu-button__items" role="menu">`, and
+`evo-menu-button` deliberately omits `a11yText`/`a11yLabelId` from its input, so
+consumers cannot supply one either. A name is not required for `role="menu"`,
+but the ARIA APG menu button pattern points the menu at its trigger with
+`aria-labelledby`, which gives screen reader users the button's text when focus
+enters the menu. This is a design system decision rather than a component fix —
+it needs to land in the skin markup first, then in `@evo-web/marko`,
+`@ebay/ebayui-core`, `@evo-web/react` and `@ebay/ui-core-react` together. Only
+skin and `@evo-web/marko` were checked.
+
+Check: render the `menu-button` "Base" skin story, or the `buttons/evo-menu-button`
+"Default" story, and inspect the `role="menu"` element — it carries neither
+`aria-label` nor `aria-labelledby`.

--- a/agent-feedback/items/2026-09-02-pre-push-vitest-attachments.md
+++ b/agent-feedback/items/2026-09-02-pre-push-vitest-attachments.md
@@ -1,0 +1,19 @@
+---
+type: tooling
+impact: low
+effort: low
+site: packages/evo-react smoke tests › .vitest-attachments
+---
+
+# Pre-push hook is blocked by its own test artifacts
+
+The pre-push build runs the evo-react smoke tests, which write screenshot
+attachments to `packages/evo-react/.vitest-attachments/`. That directory was
+not gitignored, so the hook's own untracked-files check then rejected the push
+every time. A root `.gitignore` entry was added to unblock pushing; if the
+attachments should live elsewhere (or be cleaned up by the test run), that may
+be a better fix.
+
+Check: before the `.gitignore` entry, `git push` failed with "You have
+untracked files" after a green build, and `git status` showed only
+`packages/evo-react/.vitest-attachments/`.

--- a/packages/evo-marko/src/tags/evo-listbox-button/test/__snapshots__/test.server.ts.snap
+++ b/packages/evo-marko/src/tags/evo-listbox-button/test/__snapshots__/test.server.ts.snap
@@ -1307,7 +1307,7 @@ exports[`listbox button > renders with second item selected 1`] = `
     tabindex="0"
   >
     <div
-      class="listbox__option"
+      class="listbox__option listbox__option--active"
       data-value="1"
       role="option"
     >

--- a/packages/evo-marko/src/tags/evo-menu-button/index.marko
+++ b/packages/evo-marko/src/tags/evo-menu-button/index.marko
@@ -26,7 +26,7 @@ export interface Input<Index extends number | string | (number | string)[]>
   strategy?: "absolute" | "fixed";
   fixWidth?: boolean;
 }
-const/{
+<const/{
   class: inputClass,
   noToggleIcon: inputNoToggleIcon,
   reverse,
@@ -53,12 +53,18 @@ const/{
   onKeyDown,
   onFocusOut,
   ...htmlInput
-}=input
+}=input>
 
-id/labelId
-let/selected:=input.selected
-let/open:=input.open
-const/{
+<id/labelId>
+<let/selected:=input.selected>
+<let/open:=input.open>
+// Which end of the menu the user opened it towards. `null` until they do, so
+// that a menu which starts open does not steal focus.
+<let/focusEnd=null as null | "first" | "last">
+<const/focusButton=() => {
+  $root().querySelector<HTMLElement>(".menu-button__button")!.focus();
+}>
+<const/{
   tagName,
   transparent,
   isSelected,
@@ -96,67 +102,96 @@ const/{
     transparent,
     priority,
   };
-})()
+})()>
 
-evo-expander/expander
-  ,open=open
-  ,placement=(reverse ? "bottom-end" : "bottom-start")
-  ,strategy=strategy
-  ,host=$root
-  ,overlay=$menu
+<evo-expander/expander
+  open=open
+  placement=(reverse ? "bottom-end" : "bottom-start")
+  strategy=strategy
+  host=$root
+  overlay=$menu/>
+// The menu only becomes focusable once the expander has positioned, and so
+// made visible, it.
+<script>
+  if (open && focusEnd && expander.positioned) {
+    const items = $menu().querySelectorAll<HTMLElement>(
+      `[role^="menuitem"]:not([aria-disabled="true"])`,
+    );
+    (focusEnd === "last" ? items[items.length - 1] : items[0])?.focus();
+  }
+</script>
 
-span/$root
-  ,...htmlInput
-  ,class=["menu-button", inputClass]
-  ,onKeyDown(e, el) {
-    if (open && e.key === "Escape") open = false;
+<span/$root
+  ...htmlInput
+  class=["menu-button", inputClass]
+  onKeyDown(e, el) {
+    if (e.key === "Escape" && open) {
+      open = false;
+      focusButton();
+    } else if (!disabled && (e.key === "ArrowDown" || e.key === "ArrowUp")) {
+      // Enter and space open the menu through the button's own click.
+      e.preventDefault();
+      focusEnd = e.key === "ArrowUp" ? "last" : "first";
+      open = true;
+    }
     onKeyDown && onKeyDown(e, el);
   }
-  ,onFocusOut(e, el) {
+  onFocusOut(e, el) {
     if (!el.contains(e.relatedTarget as Node)) {
       open = false;
     }
     onFocusOut && onFocusOut(e, el);
-  }
-  ${tagName as any}
-    ,class=[`menu-button__button`]
-    ,size=size
-    ,priority=priority as ButtonInput["priority"]
-    ,borderless=borderless
-    ,variant=variant as any
-    ,aria-haspopup="true"
-    ,selected=isSelected
-    ,transparent=transparent
-    ,aria-expanded=expander.ariaExpanded
-    ,aria-labelledby=prefixId &&
+  }>
+  <${tagName as any}
+    class=[`menu-button__button`]
+    size=size
+    priority=priority as ButtonInput["priority"]
+    borderless=borderless
+    variant=variant as any
+    aria-haspopup="true"
+    selected=isSelected
+    transparent=transparent
+    aria-expanded=expander.ariaExpanded
+    aria-labelledby=prefixId &&
     (variant === "icon" ? prefixId : `${prefixId} ${labelId}`)
-    ,split=split
-    ,disabled=disabled
-    ,partiallyDisabled=partiallyDisabled
-    ,onClick() {
+    split=split
+    disabled=disabled
+    partiallyDisabled=partiallyDisabled
+    onClick() {
+      focusEnd = "first";
       open = !open;
+    }>
+    <if=label>
+      <span ...label class=["menu-button-prefix-label", label.class]/>
+      ${" "}
+    </if>
+    <if=variant === "icon">
+      <${input.content}/>
+    </if>
+    <else>
+      <span id=prefixId && labelId>
+        <${input.content}/>
+      </span>
+      <if=!noToggleIcon>
+        <evo-icon-chevron-down-12/>
+      </if>
+    </else>
+  </>
+  <evo-menu/$menu: MenuRef
+    style=expander.floatingStyles
+    selected:=input.selected
+    classPrefix="menu-button"
+    fixed=strategy === "fixed"
+    variant=(variant as MenuInput<Index>["variant"])
+    fixWidth=fixWidth
+    tabindex=-1
+    footerButton=footerButton
+    onClick() {
+      if (collapseOnSelect) {
+        open = false;
+        focusButton();
+      }
     }
-    if=label
-      span ...label class=["menu-button-prefix-label", label.class]
-      -- ${" "}
-    if=variant === "icon"
-      ${input.content}
-    else
-      span id=prefixId && labelId
-        ${input.content}
-      if=!noToggleIcon
-        evo-icon-chevron-down-12
-  evo-menu/$menu: MenuRef
-    ,style=expander.floatingStyles
-    ,selected:=input.selected
-    ,classPrefix="menu-button"
-    ,fixed=strategy === "fixed"
-    ,variant=(variant as MenuInput<Index>["variant"])
-    ,fixWidth=fixWidth
-    ,tabindex=-1
-    ,footerButton=footerButton
-    ,onClick() {
-      if (collapseOnSelect) open = false;
-    }
-    ,item=items
-    ,group=groups
+    item=items
+    group=groups/>
+</span>

--- a/packages/evo-marko/src/tags/evo-menu-button/index.marko
+++ b/packages/evo-marko/src/tags/evo-menu-button/index.marko
@@ -58,9 +58,9 @@ export interface Input<Index extends number | string | (number | string)[]>
 <id/labelId>
 <let/selected:=input.selected>
 <let/open:=input.open>
-// Which end of the menu the user opened it towards. `null` until they do, so
-// that a menu which starts open does not steal focus.
-<let/focusEnd=null as null | "first" | "last">
+// Stays false until the user opens the menu, so that a menu which starts open
+// does not steal focus.
+<let/focusOnOpen=false>
 <const/focusButton=() => {
   $root().querySelector<HTMLElement>(".menu-button__button")!.focus();
 }>
@@ -113,11 +113,12 @@ export interface Input<Index extends number | string | (number | string)[]>
 // The menu only becomes focusable once the expander has positioned, and so
 // made visible, it.
 <script>
-  if (open && focusEnd && expander.positioned) {
-    const items = $menu().querySelectorAll<HTMLElement>(
-      `[role^="menuitem"]:not([aria-disabled="true"])`,
-    );
-    (focusEnd === "last" ? items[items.length - 1] : items[0])?.focus();
+  if (open && focusOnOpen && expander.positioned) {
+    $menu()
+      .querySelector<HTMLElement>(
+        `[role^="menuitem"]:not([aria-disabled="true"])`,
+      )
+      ?.focus();
   }
 </script>
 
@@ -128,11 +129,6 @@ export interface Input<Index extends number | string | (number | string)[]>
     if (e.key === "Escape" && open) {
       open = false;
       focusButton();
-    } else if (!disabled && (e.key === "ArrowDown" || e.key === "ArrowUp")) {
-      // Enter and space open the menu through the button's own click.
-      e.preventDefault();
-      focusEnd = e.key === "ArrowUp" ? "last" : "first";
-      open = true;
     }
     onKeyDown && onKeyDown(e, el);
   }
@@ -158,7 +154,7 @@ export interface Input<Index extends number | string | (number | string)[]>
     disabled=disabled
     partiallyDisabled=partiallyDisabled
     onClick() {
-      focusEnd = "first";
+      focusOnOpen = true;
       open = !open;
     }>
     <if=label>

--- a/packages/evo-marko/src/tags/evo-menu-button/test/test.browser.ts
+++ b/packages/evo-marko/src/tags/evo-menu-button/test/test.browser.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, it, expect } from "vitest";
 import { composeStories } from "@storybook/marko";
 import { render, fireEvent, cleanup } from "@marko/testing-library";
+import { userEvent, type UserEvent } from "vitest/browser";
 import { pressKey } from "../../../common/test-utils/browser";
 import * as stories from "../menu-button.stories"; // import all stories from the stories file
 const { Default } = composeStories(stories);
@@ -392,6 +393,107 @@ describe("given the evo-menu-button is open", () => {
         "aria-expanded",
         "false",
       );
+    });
+  });
+});
+
+describe("given the evo-menu-button is closed", () => {
+  const firstItemText = "item 1";
+  const lastItemText = "item 3";
+  let user: UserEvent;
+
+  const getItem = (text: string) =>
+    component.getByText(text).parentElement as HTMLElement;
+
+  beforeEach(async () => {
+    user = userEvent.setup();
+    component = await render(Default);
+    await user.click(component.getByRole("button"));
+  });
+
+  it("then clicking the button expands it and moves focus to the first item", () => {
+    expect(document.activeElement).to.equal(getItem(firstItemText));
+    expect(component.getByRole("button")).toHaveAttribute(
+      "aria-expanded",
+      "true",
+    );
+  });
+
+  for (const key of ["{Enter}", "{ }"]) {
+    describe(`when "${key}" is pressed on the button`, () => {
+      beforeEach(async () => {
+        await user.keyboard("{Escape}");
+        await user.keyboard(key);
+      });
+
+      it("then it expands and moves focus to the first item", () => {
+        expect(component.getByRole("button")).toHaveAttribute(
+          "aria-expanded",
+          "true",
+        );
+        expect(document.activeElement).to.equal(getItem(firstItemText));
+      });
+    });
+  }
+
+  for (const [key, itemText] of [
+    ["{ArrowDown}", firstItemText],
+    ["{ArrowUp}", lastItemText],
+  ]) {
+    describe(`when "${key}" is pressed on the button`, () => {
+      beforeEach(async () => {
+        await user.keyboard("{Escape}");
+        await user.keyboard(key);
+      });
+
+      it("then it expands and moves focus into the menu", () => {
+        expect(component.getByRole("button")).toHaveAttribute(
+          "aria-expanded",
+          "true",
+        );
+        expect(document.activeElement).to.equal(getItem(itemText));
+      });
+    });
+  }
+});
+
+describe("given the evo-menu-button is open via the keyboard", () => {
+  const firstItemText = "item 1";
+
+  const getItem = (text: string) =>
+    component.getByText(text).parentElement as HTMLElement;
+
+  beforeEach(async () => {
+    component = await render(Default, { collapseOnSelect: true });
+    component.getByRole("button").focus();
+    await fireEvent.click(component.getByRole("button"));
+  });
+
+  describe("when escape is pressed inside the menu", () => {
+    beforeEach(async () => {
+      await pressKey(getItem(firstItemText), { key: "Escape" });
+    });
+
+    it("then it collapses and returns focus to the button", () => {
+      expect(component.getByRole("button")).toHaveAttribute(
+        "aria-expanded",
+        "false",
+      );
+      expect(document.activeElement).to.equal(component.getByRole("button"));
+    });
+  });
+
+  describe("when an item is activated with the space key", () => {
+    beforeEach(async () => {
+      await pressKey(getItem(firstItemText), { key: " " });
+    });
+
+    it("then it collapses and returns focus to the button", () => {
+      expect(component.getByRole("button")).toHaveAttribute(
+        "aria-expanded",
+        "false",
+      );
+      expect(document.activeElement).to.equal(component.getByRole("button"));
     });
   });
 });

--- a/packages/evo-marko/src/tags/evo-menu-button/test/test.browser.ts
+++ b/packages/evo-marko/src/tags/evo-menu-button/test/test.browser.ts
@@ -399,7 +399,6 @@ describe("given the evo-menu-button is open", () => {
 
 describe("given the evo-menu-button is closed", () => {
   const firstItemText = "item 1";
-  const lastItemText = "item 3";
   let user: UserEvent;
 
   const getItem = (text: string) =>
@@ -432,26 +431,6 @@ describe("given the evo-menu-button is closed", () => {
           "true",
         );
         expect(document.activeElement).to.equal(getItem(firstItemText));
-      });
-    });
-  }
-
-  for (const [key, itemText] of [
-    ["{ArrowDown}", firstItemText],
-    ["{ArrowUp}", lastItemText],
-  ]) {
-    describe(`when "${key}" is pressed on the button`, () => {
-      beforeEach(async () => {
-        await user.keyboard("{Escape}");
-        await user.keyboard(key);
-      });
-
-      it("then it expands and moves focus into the menu", () => {
-        expect(component.getByRole("button")).toHaveAttribute(
-          "aria-expanded",
-          "true",
-        );
-        expect(document.activeElement).to.equal(getItem(itemText));
       });
     });
   }

--- a/packages/evo-marko/src/tags/evo-menu/index.marko
+++ b/packages/evo-marko/src/tags/evo-menu/index.marko
@@ -103,10 +103,7 @@ static function nextSelected(
     // TODO: remove when Marko TS works ($item errors when referenced
     // directly because it is declared inside nested loops)
     <const/$items: Iterable<HTMLElement>=$item>
-    <evo-roving-tabindex/rovTabindex
-      nodeList=$items
-      orientation="vertical"
-      selected=initialSelected/>
+    <evo-roving-tabindex/rovTabindex nodeList=$items selected=initialSelected/>
     <evo-typeahead/{ typeahead }
       nodeList=$items
       timeoutLength=typeaheadTimeoutLength/>

--- a/packages/evo-marko/src/tags/evo-menu/index.marko
+++ b/packages/evo-marko/src/tags/evo-menu/index.marko
@@ -83,7 +83,6 @@ static function nextSelected(
     Array.isArray(selected) ? selected.length > 0 : selected != null,
   )?.selected ?? undefined
 )>
-
 <id/menu>
 <span/$el
   ...htmlInput
@@ -104,7 +103,10 @@ static function nextSelected(
     // TODO: remove when Marko TS works ($item errors when referenced
     // directly because it is declared inside nested loops)
     <const/$items: Iterable<HTMLElement>=$item>
-    <evo-roving-tabindex/rovTabindex nodeList=$items selected=initialSelected/>
+    <evo-roving-tabindex/rovTabindex
+      nodeList=$items
+      orientation="vertical"
+      selected=initialSelected/>
     <evo-typeahead/{ typeahead }
       nodeList=$items
       timeoutLength=typeaheadTimeoutLength/>
@@ -149,19 +151,35 @@ static function nextSelected(
             itemClass,
             badgeNumber !== undefined && `${baseClass}__item--badged`,
           ]
+          onFocus(e, target) {
+            rovTabindex.onFocus(value);
+            item.onFocus && item.onFocus(e, target);
+          }
           onClick(e, target) {
+            // Stop the click reaching handlers on the menu itself, such as
+            // the menu button's collapse on select.
+            if (disabled) {
+              e.stopPropagation();
+              return;
+            }
             rovTabindex.onClick(value);
             selected = nextSelected(selected, value);
             item.onClick && item.onClick(e, target);
           }
           onKeyDown(e, target) {
             if (e.key === "Enter" || e.key === " ") {
-              selected = nextSelected(selected, value);
-            }
-            rovTabindex.onKeyDown(e);
-            const newIndex = typeahead(e);
-            if (newIndex !== -1) {
-              rovTabindex.setFocusIndex(newIndex);
+              // Menu items are not natively actionable, so the action keys are
+              // forwarded as a click to keep both paths identical.
+              e.preventDefault();
+              if (!disabled) {
+                target.click();
+              }
+            } else {
+              rovTabindex.onKeyDown(e);
+              const newIndex = typeahead(e);
+              if (newIndex !== -1) {
+                rovTabindex.setFocusIndex(newIndex);
+              }
             }
 
             item.onKeyDown && item.onKeyDown(e, target);

--- a/packages/evo-marko/src/tags/evo-menu/menu.stories.ts
+++ b/packages/evo-marko/src/tags/evo-menu/menu.stories.ts
@@ -20,6 +20,8 @@ import GroupsTemplate from "./examples/groups.marko";
 import GroupsTemplateCode from "./examples/groups.marko?raw";
 import ControlledTemplate from "./examples/controlled.marko";
 import ControlledTemplateCode from "./examples/controlled.marko?raw";
+import ItemDisabledTemplate from "./examples/item-diabled.marko";
+import ItemDisabledTemplateCode from "./examples/item-diabled.marko?raw";
 import FooterTemplate from "./examples/footer.marko";
 import FooterTemplateCode from "./examples/footer.marko?raw";
 
@@ -187,6 +189,11 @@ export const Badged = buildExtensionTemplate(
 export const Sprites = buildExtensionTemplate(
   SpritesTemplate,
   SpritesTemplateCode,
+);
+
+export const ItemDisabled = buildExtensionTemplate(
+  ItemDisabledTemplate,
+  ItemDisabledTemplateCode,
 );
 
 export const Footer = buildExtensionTemplate(

--- a/packages/evo-marko/src/tags/evo-menu/test/test.browser.ts
+++ b/packages/evo-marko/src/tags/evo-menu/test/test.browser.ts
@@ -3,7 +3,8 @@ import { composeStories } from "@storybook/marko";
 import { render, fireEvent, cleanup, waitFor } from "@marko/testing-library";
 import { pressKey } from "../../../common/test-utils/browser";
 import * as stories from "../menu.stories"; // import all stories from the stories file
-const { Default, Groups, Controlled, Typeahead } = composeStories(stories);
+const { Default, Groups, Controlled, Typeahead, ItemDisabled } =
+  composeStories(stories);
 const Separator: any = Default;
 
 afterEach(cleanup);
@@ -518,6 +519,127 @@ describe.skip("given the menu has checkbox items with separator", () => {
 
     it("then the item is unchecked", () => {
       expect(thirdItem).toHaveAttribute("aria-checked", "false");
+    });
+  });
+});
+
+describe("given the menu items have no explicit values", () => {
+  const firstItemText = "item 1 that has very long text";
+  const secondItemText = "item 2";
+  const thirdItemText = "item 3";
+
+  const getItem = (text: string) =>
+    component.getByText(text).parentElement as HTMLElement;
+
+  beforeEach(async () => {
+    component = await render(Default);
+    getItem(firstItemText).focus();
+  });
+
+  describe("when the down key is pressed", () => {
+    beforeEach(async () => {
+      await pressKey(getItem(firstItemText), { key: "ArrowDown" });
+    });
+
+    it("then focus and the tab stop move to the next item", () => {
+      expect(document.activeElement).to.equal(getItem(secondItemText));
+      expect(getItem(secondItemText)).toHaveAttribute("tabindex", "0");
+      expect(getItem(firstItemText)).toHaveAttribute("tabindex", "-1");
+    });
+  });
+
+  describe("when the end key is pressed", () => {
+    beforeEach(async () => {
+      await pressKey(getItem(firstItemText), { key: "End" });
+    });
+
+    it("then focus moves to the last item", () => {
+      expect(document.activeElement).to.equal(getItem(thirdItemText));
+      expect(getItem(thirdItemText)).toHaveAttribute("tabindex", "0");
+    });
+
+    describe("when the home key is pressed", () => {
+      beforeEach(async () => {
+        await pressKey(getItem(thirdItemText), { key: "Home" });
+      });
+
+      it("then focus moves back to the first item", () => {
+        expect(document.activeElement).to.equal(getItem(firstItemText));
+        expect(getItem(firstItemText)).toHaveAttribute("tabindex", "0");
+      });
+    });
+  });
+
+  describe("when the left and right keys are pressed", () => {
+    beforeEach(async () => {
+      await pressKey(getItem(firstItemText), { key: "ArrowRight" });
+      await pressKey(getItem(firstItemText), { key: "ArrowLeft" });
+    });
+
+    it("then focus stays put, since the menu is vertical", () => {
+      expect(document.activeElement).to.equal(getItem(firstItemText));
+    });
+  });
+});
+
+describe("given the menu is single-select", () => {
+  const firstItemText = "item 1 that has very long text";
+  const secondItemText = "item 2";
+
+  const getItem = (text: string) =>
+    component.getByText(text).parentElement as HTMLElement;
+
+  beforeEach(async () => {
+    component = await render(Default, { selected: 0 });
+  });
+
+  for (const key of ["Enter", " "]) {
+    describe(`when "${key}" is pressed on an item`, () => {
+      beforeEach(async () => {
+        await pressKey(getItem(secondItemText), { key });
+      });
+
+      it("then it checks that item", () => {
+        expect(getItem(secondItemText)).toHaveAttribute("aria-checked", "true");
+        expect(getItem(firstItemText)).toHaveAttribute("aria-checked", "false");
+      });
+    });
+  }
+});
+
+describe("given the menu has a disabled item", () => {
+  const firstItemText = "item 1 that has very long text";
+  const disabledItemText = "item 2";
+  const lastItemText = "item 3";
+
+  const getItem = (text: string) =>
+    component.getByText(text).parentElement as HTMLElement;
+
+  beforeEach(async () => {
+    component = await render(ItemDisabled);
+  });
+
+  describe("when the down key is pressed before the disabled item", () => {
+    beforeEach(async () => {
+      getItem(firstItemText).focus();
+      await pressKey(getItem(firstItemText), { key: "ArrowDown" });
+    });
+
+    it("then focus skips the disabled item", () => {
+      expect(document.activeElement).to.equal(getItem(lastItemText));
+    });
+  });
+
+  describe("when the disabled item is clicked", () => {
+    beforeEach(async () => {
+      await fireEvent.click(getItem(disabledItemText));
+    });
+
+    it("then it is not selected", () => {
+      expect(getItem(disabledItemText)).not.toHaveAttribute(
+        "aria-checked",
+        "true",
+      );
     });
   });
 });

--- a/packages/evo-marko/src/tags/evo-menu/test/test.browser.ts
+++ b/packages/evo-marko/src/tags/evo-menu/test/test.browser.ts
@@ -569,17 +569,6 @@ describe("given the menu items have no explicit values", () => {
       });
     });
   });
-
-  describe("when the left and right keys are pressed", () => {
-    beforeEach(async () => {
-      await pressKey(getItem(firstItemText), { key: "ArrowRight" });
-      await pressKey(getItem(firstItemText), { key: "ArrowLeft" });
-    });
-
-    it("then focus stays put, since the menu is vertical", () => {
-      expect(document.activeElement).to.equal(getItem(firstItemText));
-    });
-  });
 });
 
 describe("given the menu is single-select", () => {

--- a/packages/evo-marko/src/tags/tags/evo-expander/index.marko
+++ b/packages/evo-marko/src/tags/tags/evo-expander/index.marko
@@ -68,6 +68,8 @@ export interface Input {
 
 <return={
   floatingStyles,
+  /** Whether the overlay has been positioned, and is therefore visible. */
+  positioned: floatingStyles.visibility === "visible",
   arrowStyles,
   ariaExpanded: input.open ? ("true" as const) : ("false" as const),
 }>

--- a/packages/evo-marko/src/tags/tags/evo-roving-tabindex/index.marko
+++ b/packages/evo-marko/src/tags/tags/evo-roving-tabindex/index.marko
@@ -4,8 +4,6 @@ export interface Input<
   selected?: Index;
   selectedChange?: (selected: Index) => void;
   autoSelect?: boolean;
-  /** Which arrow keys move focus. Defaults to `"both"`. */
-  orientation?: "horizontal" | "vertical" | "both";
   nodeList: Iterable<HTMLElement>;
 }
 
@@ -77,12 +75,11 @@ static function indexOfValue(nodes: HTMLElement[], value: number | string) {
       return;
     }
 
-    const orientation = input.orientation || "both";
     const direction =
-      (e.key === "ArrowUp" && orientation !== "horizontal" && -1) ||
-      (e.key === "ArrowDown" && orientation !== "horizontal" && 1) ||
-      (e.key === "ArrowLeft" && orientation !== "vertical" && -1) ||
-      (e.key === "ArrowRight" && orientation !== "vertical" && 1) ||
+      (e.key === "ArrowUp" && -1) ||
+      (e.key === "ArrowDown" && 1) ||
+      (e.key === "ArrowLeft" && -1) ||
+      (e.key === "ArrowRight" && 1) ||
       (e.key === "Home" && 1) ||
       (e.key === "End" && -1);
     if (!direction) return;

--- a/packages/evo-marko/src/tags/tags/evo-roving-tabindex/index.marko
+++ b/packages/evo-marko/src/tags/tags/evo-roving-tabindex/index.marko
@@ -4,6 +4,8 @@ export interface Input<
   selected?: Index;
   selectedChange?: (selected: Index) => void;
   autoSelect?: boolean;
+  /** Which arrow keys move focus. Defaults to `"both"`. */
+  orientation?: "horizontal" | "vertical" | "both";
   nodeList: Iterable<HTMLElement>;
 }
 
@@ -27,23 +29,43 @@ export interface Input<
 static function getValue(el: HTMLElement) {
   return el.getAttribute("data-value") || el.getAttribute("value");
 }
+// `data-value` is read back as a string, while the value passed in by the
+// consumer may be a number, so values are compared as strings.
+static function isSameValue(a: unknown, b: unknown) {
+  return String(a) === String(b);
+}
+static function indexOfValue(nodes: HTMLElement[], value: number | string) {
+  const index = nodes.findIndex((node) => isSameValue(getValue(node), value));
+  // Lists without values fall back to the value being an index.
+  return index === -1 && typeof value === "number" ? value : index;
+}
+// Moves focus to the first item after `start` in `direction`, skipping disabled
+// items and wrapping around.
+<const/focusFrom(start: number, direction: number) {
+  const nodes = [...input.nodeList];
+  for (let i = 0, index = start; i < nodes.length; i++) {
+    index = (index + nodes.length + direction) % nodes.length;
+    const node = nodes[index];
+    if (node.getAttribute("aria-disabled") !== "true") {
+      focusValue = getValue(node) ?? index;
+      node.focus();
+      return true;
+    }
+  }
+  return false;
+}>
 
 <return={
   setFocusIndex(value: number | string) {
-    const nodes = [...input.nodeList];
-    let currentItem: HTMLElement | undefined;
-    if (typeof value === "number") {
-      currentItem = nodes[value];
-    } else {
-      currentItem = nodes.find((node) => getValue(node) === value);
-    }
-    if (currentItem && currentItem.getAttribute("aria-disabled") !== "true") {
-      focusValue = value;
-      currentItem.focus();
-    }
+    const index = indexOfValue([...input.nodeList], value);
+    if (index !== -1) focusFrom(index - 1, 1);
   },
   isFocused(value: number | string) {
-    return focusValue === value;
+    return isSameValue(focusValue, value);
+  },
+  /** Keeps the tab stop on an item that was focused from elsewhere. */
+  onFocus(value: number | string) {
+    focusValue = value;
   },
   onClick(value: number | string) {
     setSelected(value);
@@ -52,39 +74,29 @@ static function getValue(el: HTMLElement) {
   onKeyDown(e: KeyboardEvent) {
     if (e.key === "Enter" || e.key === " ") {
       setSelected(focusValue);
+      return;
     }
-    if (
-      ["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight"].indexOf(e.key) !== -1
-    ) {
-      const nodes = [...input.nodeList];
-      const size = nodes.length;
-      const direction = e.key === "ArrowLeft" || e.key === "ArrowUp" ? -1 : 1;
 
-      let currentIndex: number;
-      if (typeof focusValue === "number") {
-        currentIndex = focusValue;
-      } else {
-        currentIndex = nodes.findIndex((node) => getValue(node) === focusValue);
-      }
+    const orientation = input.orientation || "both";
+    const direction =
+      (e.key === "ArrowUp" && orientation !== "horizontal" && -1) ||
+      (e.key === "ArrowDown" && orientation !== "horizontal" && 1) ||
+      (e.key === "ArrowLeft" && orientation !== "vertical" && -1) ||
+      (e.key === "ArrowRight" && orientation !== "vertical" && 1) ||
+      (e.key === "Home" && 1) ||
+      (e.key === "End" && -1);
+    if (!direction) return;
 
-      let currentItem: HTMLElement;
-      while (true) {
-        currentIndex = ((currentIndex as number) + size + direction) % size;
-        currentItem = nodes[currentIndex];
-        if (
-          currentItem.getAttribute("aria-disabled") !== "true" ||
-          currentIndex === focusValue
-        ) {
-          break;
-        }
-      }
-      const value = getValue(currentItem);
-
-      focusValue = value || currentIndex;
-      if (input.autoSelect) {
-        setSelected(value || currentIndex);
-      }
-      currentItem.focus();
+    e.preventDefault();
+    // Home/End, and an unknown current value, start from the end that
+    // `direction` moves away from.
+    let start = direction === 1 ? -1 : 0;
+    if (e.key !== "Home" && e.key !== "End") {
+      const index = indexOfValue([...input.nodeList], focusValue);
+      if (index !== -1) start = index;
+    }
+    if (focusFrom(start, direction) && input.autoSelect) {
+      setSelected(focusValue);
     }
   },
 }>


### PR DESCRIPTION
Fixes keyboard accessibility of `evo-menu` and `evo-menu-button` following the ARIA menu button pattern:

- Opening the menu button now moves focus to the first menu item once the expander has positioned it (only for user-initiated opens, so an initially-open menu does not steal focus).
- Closing with Escape or by selecting an item (with `collapseOnSelect`) returns focus to the button.
- Menu items activate on Enter/Space by forwarding a click, support Home/End, and disabled items no longer respond to clicks or receive arrow-key focus.
- Fixes a roving-tabindex bug where the tab stop was lost after arrow navigation when items had no explicit `value` (values are now compared as strings, since `data-value` reads back as a string).
- `evo-expander` exposes a `positioned` flag so consumers can defer focusing the overlay until it is visible.

Includes browser tests for the new keyboard behavior and a changeset. Also gitignores `.vitest-attachments/`, which the pre-push hook's own smoke tests generate and then reject as untracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)