### PR TITLE
fix(video): restore compact timestamp styling on span time displays

### DIFF
--- a/.changeset/video-compact-timestamp-styling.md
+++ b/.changeset/video-compact-timestamp-styling.md
@@ -1,0 +1,6 @@
+---
+"@ebay/skin": patch
+---
+
+Restore the compact video layout's timestamp pill styling now that the time
+displays render as spans.

--- a/packages/skin/dist/video/video.css
+++ b/packages/skin/dist/video/video.css
@@ -88,7 +88,8 @@
     margin-bottom: 10px;
 }
 
-.video-player--compact .shaka-controls-button-panel button {
+.video-player--compact .shaka-controls-button-panel button,
+.video-player--compact .shaka-controls-button-panel > span {
     background-color: rgba(0, 0, 0, 0.32);
     border-radius: 50%;
     margin: 0 5px;
@@ -97,12 +98,14 @@
 .video-player .shaka-controls-button-panel span.shaka-current-time,
 .video-player .shaka-controls-button-panel span.shaka-remaining-time {
     align-items: center;
+    box-sizing: border-box;
     display: inline-flex;
 }
 
 .video-player--compact .shaka-controls-button-panel .shaka-remaining-time {
     border-radius: 16px;
     font-size: var(--font-size-medium);
+    justify-content: center;
     min-width: 80px;
     padding: var(--spacing-200) var(--spacing-100);
 }

--- a/packages/skin/src/sass/video/video.scss
+++ b/packages/skin/src/sass/video/video.scss
@@ -94,7 +94,8 @@
     margin-bottom: 10px;
 }
 
-.video-player--compact .shaka-controls-button-panel button {
+.video-player--compact .shaka-controls-button-panel button,
+.video-player--compact .shaka-controls-button-panel > span {
     background-color: rgb(0 0 0 / 0.32);
     border-radius: 50%;
     margin: 0 5px;
@@ -103,12 +104,14 @@
 .video-player .shaka-controls-button-panel span.shaka-current-time,
 .video-player .shaka-controls-button-panel span.shaka-remaining-time {
     align-items: center;
+    box-sizing: border-box;
     display: inline-flex;
 }
 
 .video-player--compact .shaka-controls-button-panel .shaka-remaining-time {
     border-radius: 16px;
     font-size: var(--font-size-medium);
+    justify-content: center;
     min-width: 80px;
     padding: var(--spacing-200) var(--spacing-100);
 }


### PR DESCRIPTION
The compact layout’s remaining-time pill was picking up its background, side margins and centering from the `.video-player--compact .shaka-controls-button-panel button` rule. When the time displays were changed from buttons to spans for accessibility, those styles stopped applying and the timestamp rendered as bare text.

The pill styles now also target direct span children of the control panel. Two properties that came from button UA defaults are added explicitly: `box-sizing: border-box` (so the padding stays inside the 48px height / 80px min-width instead of growing the pill to 64×88) and `justify-content: center` (the span is `inline-flex`, so it would otherwise left-align inside its min-width).

Includes the rebuilt `packages/skin/dist/video/video.css`, which is what consumers such as the ebayui-core example actually load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)