### PR TITLE
chore(deps): typescript 6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -146,7 +146,7 @@
         "stylelint-prettier": "^5",
         "svgson": "^5.3.1",
         "tsx": "^4.23.13",
-        "typescript": "5",
+        "typescript": "~6.0.3",
         "typescript-eslint": "^8.69.0",
         "visual-html": "^2.1.8",
         "vite": "^7.3.2",
@@ -5381,6 +5381,20 @@
       "bin": {
         "marko-type-check": "dist/cli.js",
         "mtc": "dist/cli.js"
+      }
+    },
+    "node_modules/@marko/type-check/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/@marko/vite": {
@@ -27708,9 +27722,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
     "stylelint-prettier": "^5",
     "svgson": "^5.3.1",
     "tsx": "^4.23.13",
-    "typescript": "5",
+    "typescript": "~6.0.3",
     "typescript-eslint": "^8.69.0",
     "visual-html": "^2.1.8",
     "vite": "^7.3.2",

--- a/packages/ebayui-core-react/src/ebay-phone-input/phone-input.tsx
+++ b/packages/ebayui-core-react/src/ebay-phone-input/phone-input.tsx
@@ -136,7 +136,7 @@ const EbayPhoneInput: FC<EbayPhoneInputProps> = ({
     const handleCountryChange = (event: React.ChangeEvent<HTMLButtonElement>, { index }: ChangeEventProps) => {
         setSelectedIndex(index);
         if (onChange) {
-            onChange(event as React.ChangeEvent<HTMLInputElement>, createEventData({ index }));
+            onChange(event as unknown as React.ChangeEvent<HTMLInputElement>, createEventData({ index }));
         }
     };
 

--- a/packages/ebayui-core-react/tsconfig.json
+++ b/packages/ebayui-core-react/tsconfig.json
@@ -20,7 +20,7 @@
         "noImplicitAny": false, // 300+ errors
         "noImplicitThis": true,
         "alwaysStrict": true,
-        "moduleResolution": "node",
+        "moduleResolution": "bundler",
         "types": ["@testing-library/jest-dom", "@types/node", "vitest/globals"],
         "allowSyntheticDefaultImports": true,
         "esModuleInterop": true,

--- a/packages/evo-react/src/css-modules.d.ts
+++ b/packages/evo-react/src/css-modules.d.ts
@@ -2,3 +2,8 @@ declare module "*.module.css" {
   const classes: Record<string, string>;
   export default classes;
 }
+
+// Stylesheets imported for side effects only (TS 6 flags undeclared
+// side-effect imports as TS2882).
+declare module "*.css";
+declare module "@ebay/skin/marketsans";

--- a/packages/evo-react/src/css-modules.d.ts
+++ b/packages/evo-react/src/css-modules.d.ts
@@ -3,7 +3,5 @@ declare module "*.module.css" {
   export default classes;
 }
 
-// Stylesheets imported for side effects only (TS 6 flags undeclared
-// side-effect imports as TS2882).
 declare module "*.css";
 declare module "@ebay/skin/marketsans";

--- a/packages/evo-storybook-addon-theme/src/styles.d.ts
+++ b/packages/evo-storybook-addon-theme/src/styles.d.ts
@@ -1,0 +1,3 @@
+// Stylesheets imported for side effects only.
+declare module "*.css";
+declare module "*.scss";

--- a/packages/evo-storybook-addon-theme/src/styles.d.ts
+++ b/packages/evo-storybook-addon-theme/src/styles.d.ts
@@ -1,3 +1,2 @@
-// Stylesheets imported for side effects only.
 declare module "*.css";
 declare module "*.scss";


### PR DESCRIPTION
Updates typescript to 6.0. TS 6 removes node10 module resolution, so ebayui-core-react moves to bundler resolution (its module target is already ESNext), which also surfaced one event cast now routed through unknown. TS 6's new TS2882 check requires declarations for side-effect stylesheet imports, added for evo-react and evo-storybook-addon-theme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)