### PR TITLE
Deprecate live-bag colored icon variants (follow-up to #944)

### DIFF
--- a/.changeset/deprecate-live-bag-colored-icons.md
+++ b/.changeset/deprecate-live-bag-colored-icons.md
@@ -1,0 +1,5 @@
+---
+"@ebay/skin": minor
+---
+
+Deprecate the colored `live-bag-play-filled-16-colored`, `live-bag-play-filled-24-colored`, and `live-bag-play-filled-64-colored` icons, following up on the plain `live-bag-*` icon deprecation. There is currently no colored `live-broadcast` equivalent, so these remain in the sprite and generated components unchanged; consumers using them should plan to migrate once a replacement is available.

--- a/agent-feedback/items/2026-09-11-ebay-phone-input-inputchange-flaky-under-ci-load.md
+++ b/agent-feedback/items/2026-09-11-ebay-phone-input-inputchange-flaky-under-ci-load.md
@@ -1,0 +1,12 @@
+---
+type: dx
+impact: med
+effort: med
+site: packages/ebayui-core-react/src/ebay-phone-input/__tests__/index.spec.tsx › should provide the correct event data on inputChange after changing the country
+---
+
+# `ebay-phone-input` inputChange-after-country-change test times out under CI load
+
+CI's `build` job failed with `Error: Test timed out in 10000ms` on this `userEvent`-driven test, but it passes reliably (28/28 in the file) when run in isolation locally (`npx vitest run src/ebay-phone-input/__tests__/index.spec.tsx`). Vitest's own summary in the same CI run reports `jsdom was created 134 times · 295.46s total, 49% of tracked time`, suggesting jsdom environment setup contention across the full-package test run is eating into this test's 10s budget rather than the interaction itself being slow. This is at least the third distinct flaky-under-load test observed this session (also: an `evo-dialog` browser test, and an `ebayui-core` alert-dialog test already tracked in `2026-09-03-ebayui-core-alert-dialog-enter-flaky-under-load.md`), suggesting a systemic resource-contention issue in CI rather than isolated bad tests.
+
+Check: re-run `npm run build -w packages/ebayui-core-react` in CI on an unrelated PR and see if this (or another) test times out; compare against `npx vitest run src/ebay-phone-input/__tests__/index.spec.tsx` locally, which passes cleanly in ~2s.

--- a/src/data/icons.json
+++ b/src/data/icons.json
@@ -2105,24 +2105,6 @@
         "width": "24"
       },
       {
-        "name": "live-bag-play-filled-16-colored",
-        "size": "16-colored",
-        "height": "16",
-        "width": "16"
-      },
-      {
-        "name": "live-bag-play-filled-24-colored",
-        "size": "24-colored",
-        "height": "24",
-        "width": "24"
-      },
-      {
-        "name": "live-bag-play-filled-64-colored",
-        "size": "64-colored",
-        "height": "64",
-        "width": "64"
-      },
-      {
         "name": "live-broadcast-16",
         "size": "16",
         "height": "16",
@@ -3838,7 +3820,10 @@
       "live-bag-16",
       "live-bag-20",
       "live-bag-24",
-      "live-bag-filled-24"
+      "live-bag-filled-24",
+      "live-bag-play-filled-16-colored",
+      "live-bag-play-filled-24-colored",
+      "live-bag-play-filled-64-colored"
     ],
     "deprecated": [
       {
@@ -3891,6 +3876,24 @@
         "size": "24",
         "height": "24",
         "width": "24"
+      },
+      {
+        "name": "live-bag-play-filled-16-colored",
+        "size": "16-colored",
+        "height": "16",
+        "width": "16"
+      },
+      {
+        "name": "live-bag-play-filled-24-colored",
+        "size": "24-colored",
+        "height": "24",
+        "width": "24"
+      },
+      {
+        "name": "live-bag-play-filled-64-colored",
+        "size": "64-colored",
+        "height": "64",
+        "width": "64"
       },
       {
         "name": "authenticity-guarantee-filled-16-colored",


### PR DESCRIPTION
## Summary
- Follow-up to #943 / #944, which deprecated the 5 plain `live-bag-*` icons and swapped their artwork to `live-broadcast-*`.
- The 3 colored variants (`live-bag-play-filled-16-colored`, `live-bag-play-filled-24-colored`, `live-bag-play-filled-64-colored`) were **intentionally left untouched** in #944, pending a design decision — there is no colored `live-broadcast` equivalent to swap artwork to, so the same treatment couldn't apply.
- Design (Jackie) has since confirmed on the issue thread that these should also be phased out. This PR deprecates them using the same mechanism as the plain icons: hidden from the public docs grid and moved into the "Deprecated Icons" section, while remaining in the sprite and all generated framework components for backwards compatibility (no build breakage for existing consumers).
- **Note on process:** #944 was merged before this follow-up decision was finalized. This PR closes that gap. Flagging here so it's visible in review — future icon-deprecation PRs touching a partial set of variants should hold until any open sub-decisions (like this one) are resolved before merging.

Related to #943

## Test plan
- [x] Confirmed the 3 colored icons removed from `icons.json` → `list`, added to `skipDocs` + `deprecated`
- [x] Confirmed sprite (`icons.svg`) still contains all 3 symbols, unchanged artwork (no `live-broadcast` colored equivalent exists yet)
- [x] `npm run build` passes clean from repo root
- [x] Changeset added (minor, `@ebay/skin`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)